### PR TITLE
Add wrangler38 to external layers

### DIFF
--- a/sdlf-pipLibrary/AWSDataWrangler/external_layers.json
+++ b/sdlf-pipLibrary/AWSDataWrangler/external_layers.json
@@ -7,6 +7,10 @@
         "wrangler37": {
             "url": "https://github.com/awslabs/aws-data-wrangler/releases/download/1.9.6/awswrangler-layer-1.9.6-py3.7.zip",
             "runtimes": ["python3.7"]
+        },
+        "wrangler38": {
+            "url": "https://github.com/awslabs/aws-data-wrangler/releases/download/1.9.6/awswrangler-layer-1.9.6-py3.8.zip",
+            "runtimes": ["python3.8"]
         }
     }
 ]


### PR DESCRIPTION
*Description of changes:*
Build [awswrangler](https://github.com/awslabs/aws-data-wrangler) lambda layer for python3.8.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
