### PR TITLE
added bucket policies to enforce in transit encryption for s3 buckets

### DIFF
--- a/sdlf-cicd/template-cicd-child-foundations.yaml
+++ b/sdlf-cicd/template-cicd-child-foundations.yaml
@@ -92,7 +92,7 @@ Resources:
               - !Sub arn:aws:s3:::${rArtifactsBucket}
             Condition:
               Bool:
-                'aws:SecureTransport': 'False'
+                aws:SecureTransport: False
 
 
   ######## IAM #########

--- a/sdlf-cicd/template-cicd-child-foundations.yaml
+++ b/sdlf-cicd/template-cicd-child-foundations.yaml
@@ -84,6 +84,16 @@ Resources:
               - s3:Put*
             Resource:
               - !Sub arn:aws:s3:::${rArtifactsBucket}/*
+          - Effect: Deny
+            Principal: "*"
+            Action: s3:*
+            Resource:
+              - !Sub arn:aws:s3:::${rArtifactsBucket}/*
+              - !Sub arn:aws:s3:::${rArtifactsBucket}
+            Condition:
+              Bool:
+                'aws:SecureTransport': 'False'
+
 
   ######## IAM #########
   rCodeBuildRole:

--- a/sdlf-foundations/nested-stacks/template-cloudtrail.yaml
+++ b/sdlf-foundations/nested-stacks/template-cloudtrail.yaml
@@ -117,7 +117,7 @@ Resources:
               - !Sub arn:aws:s3:::${rTrailBucket}
             Condition:
               Bool:
-                'aws:SecureTransport': 'False'
+                aws:SecureTransport: False
 
   rTrailLogGroup:
     Type: AWS::Logs::LogGroup

--- a/sdlf-foundations/nested-stacks/template-cloudtrail.yaml
+++ b/sdlf-foundations/nested-stacks/template-cloudtrail.yaml
@@ -108,6 +108,16 @@ Resources:
             Condition:
               StringEquals:
                 s3:x-amz-acl: bucket-owner-full-control
+          - Sid: AllowSSLRequestsOnly
+            Effect: Deny
+            Principal: "*"
+            Action: s3:*
+            Resource:
+              - !Sub arn:aws:s3:::${rTrailBucket}/*
+              - !Sub arn:aws:s3:::${rTrailBucket}
+            Condition:
+              Bool:
+                'aws:SecureTransport': 'False'
 
   rTrailLogGroup:
     Type: AWS::Logs::LogGroup

--- a/sdlf-foundations/nested-stacks/template-s3.yaml
+++ b/sdlf-foundations/nested-stacks/template-s3.yaml
@@ -48,6 +48,24 @@ Resources:
         IgnorePublicAcls: True
         RestrictPublicBuckets: True
 
+  rPipelineBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref rPipelineBucket
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: AllowSSLRequestsOnly
+            Action: s3:*
+            Effect: Deny
+            Resource:
+              - !Sub arn:aws:s3:::${rPipelineBucket}/*
+              - !Sub arn:aws:s3:::${rPipelineBucket}
+            Condition:
+              Bool:
+                'aws:SecureTransport': 'False'
+            Principal: "*"
+
   # To Enforce KMS encryption: https://aws.amazon.com/premiumsupport/knowledge-center/s3-bucket-store-kms-encrypted-objects/
   rCentralBucket:
     Type: AWS::S3::Bucket
@@ -75,6 +93,25 @@ Resources:
             Queue: !GetAtt rQueueCatalog.Arn
           - Event: s3:ObjectRemoved:*
             Queue: !GetAtt rQueueCatalog.Arn
+
+  rCentralBucketPolicy:
+    Condition: CreateSingleBucket
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref rCentralBucket
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: AllowSSLRequestsOnly
+            Action: s3:*
+            Effect: Deny
+            Resource:
+              - !Sub arn:aws:s3:::${rCentralBucket}/*
+              - !Sub arn:aws:s3:::${rCentralBucket}
+            Condition:
+              Bool:
+                'aws:SecureTransport': 'False'
+            Principal: "*"
 
   rCentralBucketLakeFormationS3Registration:
     Type: AWS::LakeFormation::Resource
@@ -110,6 +147,25 @@ Resources:
           - Event: s3:ObjectRemoved:*
             Queue: !GetAtt rQueueCatalog.Arn
 
+  rRawBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Condition: CreateMultipleBuckets
+    Properties:
+      Bucket: !Ref rRawBucket
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: AllowSSLRequestsOnly
+            Action: s3:*
+            Effect: Deny
+            Resource:
+              - !Sub arn:aws:s3:::${rRawBucket}/*
+              - !Sub arn:aws:s3:::${rRawBucket}
+            Condition:
+              Bool:
+                'aws:SecureTransport': 'False'
+            Principal: "*"
+
   rRawBucketLakeFormationS3Registration:
     Type: AWS::LakeFormation::Resource
     Condition: CreateMultipleBuckets
@@ -143,6 +199,25 @@ Resources:
             Queue: !GetAtt rQueueCatalog.Arn
           - Event: s3:ObjectRemoved:*
             Queue: !GetAtt rQueueCatalog.Arn
+
+  rStageBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Condition: CreateMultipleBuckets
+    Properties:
+      Bucket: !Ref rStageBucket
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: AllowSSLRequestsOnly
+            Action: s3:*
+            Effect: Deny
+            Resource:
+              - !Sub arn:aws:s3:::${rStageBucket}/*
+              - !Sub arn:aws:s3:::${rStageBucket}
+            Condition:
+              Bool:
+                'aws:SecureTransport': 'False'
+            Principal: "*"
 
   rStageBucketLakeFormationS3Registration:
     Type: AWS::LakeFormation::Resource
@@ -178,6 +253,25 @@ Resources:
           - Event: s3:ObjectRemoved:*
             Queue: !GetAtt rQueueCatalog.Arn
 
+  rAnalyticsBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Condition: CreateMultipleBuckets
+    Properties:
+      Bucket: !Ref rAnalyticsBucket
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: AllowSSLRequestsOnly
+            Action: s3:*
+            Effect: Deny
+            Resource:
+              - !Sub arn:aws:s3:::${rAnalyticsBucket}/*
+              - !Sub arn:aws:s3:::${rAnalyticsBucket}
+            Condition:
+              Bool:
+                'aws:SecureTransport': 'False'
+            Principal: "*"
+
   rAnalyticsBucketLakeFormationS3Registration:
     Type: AWS::LakeFormation::Resource
     Condition: CreateMultipleBuckets
@@ -204,6 +298,24 @@ Resources:
         IgnorePublicAcls: True
         RestrictPublicBuckets: True
 
+  rDataQualityBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref rDataQualityBucket
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: AllowSSLRequestsOnly
+            Action: s3:*
+            Effect: Deny
+            Resource:
+              - !Sub arn:aws:s3:::${rDataQualityBucket}/*
+              - !Sub arn:aws:s3:::${rDataQualityBucket}
+            Condition:
+              Bool:
+                'aws:SecureTransport': 'False'
+            Principal: "*"
+
   rDataQualityBucketLakeFormationS3Registration:
     Type: AWS::LakeFormation::Resource
     Properties:
@@ -228,6 +340,24 @@ Resources:
         BlockPublicPolicy: True
         IgnorePublicAcls: True
         RestrictPublicBuckets: True
+
+  rAthenaBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref rAthenaBucket
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Sid: AllowSSLRequestsOnly
+            Action: s3:*
+            Effect: Deny
+            Resource:
+              - !Sub arn:aws:s3:::${rAthenaBucket}/*
+              - !Sub arn:aws:s3:::${rAthenaBucket}
+            Condition:
+              Bool:
+                'aws:SecureTransport': 'False'
+            Principal: "*"
 
   ######## Lambda & SQS #########
   rQueueCatalog:

--- a/sdlf-foundations/nested-stacks/template-s3.yaml
+++ b/sdlf-foundations/nested-stacks/template-s3.yaml
@@ -63,7 +63,7 @@ Resources:
               - !Sub arn:aws:s3:::${rPipelineBucket}
             Condition:
               Bool:
-                'aws:SecureTransport': 'False'
+                aws:SecureTransport: False
             Principal: "*"
 
   # To Enforce KMS encryption: https://aws.amazon.com/premiumsupport/knowledge-center/s3-bucket-store-kms-encrypted-objects/
@@ -110,7 +110,7 @@ Resources:
               - !Sub arn:aws:s3:::${rCentralBucket}
             Condition:
               Bool:
-                'aws:SecureTransport': 'False'
+                aws:SecureTransport: False
             Principal: "*"
 
   rCentralBucketLakeFormationS3Registration:
@@ -163,7 +163,7 @@ Resources:
               - !Sub arn:aws:s3:::${rRawBucket}
             Condition:
               Bool:
-                'aws:SecureTransport': 'False'
+                aws:SecureTransport: False
             Principal: "*"
 
   rRawBucketLakeFormationS3Registration:
@@ -216,7 +216,7 @@ Resources:
               - !Sub arn:aws:s3:::${rStageBucket}
             Condition:
               Bool:
-                'aws:SecureTransport': 'False'
+                aws:SecureTransport: False
             Principal: "*"
 
   rStageBucketLakeFormationS3Registration:
@@ -269,7 +269,7 @@ Resources:
               - !Sub arn:aws:s3:::${rAnalyticsBucket}
             Condition:
               Bool:
-                'aws:SecureTransport': 'False'
+                aws:SecureTransport: False
             Principal: "*"
 
   rAnalyticsBucketLakeFormationS3Registration:
@@ -313,7 +313,7 @@ Resources:
               - !Sub arn:aws:s3:::${rDataQualityBucket}
             Condition:
               Bool:
-                'aws:SecureTransport': 'False'
+                aws:SecureTransport: False
             Principal: "*"
 
   rDataQualityBucketLakeFormationS3Registration:
@@ -356,7 +356,7 @@ Resources:
               - !Sub arn:aws:s3:::${rAthenaBucket}
             Condition:
               Bool:
-                'aws:SecureTransport': 'False'
+                aws:SecureTransport: False
             Principal: "*"
 
   ######## Lambda & SQS #########


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
SECURITY FEATURE: Added bucket policies to enforce s3 in transit encryption (HTTPS only)

"By default, Amazon S3 allows both HTTP and HTTPS requests"
( https://aws.amazon.com/premiumsupport/knowledge-center/s3-bucket-policy-for-config-rule/ )

Bucket whose policies were added or modified:

aws-serverless-data-lake-framework/sdlf-cicd/template-cicd-child-foundations.yaml:
1.a. - rArtifactsBucket. (modified)
aws-serverless-data-lake-framework/sdlf-foundations/nested-stacks/template-cloudtrail.yaml:
2.a. - rTrailBucket (modified)
aws-serverless-data-lake-framework/sdlf-foundations/nested-stacks/template-s3.yaml:
3.a. - rPipelineBucket (new)
3.b. - rCentralBucket (new)
3.c. - rRawBucket (new)
3.d. - rStageBucket (new)
3.e. - rAnalyticsBucket (new)
3.f. - rDataQualityBucket(new)
3.g. - rAthenaBucket. (new)

Note: Edited CFN to fit current code style

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
