### PR TITLE
Correct typo of Glue Job's name

### DIFF
--- a/sdlf-utils/ingestion-examples/cdc/dms-task/template.yaml
+++ b/sdlf-utils/ingestion-examples/cdc/dms-task/template.yaml
@@ -200,7 +200,7 @@ Resources:
   rGlueJobLoadInitial:
     Type: AWS::Glue::Job
     Properties:
-      Name: !Sub ${pOrg}-${pApp}-${pEnvironment}-${pTeamName}-${pDatasetName}-dms-cdc-dms-cdc-load-initial
+      Name: !Sub ${pOrg}-${pApp}-${pEnvironment}-${pTeamName}-${pDatasetName}-dms-cdc-load-initial
       Role: !Sub "{{resolve:ssm:/SDLF/IAM/${pTeamName}/DMSExecutionRoleArn:1}}"
       ExecutionProperty:
         MaxConcurrentRuns: 20
@@ -218,7 +218,7 @@ Resources:
   rGlueJobController:
     Type: AWS::Glue::Job
     Properties:
-      Name: !Sub ${pOrg}-${pApp}-${pEnvironment}-${pTeamName}-${pDatasetName}-dms-cdc-dms-cdc-controller
+      Name: !Sub ${pOrg}-${pApp}-${pEnvironment}-${pTeamName}-${pDatasetName}-dms-cdc-controller
       Role: !Sub "{{resolve:ssm:/SDLF/IAM/${pTeamName}/DMSExecutionRoleArn:1}}"
       ExecutionProperty:
         MaxConcurrentRuns: 1


### PR DESCRIPTION
Resources "rGlueJobLoadIncremental" and "rGlueJobController" had a, what appeared to be, typos of their names. 
Both of them had duplicate "-dms-cdc" sections in their names.

*Issue #, if available:*
LogGroup from "altb-datalake-dev-intsys-dms-cdc-init-controller" Lambda Function thowing EntityNotFoundException.

*Description of changes:*
Change names for "rGlueJobLoadInitial" and "rGlueJobController"

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
