### PR TITLE
Add alias option for target e-mail

### DIFF
--- a/sdlf-foundations/nested-stacks/template-kibana.yaml
+++ b/sdlf-foundations/nested-stacks/template-kibana.yaml
@@ -18,13 +18,13 @@ Parameters:
   # Email address for the Elasticsearch domain admin
   DomainAdminEmail:
     Type: String
-    AllowedPattern: '^\w+([\.-]?\w+)*@\w+([\.-]?\w+)*(\.\w{2,3})+$'
+    AllowedPattern: '^\w+([\+\.-]?\w+)*@\w+([\.-]?\w+)*(\.\w{2,3})+$'
     Description: E-mail address of the Elasticsearch admin
 
   # Email address for Cognito Admin user
   CognitoAdminEmail:
     Type: String
-    AllowedPattern: '^\w+([\.-]?\w+)*@\w+([\.-]?\w+)*(\.\w{2,3})+$'
+    AllowedPattern: '^\w+([\+\.-]?\w+)*@\w+([\.-]?\w+)*(\.\w{2,3})+$'
     Description: E-mail address of the Cognito admin
 
   # ES cluster size


### PR DESCRIPTION
Add option to set target e-mail for notification as an alias.

"To" e-mail with alias described in here: https://forums.aws.amazon.com/thread.jspa?threadID=85882

*Issue #, if available:*
Not Available

*Description of changes:*
Add into e-mail regex validation option of "+" character into first part e-mail structure


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
