### PR TITLE
Dev

### DIFF
--- a/sdlf-team/nested-stacks/template-cicd.yaml
+++ b/sdlf-team/nested-stacks/template-cicd.yaml
@@ -74,6 +74,9 @@ Conditions:
     - "true"
   NotRunUnitTestingStage: !Not
     - Condition: RunUnitTestingStage
+  IsProduction: !Equals
+    - !Ref pEnvironment
+    - "prod"
 
 Resources:
   ######## SNS #########
@@ -93,7 +96,9 @@ Resources:
           - Sid: !Sub sdlf-${pTeamName}-notifications
             Effect: Allow
             Principal:
-              Service: cloudwatch.amazonaws.com
+              Service:
+                - cloudwatch.amazonaws.com
+                - events.amazonaws.com
             Action: sns:Publish
             Resource: !Ref rSNSTopic
       Topics:
@@ -891,6 +896,50 @@ Resources:
             InputTemplate: !Sub '"The Pipeline <pipeline> has failed. Go to https://console.aws.amazon.com/codepipeline/home?region=${AWS::Region}#/view/${rDatasetCodePipeline}"'
             InputPathsMap:
               pipeline: $.detail.pipeline
+
+  rPullRequestCreated:
+    Condition: IsProduction
+    Type: AWS::Events::Rule
+    Properties:
+      Name: !Sub sdlf-pr-created-${pTeamName}
+      Description: !Sub Notify ${pTeamName} team of newly created pull request
+      EventPattern: !Sub
+        - |-
+          {
+            "detail-type": [
+              "CodeCommit Pull Request State Change"
+            ],
+            "resources": [
+              "arn:aws:codecommit:${AWS::Region}:${pSharedDevOpsAccountId}:sdlf-${pTeamName}-pipeline",
+              "arn:aws:codecommit:${AWS::Region}:${pSharedDevOpsAccountId}:sdlf-${pTeamName}-dataset",
+              "arn:aws:codecommit:${AWS::Region}:${pSharedDevOpsAccountId}:sdlf-${pTeamName}-datalakeLibrary",
+              "arn:aws:codecommit:${AWS::Region}:${pSharedDevOpsAccountId}:sdlf-${pTeamName}-pipLibrary",
+              "arn:aws:codecommit:${AWS::Region}:${pSharedDevOpsAccountId}:sdlf-${pTeamName}-stageA",
+              "arn:aws:codecommit:${AWS::Region}:${pSharedDevOpsAccountId}:sdlf-${pTeamName}-stageB",
+              "arn:aws:codecommit:${AWS::Region}:${pSharedDevOpsAccountId}:sdlf-${pTeamName}-stageC"
+            ],
+            "source": [
+              "aws.codecommit"
+            ],
+            "detail": {
+              "destinationReference": [
+                {"prefix":"refs/heads/${cBranch}"},
+                {"prefix":"${cBranch}"}
+              ],
+              "event": [
+                "pullRequestCreated"
+              ]
+            }
+          }
+        - { cBranch: !FindInMap [pCodeCommitBranch, !Ref pEnvironment, branch] }
+      State: ENABLED
+      Targets:
+        - Arn: !Ref rSNSTopic
+          Id: !Sub sdlf-${pTeamName}-pull-request-created
+          InputTransformer:
+            InputTemplate: '"<notificationBody>"'
+            InputPathsMap:
+              notificationBody: $.detail.notificationBody
 
   ######## SSM #########
   rSNSTopicSsm:

--- a/sdlf-team/nested-stacks/template-kms.yaml
+++ b/sdlf-team/nested-stacks/template-kms.yaml
@@ -35,7 +35,9 @@ Resources:
           - Sid: Allow CloudWatch alarms access
             Effect: Allow
             Principal:
-              Service: cloudwatch.amazonaws.com
+              Service:
+                - cloudwatch.amazonaws.com
+                - events.amazonaws.com
             Action:
               - kms:Decrypt
               - kms:GenerateDataKey*

--- a/sdlf-team/scripts/bootstrap_team.sh
+++ b/sdlf-team/scripts/bootstrap_team.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 DIRNAME=$(pwd)
 TEAM_NAME=$(sed -e 's/^"//' -e 's/"$//' <<<"$(jq '.[] | select(.ParameterKey=="pTeamName") | .ParameterValue' ${DIRNAME}/../parameters-${ENV}.json)")
-NOTIFICATION_EMAIL=$(sed -e 's/^"//' -e 's/"$//' <<<"$(jq '.[] | select(.ParameterKey=="pSNSNotificationsEmail") | .ParameterValue' ${DIRNAME}/../parameters-${ENV}.json)")
 function create_approbal_rule()
 {
   CA_OUT=$(aws codecommit create-approval-rule-template \
@@ -59,7 +58,6 @@ if ! aws cloudformation describe-stacks --stack-name ${STACK_NAME}; then
         ParameterKey=pChildAccountId,ParameterValue="${CHILD_ACCOUNT}" \
         ParameterKey=pEnvironment,ParameterValue="${ENV}" \
         ParameterKey=pTeamName,ParameterValue="${TEAM_NAME}" \
-        ParameterKey=pSNSNotificationsEmail,ParameterValue=\"${NOTIFICATION_EMAIL}\" \
     --template-body file://${DIRNAME}/template-team-repos.yaml \
     --tags file://${DIRNAME}/../tags.json \
     --capabilities "CAPABILITY_NAMED_IAM" "CAPABILITY_AUTO_EXPAND"

--- a/sdlf-team/scripts/template-team-repos.yaml
+++ b/sdlf-team/scripts/template-team-repos.yaml
@@ -27,6 +27,9 @@ Mappings:
 
 Conditions:
   CrossAccount: !Not [!Equals [!Ref pChildAccountId, !Ref "AWS::AccountId"]]
+  IsProduction: !Equals
+    - !Ref pEnvironment
+    - "prod"
 
 Resources:
   rCodeCommitRole:
@@ -132,11 +135,50 @@ Resources:
               ]
             }
           }
-        - {
-            cBranch: !FindInMap [pCodeCommitBranch, !Ref pEnvironment, branch]
-          }
+        - { cBranch: !FindInMap [pCodeCommitBranch, !Ref pEnvironment, branch] }
       State: ENABLED
       Targets:
         - Arn: !Sub arn:aws:events:${AWS::Region}:${pChildAccountId}:event-bus/default
           Id: !Sub sdlf-cicd-team-codecommit-${pEnvironment}-${pTeamName}
+          RoleArn: !Sub arn:aws:iam::${AWS::AccountId}:role/sdlf-cicd-foundations-eventbus-${pEnvironment}
+
+  rPullRequestCreated:
+    Condition: IsProduction
+    Type: AWS::Events::Rule
+    Properties:
+      Name: !Sub sdlf-cicd-team-codecommit-pr-${pEnvironment}-${pTeamName}
+      Description: !Sub Notify ${pTeamName} team of newly created pull request
+      EventPattern: !Sub
+        - |-
+          {
+            "detail-type": [
+              "CodeCommit Pull Request State Change"
+            ],
+            "resources": [
+              "arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-pipeline",
+              "arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-dataset",
+              "arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-datalakeLibrary",
+              "arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-pipLibrary",
+              "arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-stageA",
+              "arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-stageB",
+              "arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-stageC"
+            ],
+            "source": [
+              "aws.codecommit"
+            ],
+            "detail": {
+              "destinationReference": [
+                {"prefix":"refs/heads/${cBranch}"},
+                {"prefix":"${cBranch}"}
+              ],
+              "event": [
+                "pullRequestCreated"
+              ]
+            }
+          }
+        - { cBranch: !FindInMap [pCodeCommitBranch, !Ref pEnvironment, branch] }
+      State: ENABLED
+      Targets:
+        - Arn: !Sub arn:aws:events:${AWS::Region}:${pChildAccountId}:event-bus/default
+          Id: !Sub sdlf-cicd-team-codecommit-pr-${pEnvironment}-${pTeamName}
           RoleArn: !Sub arn:aws:iam::${AWS::AccountId}:role/sdlf-cicd-foundations-eventbus-${pEnvironment}

--- a/sdlf-team/scripts/template-team-repos.yaml
+++ b/sdlf-team/scripts/template-team-repos.yaml
@@ -15,25 +15,18 @@ Parameters:
   pTeamName:
     Description: Team name
     Type: String
-  pSNSNotificationsEmail:
-    Description: List of SNS Notification Email Endpoints
-    Type: CommaDelimitedList
 
 Mappings:
   pCodeCommitBranch:
     dev:
       branch: dev
-      prefix: '{"prefix":"dev"}'
     test:
       branch: test
-      prefix: '{"prefix":"test"}'
     prod:
       branch: master
-      prefix: '{"prefix":"master"}'
 
 Conditions:
   CrossAccount: !Not [!Equals [!Ref pChildAccountId, !Ref "AWS::AccountId"]]
-  IsProduction: !Equals [!Ref pEnvironment, "prod"]
 
 Resources:
   rCodeCommitRole:
@@ -103,125 +96,47 @@ Resources:
                   ForAllValues:StringLike:
                     aws:PrincipalArn: !Sub "*${pTeamName}*"
 
-  rCodeCommitCoreTriggerRule:
+  rCodeCommitTriggerRule:
     Condition: CrossAccount
     Type: AWS::Events::Rule
     Properties:
-      Name: !Sub sdlf-cicd-team-codecommit-core-${pEnvironment}-${pTeamName}
-      EventPattern:
-        source:
-          - aws.codecommit
-        detail-type:
-          - CodeCommit Repository State Change
-        resources:
-          - !Sub arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-pipeline
-          - !Sub arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-dataset
-          - !Sub arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-datalakeLibrary
-          - !Sub arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-pipLibrary
-        detail:
-          event:
-            - referenceCreated
-            - referenceUpdated
-          referenceType:
-            - branch
-          referenceName:
-            - !FindInMap [pCodeCommitBranch, !Ref pEnvironment, branch]
+      Name: !Sub sdlf-cicd-team-codecommit-${pEnvironment}-${pTeamName}
+      EventPattern: !Sub
+        - |-
+          {
+            "detail-type": [
+              "CodeCommit Repository State Change"
+            ],
+            "resources": [
+              "arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-pipeline",
+              "arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-dataset",
+              "arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-datalakeLibrary",
+              "arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-pipLibrary",
+              "arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-stageA",
+              "arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-stageB",
+              "arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-stageC"
+            ],
+            "source": [
+              "aws.codecommit"
+            ],
+            "detail": {
+              "referenceType": [
+                "branch"
+              ],
+              "event": [
+                "referenceCreated",
+                "referenceUpdated"
+              ],
+              "referenceName": [
+                {"prefix":"${cBranch}"}
+              ]
+            }
+          }
+        - {
+            cBranch: !FindInMap [pCodeCommitBranch, !Ref pEnvironment, branch]
+          }
       State: ENABLED
       Targets:
         - Arn: !Sub arn:aws:events:${AWS::Region}:${pChildAccountId}:event-bus/default
-          Id: !Sub sdlf-cicd-team-codecommit-core-${pEnvironment}-${pTeamName}
+          Id: !Sub sdlf-cicd-team-codecommit-${pEnvironment}-${pTeamName}
           RoleArn: !Sub arn:aws:iam::${AWS::AccountId}:role/sdlf-cicd-foundations-eventbus-${pEnvironment}
-
-  rCodeCommitStagesTriggerRule:
-    Condition: CrossAccount
-    Type: AWS::Events::Rule
-    Properties:
-      Name: !Sub sdlf-cicd-team-codecommit-stages-${pEnvironment}-${pTeamName}
-      EventPattern:
-        source:
-          - aws.codecommit
-        detail-type:
-          - CodeCommit Repository State Change
-        resources:
-          - !Sub arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-stageA
-          - !Sub arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-stageB
-          - !Sub arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-stageC
-        detail:
-          event:
-            - referenceCreated
-            - referenceUpdated
-          referenceType:
-            - branch
-          referenceName:
-            - !FindInMap [pCodeCommitBranch, !Ref pEnvironment, prefix]
-      State: ENABLED
-      Targets:
-        - Arn: !Sub arn:aws:events:${AWS::Region}:${pChildAccountId}:event-bus/default
-          Id: !Sub sdlf-cicd-team-codecommit-stages-${pEnvironment}-${pTeamName}
-          RoleArn: !Sub arn:aws:iam::${AWS::AccountId}:role/sdlf-cicd-foundations-eventbus-${pEnvironment}
-
-  rSNSTopic:
-    Condition: IsProduction
-    Type: AWS::SNS::Topic
-    Properties:
-      TopicName: !Sub sdlf-repo-notifications-${pEnvironment}-${pTeamName}
-
-  rSNSTopicPolicy:
-    Condition: IsProduction
-    Type: AWS::SNS::TopicPolicy
-    Properties:
-      PolicyDocument:
-        Id: !Sub sdlf-${pTeamName}-repo-notifications
-        Version: 2012-10-17
-        Statement:
-          - Sid: !Sub sdlf-${pTeamName}-repo-notifications
-            Effect: Allow
-            Principal:
-              Service: events.amazonaws.com
-            Action: sns:Publish
-            Resource: !Ref rSNSTopic
-      Topics:
-        - !Ref rSNSTopic
-
-  rSNSTopicSubscription:
-    Condition: IsProduction
-    Type: Custom::SNSSubscription
-    Properties:
-      ServiceToken: !ImportValue sdlf-sns-topic-subscription-lambda-arn
-      TeamName: !Sub ${pTeamName}
-      TopicArn: !Ref rSNSTopic
-      SubscriptionEndpoints: !Ref pSNSNotificationsEmail
-      SubscriptionProtocol: email
-
-  rPullRequestCreated:
-    Condition: IsProduction
-    Type: AWS::Events::Rule
-    Properties:
-      Name: !Sub sdlf-pr-created-${pTeamName}
-      Description: !Sub Notify ${pTeamName} team of newly created pull request
-      EventPattern:
-        source:
-          - aws.codecommit
-        detail-type:
-          - CodeCommit Pull Request State Change
-        resources:
-          - !Sub arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-pipeline
-          - !Sub arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-dataset
-          - !Sub arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-datalakeLibrary
-          - !Sub arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-pipLibrary
-          - !Sub arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-stageA
-          - !Sub arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-stageB
-        detail:
-          destinationReference:
-            - refs/heads/master
-            - master
-          event:
-            - pullRequestCreated
-      State: ENABLED
-      Targets:
-        - Arn: !Ref rSNSTopic
-          Id: !Sub sdlf-${pTeamName}-pull-request-created
-          InputTransformer:
-            InputTemplate: '"<notificationBody>"'
-            InputPathsMap:
-              notificationBody: $.detail.notificationBody

--- a/sdlf-team/scripts/template-team-repos.yaml
+++ b/sdlf-team/scripts/template-team-repos.yaml
@@ -23,10 +23,13 @@ Mappings:
   pCodeCommitBranch:
     dev:
       branch: dev
+      prefix: '{"prefix":"dev"}'
     test:
       branch: test
+      prefix: '{"prefix":"test"}'
     prod:
       branch: master
+      prefix: '{"prefix":"master"}'
 
 Conditions:
   CrossAccount: !Not [!Equals [!Ref pChildAccountId, !Ref "AWS::AccountId"]]
@@ -100,11 +103,11 @@ Resources:
                   ForAllValues:StringLike:
                     aws:PrincipalArn: !Sub "*${pTeamName}*"
 
-  rCodeCommitTriggerRule:
+  rCodeCommitCoreTriggerRule:
     Condition: CrossAccount
     Type: AWS::Events::Rule
     Properties:
-      Name: !Sub sdlf-cicd-team-codecommit-${pEnvironment}-${pTeamName}
+      Name: !Sub sdlf-cicd-team-codecommit-core-${pEnvironment}-${pTeamName}
       EventPattern:
         source:
           - aws.codecommit
@@ -115,9 +118,6 @@ Resources:
           - !Sub arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-dataset
           - !Sub arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-datalakeLibrary
           - !Sub arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-pipLibrary
-          - !Sub arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-stageA
-          - !Sub arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-stageB
-          - !Sub arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-stageC
         detail:
           event:
             - referenceCreated
@@ -129,7 +129,35 @@ Resources:
       State: ENABLED
       Targets:
         - Arn: !Sub arn:aws:events:${AWS::Region}:${pChildAccountId}:event-bus/default
-          Id: !Sub sdlf-cicd-team-codecommit-${pEnvironment}-${pTeamName}
+          Id: !Sub sdlf-cicd-team-codecommit-core-${pEnvironment}-${pTeamName}
+          RoleArn: !Sub arn:aws:iam::${AWS::AccountId}:role/sdlf-cicd-foundations-eventbus-${pEnvironment}
+
+  rCodeCommitStagesTriggerRule:
+    Condition: CrossAccount
+    Type: AWS::Events::Rule
+    Properties:
+      Name: !Sub sdlf-cicd-team-codecommit-stages-${pEnvironment}-${pTeamName}
+      EventPattern:
+        source:
+          - aws.codecommit
+        detail-type:
+          - CodeCommit Repository State Change
+        resources:
+          - !Sub arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-stageA
+          - !Sub arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-stageB
+          - !Sub arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-stageC
+        detail:
+          event:
+            - referenceCreated
+            - referenceUpdated
+          referenceType:
+            - branch
+          referenceName:
+            - !FindInMap [pCodeCommitBranch, !Ref pEnvironment, prefix]
+      State: ENABLED
+      Targets:
+        - Arn: !Sub arn:aws:events:${AWS::Region}:${pChildAccountId}:event-bus/default
+          Id: !Sub sdlf-cicd-team-codecommit-stages-${pEnvironment}-${pTeamName}
           RoleArn: !Sub arn:aws:iam::${AWS::AccountId}:role/sdlf-cicd-foundations-eventbus-${pEnvironment}
 
   rSNSTopic:


### PR DESCRIPTION
*Issue #, if available:* #11

*Description of changes:*
- Pull request Event Rule and SNS subscription pushed to child account. It has the added benefit of leveraging the same SNS team topic. This is a fix to issue #11 
- Modified EventBridge rules to allow prefixes on branch names. It will enable stageA/B CodePipelines to be triggered on branches such as `dev-ml` (i.e. `<env>-<stageName>`) 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
