### PR TITLE
Multiple endpoint emails subscription parameter

### DIFF
--- a/sdlf-foundations/deploy.sh
+++ b/sdlf-foundations/deploy.sh
@@ -104,5 +104,10 @@ fi
 
 echo "Loading Deequ scripts ..."
 ARTIFACTS_BUCKET=$(sed -e 's/^"//' -e 's/"$//' <<<"$(aws ssm get-parameter --name /SDLF/S3/ArtifactsBucket --profile $PROFILE --query "Parameter.Value")")
+if [ -z "${ARTIFACTS_BUCKET// }" ]; then
+  echo -e "No parameter found for key /SDLF/S3/ArtifactsBucket. Possible creation problem within foundation stacks."
+  exit 1
+fi
+
 aws s3 cp ./scripts/deequ/jar/deequ-1.0.3-RC1.jar s3://$ARTIFACTS_BUCKET/deequ/jars/ --profile $PROFILE
 aws s3 sync ./scripts/deequ/resources/ s3://$ARTIFACTS_BUCKET/deequ/scripts/ --profile $PROFILE

--- a/sdlf-foundations/lambda/topic/src/lambda_function.py
+++ b/sdlf-foundations/lambda/topic/src/lambda_function.py
@@ -1,0 +1,351 @@
+import json
+import os
+import logging
+import traceback
+
+import boto3
+
+from urllib.request import Request, urlopen
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+logging.basicConfig(
+    format='%(levelname)s %(threadName)s [%(filename)s:%(lineno)d] %(message)s',
+    datefmt='%Y-%m-%d:%H:%M:%S',
+    level=logging.INFO
+)
+
+try:
+    logger.info("Container initialization completed")
+
+except Exception as e:
+    logger.error(e, exc_info=True)
+    init_failed = e
+
+def isHttpStatus200(response_data):
+    return isExpectedHttpStatusCode(response_data, 200)
+
+def isExpectedHttpStatusCode(response_data, status_code):
+    if response_data is not None and \
+        'ResponseMetadata' in response_data and \
+        'HTTPStatusCode' in response_data['ResponseMetadata'] and \
+        response_data['ResponseMetadata']['HTTPStatusCode'] == status_code: 
+        return True
+
+    return False
+
+def send_response(e, c, rs, rd):
+    """ 
+    Packages response and send signals to CloudFormation 
+    :param e: The event given to this Lambda function 
+    :param c: Context object, as above 
+    :param rs: Returned status to be sent back to CFN 
+    :param rd: Returned data to be sent back to CFN 
+    """
+    r = json.dumps({
+        "Status": rs,
+        "Reason": "CloudWatch Log Stream: " + c.log_stream_name,
+        "PhysicalResourceId": e['LogicalResourceId'],
+        "StackId": e['StackId'],
+        "RequestId": e['RequestId'],
+        "LogicalResourceId": e['LogicalResourceId'],
+        "Data": rd
+    })
+    d = str.encode(r)
+    h = {
+        'content-type': '',
+        'content-length': str(len(d))
+    }
+    req = Request(e['ResponseURL'], data=d, method='PUT', headers=h)
+    r = urlopen(req)
+    logger.info("Status message: {} {}".format(r.msg, r.getcode()))
+
+def get_ssm_parameter(logger, ssm_param_name):
+    """ 
+    Gets an SSM parameter.
+
+    :param logger: Logger used for Lambda messages sent to CloudWatch
+    :param ssm_param_name: Name of the SSM parameter
+    """
+
+    client = boto3.client('ssm')
+    parameter = client.get_parameter(Name=ssm_param_name)
+    ssm_param_value = parameter ['Parameter']['Value']    
+    
+    logger.debug("Getting the value for parameter {} = {}".format(ssm_param_name, ssm_param_value))
+    
+    return ssm_param_value
+
+def get_team_metadata_from_dynamo(team_name, table = None):
+    """ 
+    Gets whole team metadata.
+
+    :param team_name: Name of the team that holds metadata
+    :param table: DynamoDB table (if passed, no new boto3 resource assignment is done)
+    """
+
+    if table is None:
+        dynamodb      = boto3.resource('dynamodb')
+        table_name    = get_ssm_parameter(logger, os.getenv('TEAM_METADATA_TABLE_SSM_PARAM'))
+        table         = dynamodb.Table(table_name)
+
+    response_data = table.get_item(
+        Key={
+            'team': team_name
+        }
+    )
+
+    if isHttpStatus200(response_data) and 'Item' in response_data:
+        return response_data['Item']
+
+def remove_subscription_from_dynamo(team_name, topic_arn, endpoint):
+    """ 
+    Deregisters an SNS topic subscription from DynamoDB table, organized by team names.
+
+    :param team_name: Name of the team that holds metadata
+    :param topic_arn: Topic ARN of the subscription
+    :param endpoint: Endpoint to be added to DynamoDB control table
+    """
+
+    dynamodb      = boto3.resource('dynamodb')
+    table_name    = get_ssm_parameter(logger, os.getenv('TEAM_METADATA_TABLE_SSM_PARAM'))
+    table         = dynamodb.Table(table_name)
+    team_item     = get_team_metadata_from_dynamo(team_name, table)
+    item          = None
+
+    if team_item is None:
+        logger.info("Team %s was not found into DynammoDB table.", team_name)
+
+    else:
+        item = team_item
+        for i in range(len(item['sns_subscriptions'])):
+            if item['sns_subscriptions'][i]['topic_arn'] == topic_arn \
+                and item['sns_subscriptions'][i]['endpoint'] == endpoint:
+                del item['sns_subscriptions'][i]
+                break
+
+        response_data = table.put_item(
+            Item=item
+        )
+        
+        if isHttpStatus200(response_data):
+            logger.info("Item updated %s into DynammoDB table.", item)
+
+def get_subscription_arn_from_dynamo(team_name, topic_arn, endpoint):
+    """ 
+    Get a subscription ARN base on the endpoint filter informed.
+
+    :param team_name: Name of the team that holds metadata
+    :param topic_arn: Topic ARN of the subscription
+    :param endpoint: Endpoint to be found in DynamoDB control table
+    """
+
+    team_item = get_team_metadata_from_dynamo(team_name)
+    if team_item and 'sns_subscriptions' in team_item:
+        sns_subscriptions = list(filter(lambda d: d['topic_arn'] in [topic_arn]
+                                        and d['endpoint'] in [endpoint], team_item['sns_subscriptions']))
+        # It should have exist only one subscription ARN for a specific endpoint/SNS topic
+        if sns_subscriptions is not None and len(sns_subscriptions) == 1:
+            subscription_arn = sns_subscriptions[0]['subscription_arn']
+            logger.debug("Subscription ARN %s", subscription_arn)
+            
+            return subscription_arn
+
+    return None
+
+def unsubscribe_endpoint(logger, team_name, topic_arn, endpoint):
+    """ 
+    Unsubscribes and endpoint to an SNS topic and deregisters that from DynamoDB table,
+    organized by team names.
+
+    :param logger: Logger used for Lambda messages sent to CloudWatch
+    :param team_name: Name of the team that holds metadata
+    :param topic_arn: Topic ARN for unsubscription
+    :param endpoint: Endpoint to be unsubscribed from Topic ARN
+    """
+
+    error_code       = None
+    subscription_arn = get_subscription_arn_from_dynamo(team_name, topic_arn, endpoint)
+    if subscription_arn is None:
+        raise Exception("Failed, subscription ARN not found, when unsubscribing %s from topic %s.", endpoint, topic_arn)
+
+    try:
+        client = boto3.client('sns')
+        response_data = client.unsubscribe(
+            SubscriptionArn=subscription_arn
+        )
+    except Exception as ex:
+        error_code = ex.response.get("Error", {}).get("Code")
+        if error_code == "InvalidParameter":
+            logger.info(
+                "Endpoint %s is still pending confirmation, so no unsubscription required.", endpoint)
+
+    # Endpoint was removed from parameters-ENV.json file but the subscription was not confirmed.
+    # Due to that, we have to ignore this error (try/catch above) but need to remove from dynamodb.
+    if error_code == "InvalidParameter" or isHttpStatus200(response_data): 
+        remove_subscription_from_dynamo(team_name, topic_arn, endpoint)
+            
+        logger.info(
+            "Endpoint %s unsubscribed from topic %s.", endpoint, topic_arn)
+    else:
+        raise Exception(
+            "Failed when unsubscribing %s from topic %s.", endpoint, topic_arn)
+
+def register_subscription_into_dynamo(team_name, topic_arn, endpoint, subscription_arn):
+    """ 
+    Registers an SNS topic subscription into DynamoDB table, organized by team names.
+
+    :param team_name: Name of the team that holds metadata
+    :param topic_arn: Topic ARN of the subscription
+    :param endpoint: Endpoint to be added to DynamoDB control table
+    :param subscription_arn: Subscription ARN of the endpoint
+    """
+
+    dynamodb      = boto3.resource('dynamodb')
+    table_name    = get_ssm_parameter(logger, os.getenv('TEAM_METADATA_TABLE_SSM_PARAM'))
+    table         = dynamodb.Table(table_name)
+    team_item     = get_team_metadata_from_dynamo(team_name, table)
+    item          = None
+    item_status   = None
+
+    if team_item is None:
+        item={
+            'team': team_name,
+            'sns_subscriptions': [
+                {
+                    'endpoint': endpoint,
+                    'subscription_arn': subscription_arn,
+                    'topic_arn': topic_arn
+
+                }
+            ]
+        }
+        item_status = "added"
+
+    else:
+        item = team_item
+        for subscription in item['sns_subscriptions']:
+            if subscription['topic_arn'] == topic_arn and subscription['endpoint'] == endpoint:
+                subscription['subscription_arn'] = subscription_arn
+                item_status = "updated"
+                break
+
+        # New item
+        if item_status is None:
+            subscription={
+                'endpoint': endpoint,
+                'subscription_arn': subscription_arn,
+                'topic_arn': topic_arn
+            }
+
+            item['sns_subscriptions'].append(subscription)
+            item_status = "added"
+
+    response_data = table.put_item(
+        Item=item
+    )
+    
+    if isHttpStatus200(response_data):
+        logger.info("Item %s %s into DynammoDB table.", item_status, item)
+
+def subscribe_endpoint(logger, team_name, topic_arn, endpoint, protocol):
+    """ 
+    Subscribes and endpoint to an SNS topic and registers that into DynamoDB table,
+    organized by team names.
+
+    :param logger: Logger used for Lambda messages sent to CloudWatch
+    :param team_name: Name of the team that holds metadata
+    :param topic_arn: Topic ARN for subscription
+    :param endpoint: Endpoint to be subscribed to Topic ARN
+    :param protocol: Protocol of the endpoint being subscribed
+    """
+
+    # Only does if there is no subscription yet for endpoint/SNS Topic
+    if get_subscription_arn_from_dynamo(team_name, topic_arn, endpoint) is None:
+        client = boto3.client('sns')
+
+        response_data = client.subscribe(
+            TopicArn=topic_arn,
+            Protocol=protocol,
+            Endpoint=endpoint,
+            ReturnSubscriptionArn=True
+        )
+        
+        if isHttpStatus200(response_data):
+            register_subscription_into_dynamo(team_name, topic_arn, endpoint, response_data['SubscriptionArn'])
+
+            logger.info(
+                "Endpoint %s subscribed to topic %s at team %s.", endpoint, topic_arn, team_name)
+        else:
+            raise Exception(
+                "Failed when subscribing %s to topic %s at team %s.", endpoint, topic_arn, team_name)    
+    else:
+        logger.info(
+                "Endpoint %s is already subscribed to topic %s at team %s.", endpoint, topic_arn, team_name)
+
+def adjust_subscriptions(event, logger):
+    """
+    Adjusts subscription according to the parameters informed into the Custom Resource.
+
+    :param event: Event sent from CFN when the custom resource is created 
+    :param logger: Logger used for Lambda messages sent to CloudWatch
+    """
+    
+    resource_properties        = event['ResourceProperties']
+    team_name                  = resource_properties['TeamName']
+    topic_arn                  = resource_properties['TopicArn']
+    subscription_protocol      = resource_properties['SubscriptionProtocol']
+    subscription_endpoints     = resource_properties['SubscriptionEndpoints']
+    old_resource_properties    = event['OldResourceProperties'] if 'OldResourceProperties' in event else None
+    old_subscription_endpoints = old_resource_properties['SubscriptionEndpoints'] if old_resource_properties else None
+
+    if subscription_endpoints:
+        for endpoint in subscription_endpoints:
+            if old_subscription_endpoints is None or endpoint not in old_subscription_endpoints:
+                subscribe_endpoint(logger, team_name, topic_arn, endpoint, subscription_protocol)
+
+    if old_subscription_endpoints:
+        for endpoint in old_subscription_endpoints:
+            if subscription_endpoints is None or endpoint not in subscription_endpoints:
+                unsubscribe_endpoint(logger, team_name, topic_arn, endpoint)
+
+def lambda_handler(event, context):
+    """ 
+    Entrypoint to Lambda.
+
+    :param event: The event given to this Lambda function 
+    :param context: Context object containing Lambda metadata   
+    """
+
+    request_type = event['RequestType']
+
+    try:
+        if request_type == 'Create' or request_type == 'Update':
+            adjust_subscriptions(event, logger)
+            
+            message = None
+            if request_type == 'Create':
+                message = {
+                    "Message": "Created"
+                }
+            elif request_type == 'Update':
+                message = {
+                    "Message": "Updated"
+                }
+                
+            send_response(event, context, "SUCCESS", message)
+            
+        else:
+            send_response(event, context, "SUCCESS", {"Message": "Function Not Applicable"})
+
+    except Exception as ex:
+        logger.error(ex)
+        traceback.print_tb(ex.__traceback__)
+        send_response(
+            event,
+            context,
+            "FAILED",
+            {
+                "Message": "Exception"
+            }
+        )

--- a/sdlf-foundations/nested-stacks/template-dynamo.yaml
+++ b/sdlf-foundations/nested-stacks/template-dynamo.yaml
@@ -434,6 +434,24 @@ Resources:
     UpdateReplacePolicy: Retain
     DeletionPolicy: Retain
 
+  rDynamoTeamMetadata:
+    Type: AWS::DynamoDB::Table
+    Properties:
+      KeySchema:
+        - AttributeName: team
+          KeyType: HASH
+      AttributeDefinitions:
+        - AttributeName: "team"
+          AttributeType: S
+      BillingMode: PAY_PER_REQUEST
+      TableName: !Sub "octagon-Teams-${pEnvironment}"
+      SSESpecification:
+        SSEEnabled: True
+        SSEType: KMS
+        KMSMasterKeyId: !Ref pKMSKeyId
+    UpdateReplacePolicy: Retain
+    DeletionPolicy: Retain
+
   rDynamoObjectMetadataSsm:
     Type: AWS::SSM::Parameter
     Properties:
@@ -441,6 +459,7 @@ Resources:
       Type: String
       Value: !Ref rDynamoObjectMetadata
       Description: Name of the DynamoDB used to store metadata
+
   rDynamoTransformMappingSsm:
     Type: AWS::SSM::Parameter
     Properties:
@@ -448,6 +467,14 @@ Resources:
       Type: String
       Value: !Sub octagon-Datasets-${pEnvironment}
       Description: Name of the DynamoDB used to store mappings to transformation
+
+  rDynamoTeamMetadataSsm:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: /SDLF/Dynamo/TeamMetadata
+      Type: String
+      Value: !Ref rDynamoTeamMetadata
+      Description: Name of the DynamoDB used to store team's metadata
 
 Outputs:
   oDynamoOctagonObjectMetadataStream:

--- a/sdlf-foundations/nested-stacks/template-s3.yaml
+++ b/sdlf-foundations/nested-stacks/template-s3.yaml
@@ -15,8 +15,6 @@ Parameters:
     Type: String
   pOrganizationName:
     Type: String
-  pSNSNotificationsEmail:
-    Type: String
 
 Conditions:
   CreateMultipleBuckets: !Equals [!Ref pNumBuckets, "3"]
@@ -231,33 +229,6 @@ Resources:
         IgnorePublicAcls: True
         RestrictPublicBuckets: True
 
-  ######## SNS #########
-  rSNSTopic:
-    Type: AWS::SNS::Topic
-    Properties:
-      TopicName: sdlf-notifications
-      KmsMasterKeyId: !Ref pKMSKeyId
-      Subscription:
-        - Endpoint: !Ref pSNSNotificationsEmail
-          Protocol: email
-  rSNSTopicPolicy:
-    Type: AWS::SNS::TopicPolicy
-    Properties:
-      PolicyDocument:
-        Id: sdlf-notifications
-        Version: 2012-10-17
-        Statement:
-          - Sid: sdlf-notifications
-            Effect: Allow
-            Principal:
-              Service:
-                - cloudtrail.amazonaws.com
-                - cloudwatch.amazonaws.com
-            Action: sns:Publish
-            Resource: !Ref rSNSTopic
-      Topics:
-        - !Ref rSNSTopic
-
   ######## Lambda & SQS #########
   rQueueCatalog:
     Type: AWS::SQS::Queue
@@ -326,25 +297,6 @@ Resources:
       Timeout: 60
       Role: !GetAtt rRoleLambdaExecution.Arn
 
-  rLambdaCatalogCloudWatchAlarm:
-    Type: AWS::CloudWatch::Alarm
-    Properties:
-      AlarmName: sdlf-catalog
-      AlarmDescription: Catalog Lambda Alarm
-      AlarmActions:
-        - !Ref rSNSTopic
-      MetricName: Errors
-      EvaluationPeriods: 5
-      Period: 60
-      ComparisonOperator: GreaterThanThreshold
-      Namespace: AWS/Lambda
-      Statistic: Sum
-      Threshold: 10
-      Unit: Count
-      Dimensions:
-        - Name: FunctionName
-          Value: !Ref rLambdaCatalog
-
   rLambdaRouting:
     Type: AWS::Serverless::Function
     Properties:
@@ -366,25 +318,6 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaRouting}
-
-  rLambdaRoutingCloudWatchAlarm:
-    Type: AWS::CloudWatch::Alarm
-    Properties:
-      AlarmName: sdlf-routing
-      AlarmDescription: Routing Lambda Alarm
-      AlarmActions:
-        - !Ref rSNSTopic
-      MetricName: Errors
-      EvaluationPeriods: 5
-      Period: 60
-      ComparisonOperator: GreaterThanThreshold
-      Namespace: AWS/Lambda
-      Statistic: Sum
-      Threshold: 10
-      Unit: Count
-      Dimensions:
-        - Name: FunctionName
-          Value: !Ref rLambdaRouting
 
   rLambdaCatalogRedrive:
     Type: AWS::Serverless::Function
@@ -543,55 +476,6 @@ Resources:
                   - kms:ReEncrypt*
                 Resource: !Ref pKMSKeyId
 
-  ####### CICD Notifications #######
-  rCICDFoundationsPipelineFailedRule:
-    Type: AWS::Events::Rule
-    Properties:
-      Name: sdlf-cicd-foundations-failure
-      Description: Notify data lake admins of foundations CICD pipeline failure
-      EventPattern:
-        source:
-          - aws.codepipeline
-        detail-type:
-          - CodePipeline Pipeline Execution State Change
-        detail:
-          state:
-            - FAILED
-          pipeline:
-            - !Sub arn:aws:codepipeline:${AWS::Region}:${AWS::AccountId}:sdlf-cicd-foundations
-      State: ENABLED
-      Targets:
-        - Arn: !Ref rSNSTopic
-          Id: sdlf-cicd-foundations-failure
-          InputTransformer:
-            InputTemplate: !Sub '"The Pipeline <pipeline> has failed. Go to https://console.aws.amazon.com/codepipeline/home?region=${AWS::Region}#/view/sdlf-cicd-foundations"'
-            InputPathsMap:
-              pipeline: $.detail.pipeline
-
-  rCICDTeamPipelineFailedRule:
-    Type: AWS::Events::Rule
-    Properties:
-      Name: sdlf-cicd-team-failure
-      Description: Notify data lake admins of team CICD pipeline failure
-      EventPattern:
-        source:
-          - aws.codepipeline
-        detail-type:
-          - CodePipeline Pipeline Execution State Change
-        detail:
-          state:
-            - FAILED
-          pipeline:
-            - !Sub arn:aws:codepipeline:${AWS::Region}:${AWS::AccountId}:sdlf-cicd-team
-      State: ENABLED
-      Targets:
-        - Arn: !Ref rSNSTopic
-          Id: sdlf-cicd-team-failure
-          InputTransformer:
-            InputTemplate: !Sub '"The Pipeline <pipeline> has failed. Go to https://console.aws.amazon.com/codepipeline/home?region=${AWS::Region}#/view/sdlf-cicd-team"'
-            InputPathsMap:
-              pipeline: $.detail.pipeline
-
   ####### SSM #######
   rS3ArtifactBucketSsm:
     Type: AWS::SSM::Parameter
@@ -652,9 +536,6 @@ Resources:
       Description: URL of dead letter routing queue
 
 Outputs:
-  oSNSNotificationsTopic:
-    Value: !Ref rSNSTopic
-    Description: SNS Notifications Topic
   oLambdaCatalog:
     Value: !Ref rLambdaCatalog
     Description: Catalogs S3 Put/DeleteObject into ObjectMetadataCatalog DynamoDB table

--- a/sdlf-foundations/nested-stacks/template-sns.yaml
+++ b/sdlf-foundations/nested-stacks/template-sns.yaml
@@ -1,0 +1,213 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Transform: "AWS::Serverless-2016-10-31"
+Description: "SNS resources (topic, subscription through custom resource) and alarms/notifications."
+
+Parameters:
+  pEnvironment:
+    Type: String
+  pKMSKeyId:
+    Type: String
+  pLambdaCatalog:
+    Type: String
+  pLambdaRouting:
+    Type: String
+  pSNSNotificationsEmail:
+    Type: CommaDelimitedList
+
+Globals:
+  Function:
+      Runtime: python3.7
+      Handler: lambda_function.lambda_handler
+      KmsKeyArn: !Ref pKMSKeyId
+
+Resources:
+  ######## LAMBDA #########
+  rSNSTopicSubscriptionLambda:
+    Type: "AWS::Serverless::Function"
+    Properties:
+      CodeUri: ../lambda/topic/src
+      FunctionName: !Join ['-', ["sdlf", "cr", "sns", "topic", "endpoints", "subscription"]]
+      Description: "Subscribes multiple endpoints to an SNS topic."
+      Role: !GetAtt rSNSTopicSubscriptionRole.Arn
+      Timeout: 30
+      Environment:
+        Variables:
+          TEAM_METADATA_TABLE_SSM_PARAM: '/SDLF/Dynamo/TeamMetadata' 
+
+  ######## IAM #########
+  rSNSTopicSubscriptionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Join ['-', ["sdlf", "cr", "sns", "topic", "endpoints", "subscription", "role"]]
+      AssumeRolePolicyDocument:
+        Statement:
+          - Action: sts:AssumeRole
+            Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+        Version: '2012-10-17'
+      Path: /
+      Policies:
+        -
+          PolicyName: root
+          PolicyDocument:
+            Statement:
+              - Action:
+                  - logs:CreateLogGroup
+                  - logs:DescribeLogGroups
+                  - logs:CreateLogStream
+                  - logs:DescribeLogStreams
+                  - logs:PutLogEvents
+                Effect: Allow
+                Resource:
+                  - !Sub 'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:*'
+                Sid: LogAccessPolicy
+              - Action:
+                  - sns:Unsubscribe
+                  - sns:Subscribe
+                Effect: Allow
+                Resource: 
+                  - !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:sdlf-*"
+                Sid: SNSSubscription
+              - Action:
+                  - ssm:GetParameter
+                Effect: Allow
+                Resource: 
+                  - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/*"
+                Sid: SSMGetParameter
+              - Action:
+                  - dynamodb:GetItem
+                  - dynamodb:PutItem
+                Effect: Allow
+                Resource: 
+                  - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/octagon-Teams-${pEnvironment}"
+                Sid: DynamoDBControl
+            Version: '2012-10-17'
+
+  ######## SNS #########
+  rSNSTopic:
+    Type: AWS::SNS::Topic
+    Properties:
+      TopicName: sdlf-notifications
+      KmsMasterKeyId: !Ref pKMSKeyId
+  rSNSTopicPolicy:
+    Type: AWS::SNS::TopicPolicy
+    Properties:
+      PolicyDocument:
+        Id: sdlf-notifications
+        Version: 2012-10-17
+        Statement:
+          - Sid: sdlf-notifications
+            Effect: Allow
+            Principal:
+              Service:
+                - cloudtrail.amazonaws.com
+                - cloudwatch.amazonaws.com
+            Action: sns:Publish
+            Resource: !Ref rSNSTopic
+      Topics:
+        - !Ref rSNSTopic
+  rSNSTopicSubscription:
+    Type: Custom::SNSSubscription
+    Properties:
+      ServiceToken: !GetAtt rSNSTopicSubscriptionLambda.Arn
+      TeamName: 'admin'
+      TopicArn: !Ref rSNSTopic
+      SubscriptionEndpoints: !Ref pSNSNotificationsEmail
+      SubscriptionProtocol: 'email'
+      
+  ######## CLOUD WATCH #########
+  rLambdaCatalogCloudWatchAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: sdlf-catalog
+      AlarmDescription: Catalog Lambda Alarm
+      AlarmActions:
+        - !Ref rSNSTopic
+      MetricName: Errors
+      EvaluationPeriods: 5
+      Period: 60
+      ComparisonOperator: GreaterThanThreshold
+      Namespace: AWS/Lambda
+      Statistic: Sum
+      Threshold: 10
+      Unit: Count
+      Dimensions:
+        - Name: FunctionName
+          Value: !Ref pLambdaCatalog
+
+  rLambdaRoutingCloudWatchAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmName: sdlf-routing
+      AlarmDescription: Routing Lambda Alarm
+      AlarmActions:
+        - !Ref rSNSTopic
+      MetricName: Errors
+      EvaluationPeriods: 5
+      Period: 60
+      ComparisonOperator: GreaterThanThreshold
+      Namespace: AWS/Lambda
+      Statistic: Sum
+      Threshold: 10
+      Unit: Count
+      Dimensions:
+        - Name: FunctionName
+          Value: !Ref pLambdaRouting
+
+  ####### Event Rules #######
+  rCICDFoundationsPipelineFailedRule:
+    Type: AWS::Events::Rule
+    Properties:
+      Name: sdlf-cicd-foundations-failure
+      Description: Notify data lake admins of foundations CICD pipeline failure
+      EventPattern:
+        source:
+          - aws.codepipeline
+        detail-type:
+          - CodePipeline Pipeline Execution State Change
+        detail:
+          state:
+            - FAILED
+          pipeline:
+            - !Sub arn:aws:codepipeline:${AWS::Region}:${AWS::AccountId}:sdlf-cicd-foundations
+      State: ENABLED
+      Targets:
+        - Arn: !Ref rSNSTopic
+          Id: sdlf-cicd-foundations-failure
+          InputTransformer:
+            InputTemplate: !Sub '"The Pipeline <pipeline> has failed. Go to https://console.aws.amazon.com/codepipeline/home?region=${AWS::Region}#/view/sdlf-cicd-foundations"'
+            InputPathsMap:
+              pipeline: $.detail.pipeline
+
+  rCICDTeamPipelineFailedRule:
+    Type: AWS::Events::Rule
+    Properties:
+      Name: sdlf-cicd-team-failure
+      Description: Notify data lake admins of team CICD pipeline failure
+      EventPattern:
+        source:
+          - aws.codepipeline
+        detail-type:
+          - CodePipeline Pipeline Execution State Change
+        detail:
+          state:
+            - FAILED
+          pipeline:
+            - !Sub arn:aws:codepipeline:${AWS::Region}:${AWS::AccountId}:sdlf-cicd-team
+      State: ENABLED
+      Targets:
+        - Arn: !Ref rSNSTopic
+          Id: sdlf-cicd-team-failure
+          InputTransformer:
+            InputTemplate: !Sub '"The Pipeline <pipeline> has failed. Go to https://console.aws.amazon.com/codepipeline/home?region=${AWS::Region}#/view/sdlf-cicd-team"'
+            InputPathsMap:
+              pipeline: $.detail.pipeline
+
+Outputs:
+  osnsTopicSubscriptionLambdaArn:
+    Value: !GetAtt rSNSTopicSubscriptionLambda.Arn
+    Description: "SNS Topic Subscription Lambda ARN."
+    Export:
+      Name: "sdlf-sns-topic-subscription-lambda-arn"

--- a/sdlf-foundations/template.yaml
+++ b/sdlf-foundations/template.yaml
@@ -78,7 +78,6 @@ Resources:
         pKMSKeyId: !GetAtt [rKMSStack, Outputs.oKMSKeyId]
         pNumBuckets: !Ref pNumBuckets
         pOrganizationName: !Ref pOrganizationName
-        pSNSNotificationsEmail: !Ref pSNSNotificationsEmail
       Tags:
         - Key: tagging-policy
           Value: !Sub ${pOrganizationName}-${pApplicationName}-${pEnvironment}-foundations
@@ -112,6 +111,23 @@ Resources:
       Tags:
         - Key: tagging-policy
           Value: !Sub ${pOrganizationName}-${pApplicationName}-${pEnvironment}-foundations
+
+  ######## SNS AND NOTIFICATIONS #########
+  rSNSStack:
+    Type: AWS::CloudFormation::Stack
+    DependsOn: rDynamoStack
+    Properties:
+      TemplateURL: ./nested-stacks/template-sns.yaml
+      Parameters:
+        pEnvironment: !Ref pEnvironment
+        pKMSKeyId: !GetAtt [ "rKMSStack", "Outputs.oKMSKeyId" ]
+        pLambdaCatalog: !GetAtt [ "rS3Stack", "Outputs.oLambdaCatalog" ]
+        pLambdaRouting: !GetAtt [ "rS3Stack", "Outputs.oLambdaRouting" ]
+        pSNSNotificationsEmail: !Ref pSNSNotificationsEmail
+      Tags:
+        -
+          Key: 'tagging-policy'
+          Value: !Join ['-', [!Ref pOrganizationName, !Ref pApplicationName, !Ref pEnvironment, "common"]]
 
   ######## GLUE REPLICATION #########
   rGlueReplicationStack:

--- a/sdlf-team/nested-stacks/template-cicd.yaml
+++ b/sdlf-team/nested-stacks/template-cicd.yaml
@@ -2,12 +2,6 @@ AWSTemplateFormatVersion: 2010-09-09
 Description: CICD Resources to manage a team
 
 Parameters:
-  pAnalyticsBucket:
-    Type: String
-  pApplicationName:
-    Type: String
-  pCentralBucket:
-    Type: String
   pCFNBucket:
     Type: String
   pCloudWatchRepositoryTriggerRoleArn:
@@ -39,20 +33,14 @@ Parameters:
     Type: String
   pMinimumTestCoverage:
     Type: String
-  pOrganizationName:
-    Type: String
-  pPipelineBucket:
-    Type: String
   pPipLibrariesRepositoryName:
     Type: String
   pRunCodeCoverage:
     Type: String
   pSharedDevOpsAccountId:
     Type: String
-  pStageBucket:
-    Type: String
   pSNSNotificationsEmail:
-    Type: String
+    Type: CommaDelimitedList
   pTeamName:
     Type: String
   pTransformValidateRoleArn:
@@ -82,9 +70,6 @@ Resources:
     Properties:
       TopicName: !Sub sdlf-${pTeamName}-notifications
       KmsMasterKeyId: !Ref pKMSInfraKeyId
-      Subscription:
-        - Endpoint: !Ref pSNSNotificationsEmail
-          Protocol: email
 
   rSNSTopicPolicy:
     Type: AWS::SNS::TopicPolicy
@@ -101,6 +86,15 @@ Resources:
             Resource: !Ref rSNSTopic
       Topics:
         - !Ref rSNSTopic
+
+  rSNSTopicSubscription:
+    Type: Custom::SNSSubscription
+    Properties:
+      ServiceToken: !ImportValue sdlf-sns-topic-subscription-lambda-arn
+      TeamName: !Sub ${pTeamName}
+      TopicArn: !Ref rSNSTopic
+      SubscriptionEndpoints: !Ref pSNSNotificationsEmail
+      SubscriptionProtocol: 'email'
 
   ######## CODEBUILD JOBS #########
   rBuildDatasetMappings:

--- a/sdlf-team/template.yaml
+++ b/sdlf-team/template.yaml
@@ -123,9 +123,6 @@ Resources:
     Properties:
       TemplateURL: ./nested-stacks/template-cicd.yaml
       Parameters:
-        pAnalyticsBucket: !Ref pAnalyticsBucket
-        pApplicationName: !Ref pApplicationName
-        pCentralBucket: !Ref pCentralBucket
         pCFNBucket: !Ref pCFNBucket
         pCloudWatchRepositoryTriggerRoleArn:
           !GetAtt [rIAMStack, Outputs.oCloudWatchRepositoryTriggerRoleArn]
@@ -143,12 +140,9 @@ Resources:
         pKMSInfraKeyId: !GetAtt [rKMSStack, Outputs.oKMSInfraKeyId]
         pLibrariesBranchName: !Ref pLibrariesBranchName
         pMinimumTestCoverage: !Ref pMinTestCoverage
-        pOrganizationName: !Ref pOrganizationName
-        pPipelineBucket: !Ref pPipelineBucket
         pPipLibrariesRepositoryName: !Ref pPipLibrariesRepositoryName
         pRunCodeCoverage: !Ref pRunCodeCoverage
         pSharedDevOpsAccountId: !Ref pSharedDevOpsAccountId
-        pStageBucket: !Ref pStageBucket
         pSNSNotificationsEmail: !Ref pSNSNotificationsEmail
         pTeamName: !Ref pTeamName
         pTransformValidateRoleArn:


### PR DESCRIPTION
*Description of changes:*
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

This changes the foundation and team on boarding functionalities allowing the specification of multiple email endpoints for SNS topics.

A DynamoDB table was used to store team's metadata and let us control updates on the SNS subscriptions. We unsubscribe based on parameter changes from one execution to the previous. This unsubscribe action is done only if the email owner has already accepted the invitation, but the DynamoDB table is always updated.

An important drawback is that we are not able to confirm subscription automatically.

*Testing:*
I started with the creation (first scenario below), update (from second till the last scenario), and delete (just asked delete action through CloudFormation screen) of stacks related to commits on sdlf-cloudformation, and also sdlf-team.

I executed in the following:
*  Execute with one value only and accept the subscription email received
   *  Expected Results: One confirmation at topic subscriptions screen, and one record into the DynamoDB table
*  Execute with two more values, split by comma, and to not accept the subscriptions
   *  Expected Results: One confirmation and two pending at topic subscriptions screen, and three records into the DynamoDB table
*  Execute with a new value, not specified before, keeping the first one (first test case), removing the other two from previous test case (second one), and accepting the subscription email received
   *  Expected Results: Two confirmations and two pending at topic subscriptions screen, two records (first and fourth emails) into the DynamoDB table, and at CloudWatch logs is possible to see that the second and third emails were not unsubscribed because they have never accepted.
*  Execute again keeping the last value only (third test case)
   *  Expected Results: One confirmation (third test case, fourth email) and two pending at topic subscriptions screen, one record (fourth email) into the DynamoDB table, and at CloudWatch logs is possible to see that the first email was unsubscribed from the topic.