### PR TITLE
Update catalog lambda to handle S3 multipart upload events

### DIFF
--- a/sdlf-foundations/lambda/catalog/src/lambda_function.py
+++ b/sdlf-foundations/lambda/catalog/src/lambda_function.py
@@ -57,7 +57,9 @@ def lambda_handler(event, context):
         logger.info('Received {} messages'.format(len(event['Records'])))
         for record in event['Records']:
             logger.info('Parsing S3 Event')
-            message = json.loads(record['body'])['Records'][0]
+            # Handling S3 Multipart Upload
+            message = json.loads(record['body'])['Records'][0] \
+                if 'eventName' not in event else record
             operation = message['eventName'].split(':')[-1]
 
             logger.info(f"Performing Dynamo {operation} operation")


### PR DESCRIPTION
Previously, this lambda failed because it was able to handle only regular s3 events. For large files that require multipart upload, a different s3 event is generated and this lambda was unable to handle it. Now it is fixed.

*Issue #, if available:*

*Description of changes:* The new block code checks if there is present a json key called "eventName". If it is present, it means that is a multipart upload and all information is at root event level. Otherwise, it is a regular s3 event and it required to extract information from "record['body']" key.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
