### PR TITLE
Adding deploy mode for datasets

### DIFF
--- a/sdlf-utils/pipeline-examples/alternative-sdlf-dataset/README.md
+++ b/sdlf-utils/pipeline-examples/alternative-sdlf-dataset/README.md
@@ -1,0 +1,79 @@
+# README 
+This repository contains the code that enables the deployment of a new dataset.
+This is an alternative to the main sdlf-dataset repository, that enables you to maintain the history of the deployed datasets, in a single folder.
+Using this repo instead of the original one you will have only one `parameters` folder, and will create there as much parameters as datasets you have. Instead of having a folder per environment.
+
+- To be able to use this approach as initial setup you only need replace the entire content of the main repository `sdlf-dataset` with all the content in the preset folder `alternative-sdlf-dataset`, and use it as explained in the main documentation.
+
+- To be able to deploy in different environments (dev, test, prod), you should ensure you are pushing your changes to the corresponding branch (dev. test, master).
+
+## Motivation
+Usually you need to deploy not a single dataset but many, so to have a single parameters-$ENV.json file per environment forces you to change the json descriptor each time you need to deploy a new dataset, losing the Jsons that were used to deploy the above datasets.
+In the day to day work with the framework, it is common the need to re-deploy the same dataset several times, after a minor change, specially in the dev environment, and rewrite the Json descriptor file each time is not an optimal way to do that.
+Instead of having a single json, we propose to have a folder with one Json file per dataset.
+That way the template creates the necessary resources for each dataset from the parameters defined in a parameters/parameters-$DATASET.json file in the parameters folder, the dataset will be deployed only if it has changed since the last commit, that way we have in the parameters folder the history of all the deployed datasets.
+The resources will be created depending on the branch (dev, test, master) in the corresponding environment/account (dev,test,prod), so no specific environment is necessary in the parameters file name itself.
+
+
+## Prerequisites
+Before attempting to deploy a dataset, ensure that both the **FOUNDATIONS** and **PIPELINE** infrastructure has completed its provisioning, and has been successfully deployed. They contain infrastructure resources that the **DATASET**  stack depends on, and without them in place, the deployment of this stack will fail. These resources include:
+1. IAM roles
+2. The Glue data catalog
+3. CodeBuild jobs
+4. S3 buckets
+
+## Deploying a dataset
+
+### Parameters
+Before deploying a new dataset, ensure that the `parameters/parameters-$DATASET.json` file contains the following parameters that **DATASET** requires:
+
+1. `pTeamName` [***REQUIRED***] — Name of the team as defined in `common-team` that will be owning this dataset.
+1. `pPipelineName` [***REQUIRED***] — Name of the pipeline as defined in `common-pipeline` that will be processing this dataset.
+1. `pDatasetName` [***REQUIRED***] — Name to give the dataset being deployed. Pick a name that refers to a group of data with a common schema or datasource (e.g. telemetry, orders...). This name will be used as an S3 prefix.
+1. `pCreateDatabase` [***OPTIONAL***] — Create a database if True, it will not create if False, Creates or not a glue data catalog database for the dataset and a carwler.
+1. `pScheduleExpression` [***OPTIONAL***] — Schedule Expression to trigger the stage B stage of the example pipeline "main" i.e. cron(0 12 * * ? *)
+
+The required parameters MUST be defined in a `parameters/parameters-$DATASET.json` file. The file should look like the following:
+
+    [
+        {
+            "ParameterKey": "pTeamName",
+            "ParameterValue": "<teamName>"
+        },
+        {
+            "ParameterKey": "pPipelineName",
+            "ParameterValue": "<pipelineName>"
+        },
+        {
+            "ParameterKey": "pDatasetName",
+            "ParameterValue": "<datasetName>"
+        },
+        {
+            "ParameterKey": "pCreateDatabase",
+            "ParameterValue": "True"
+        },
+        {
+            "ParameterKey": "pScheduleExpression",
+            "ParameterValue": "cron(*/5 * * * ? *)"
+        }
+    ]
+
+A tags.json file in the same directory can also be amended to tag all resources deployed by CloudFormation.
+
+### Deployment
+To deploy a new dataset you should:
+1. Create a new `parameters/parameters-$DATASET.json` file.
+1. Commit and push it in the repo sdlf-$TEAM-dataset, in the desired branch, corresponding to the desired environment/account (dev,test,master).
+1. Wait for the code pipeline and the corresponding cloudFormation stack to complete the deployment of all the infrastructure before proceeding further.
+
+## Architecture
+
+This template creates the necessary resources for each dataset from the parameters defined in a `parameters/parameters-$DATASET.json` file in the parameters folder, the dataset in will be deployed only if it has changed since the last commit, that way we have a in the parameters folder the history of all the deployed datasets.
+The resources will be created depending on the branch (dev, test, master) in the corresponding environment/account (dev,test,prod).
+
+This template creates the following resources:
+1. SQS Queues - Hold dataset specific messages awaiting to be processed in the next stage
+   1. `QueuePostStepRouting`
+   2. `DeadLetterQueuePostStepRouting`
+2. CloudWatch Rules - Triggers the the next stage pipeline every X minutes to process the dataset messages from the queue (depending on the parameter)
+3. Glue crawler (depending on the parameter)

--- a/sdlf-utils/pipeline-examples/alternative-sdlf-dataset/README.md
+++ b/sdlf-utils/pipeline-examples/alternative-sdlf-dataset/README.md
@@ -47,14 +47,6 @@ The required parameters MUST be defined in a `parameters/parameters-$DATASET.jso
         {
             "ParameterKey": "pDatasetName",
             "ParameterValue": "<datasetName>"
-        },
-        {
-            "ParameterKey": "pCreateDatabase",
-            "ParameterValue": "True"
-        },
-        {
-            "ParameterKey": "pScheduleExpression",
-            "ParameterValue": "cron(*/5 * * * ? *)"
         }
     ]
 

--- a/sdlf-utils/pipeline-examples/alternative-sdlf-dataset/deploy.sh
+++ b/sdlf-utils/pipeline-examples/alternative-sdlf-dataset/deploy.sh
@@ -1,0 +1,168 @@
+#!/bin/bash
+sflag=false
+nflag=false
+pflag=false
+
+DIRNAME=$(dirname "$0")
+
+usage () { echo "
+    -h -- Opens up this help message
+    -n -- Name of the Dataset name
+    -p -- Name of the AWS profile to use
+    -s -- Name of S3 bucket to upload artifacts to
+"; }
+options=':n:p:s:h'
+while getopts $options option
+do
+    case "$option" in
+        n  ) nflag=true; STACK_NAME=$OPTARG;;
+        p  ) pflag=true; PROFILE=$OPTARG;;
+        s  ) sflag=true; S3_BUCKET=$OPTARG;;
+        h  ) usage; exit;;
+        \? ) echo "Unknown option: -$OPTARG" >&2; exit 1;;
+        :  ) echo "Missing option argument for -$OPTARG" >&2; exit 1;;
+        *  ) echo "Unimplemented option: -$OPTARG" >&2; exit 1;;
+    esac
+done
+
+if ! $pflag
+then
+    echo "-p not specified, using default..." >&2
+    PROFILE="default"
+fi
+ACCOUNT_ID=$(sed -e 's/^"//' -e 's/"$//' <<<"$(aws ssm get-parameter --name /SDLF/Misc/DevOpsAccountId --profile $PROFILE --query "Parameter.Value")")
+ENV=$(sed -e 's/^"//' -e 's/"$//' <<<"$(aws ssm get-parameter --name /SDLF/Misc/pEnv --profile $PROFILE --query "Parameter.Value")")
+
+# Devops role for cicd
+aws sts assume-role --role-arn "arn:aws:iam::$ACCOUNT_ID:role/sdlf-cicd-team-codecommit-$ENV-engineering" \
+  --role-session-name codecommit_access | jq -r .Credentials > tmp_credentials.json
+
+export AWS_ACCESS_KEY_ID="$(jq -r '.AccessKeyId' tmp_credentials.json)"
+export AWS_SECRET_ACCESS_KEY="$(jq -r '.SecretAccessKey' tmp_credentials.json)"
+export AWS_SESSION_TOKEN="$(jq -r '.SessionToken' tmp_credentials.json)"
+
+PREV_COMMIT=$(aws codecommit get-commit \
+  --repository-name sdlf-engineering-dataset \
+  --commit-id "${CODEBUILD_RESOLVED_SOURCE_VERSION}" | jq -r '.commit.parents[]' | head -n 1)
+
+aws codecommit get-differences --repository-name sdlf-engineering-dataset \
+  --after-commit-specifier "${CODEBUILD_RESOLVED_SOURCE_VERSION}" \
+  --before-commit-specifier "${PREV_COMMIT}" > git_all_changed_files.txt
+
+jq -r '.differences[].afterBlob.path' git_all_changed_files.txt | sort | uniq | grep ".json$" > changed_json_files.txt || echo "No .json file changes detected."
+# Unset credentials, we are done with these keys.
+unset AWS_ACCESS_KEY_ID
+unset AWS_SECRET_ACCESS_KEY
+unset AWS_SESSION_TOKEN
+
+printf 'Following are changed files after commit:\t%s\n' "$(cat changed_json_files.txt)"
+
+grep 'parameter' < changed_json_files.txt | while IFS= read -r parameter_file
+do
+  TEAM_NAME=$(sed -e 's/^"//' -e 's/"$//' <<<"$(jq '.[] | select(.ParameterKey=="pTeamName") | .ParameterValue' $parameter_file)")
+  PIPELINE_NAME=$(sed -e 's/^"//' -e 's/"$//' <<<"$(jq '.[] | select(.ParameterKey=="pPipelineName") | .ParameterValue' $parameter_file)")
+  DATASET_NAME=$(sed -e 's/^"//' -e 's/"$//' <<<"$(jq '.[] | select(.ParameterKey=="pDatasetName") | .ParameterValue' $parameter_file)")
+  if ! $sflag
+  then
+      S3_BUCKET=$(sed -e 's/^"//' -e 's/"$//' <<<"$(aws ssm get-parameter --name /SDLF/S3/CFNBucket --profile $PROFILE --query "Parameter.Value")")
+  fi
+  if ! $nflag
+  then
+      if [ $DATASET_NAME == $PIPELINE_NAME ]; then
+        echo "Dataset and pipeline cannot hold the same name. Deploy aborted."
+        echo $PIPELINE_NAME
+        echo $DATASET_NAME
+        exit 1
+      else
+        STACK_NAME="sdlf-$TEAM_NAME-$DATASET_NAME"
+      fi
+  fi
+
+  echo "Checking if bucket exists ..."
+  if ! aws s3 ls $S3_BUCKET --profile $PROFILE; then
+    echo "S3 bucket named $S3_BUCKET does not exist. Create? [Y/N]"
+    read choice
+    if [ $choice == "Y" ] || [ $choice == "y" ]; then
+      aws s3 mb s3://$S3_BUCKET --profile $PROFILE
+    else
+      echo "Bucket does not exist. Deploy aborted."
+      exit 1
+    fi
+  fi
+
+  mkdir -p $DIRNAME/output
+  aws cloudformation package --profile $PROFILE --template-file $DIRNAME/template.yaml --s3-bucket $S3_BUCKET --s3-prefix $TEAM_NAME/dataset/$DATASET_NAME --output-template-file $DIRNAME/output/packaged-template.yaml
+
+  echo "Checking if stack exists ..."
+  if ! aws cloudformation describe-stacks --profile $PROFILE --stack-name $STACK_NAME; then
+    echo -e "Stack does not exist, creating ..."
+    aws cloudformation create-stack \
+      --stack-name $STACK_NAME \
+      --parameters file://$parameter_file \
+      --template-body file://$DIRNAME/output/packaged-template.yaml \
+      --tags file://$DIRNAME/tags.json \
+      --capabilities "CAPABILITY_NAMED_IAM" "CAPABILITY_AUTO_EXPAND" \
+      --profile $PROFILE
+
+    echo "Waiting for stack to be created ..."
+    aws cloudformation wait stack-create-complete --profile $PROFILE \
+      --stack-name $STACK_NAME
+
+    echo "Creating octagon-Datasets-$ENV DynamoDB entry"
+    DATASET_JSON=$( jq -n \
+                  --arg dn "$TEAM_NAME-$DATASET_NAME" \
+                  --arg pn "$PIPELINE_NAME" \
+                  '{"name": {"S": $dn}, "pipeline": {"S": $pn}, "transforms": { "M": {"stage_a_transform": {"S": "light_transform_blueprint"}, "stage_b_transform": {"S": "heavy_transform_blueprint"}}}, "max_items_process": { "M": {"stage_b": {"N": "100"}, "stage_c": {"N": "100"}}}, "min_items_process": { "M": {"stage_b": {"N": "1"}, "stage_c": {"N": "1"}}}, "version": {"N": "1"}}' )
+    aws dynamodb put-item --profile $PROFILE \
+      --table-name octagon-Datasets-$ENV \
+      --item "$DATASET_JSON"
+    echo "$TEAM_NAME-$DATASET_NAME DynamoDB Dataset entry created"
+  else
+    echo -e "Stack exists, attempting update ..."
+
+    set +e
+    update_output=$(aws cloudformation update-stack \
+      --profile $PROFILE \
+      --stack-name $STACK_NAME \
+      --parameters file://$parameter_file \
+      --template-body file://$DIRNAME/output/packaged-template.yaml \
+      --tags file://$DIRNAME/tags.json \
+      --capabilities "CAPABILITY_NAMED_IAM" "CAPABILITY_AUTO_EXPAND" 2>&1)
+    status=$?
+    set -e
+
+    echo "$update_output"
+
+    if [ $status -ne 0 ] ; then
+      # Don't fail for no-op update
+      if [[ $update_output == *"ValidationError"* && $update_output == *"No updates"* ]] ; then
+        echo -e "\nFinished create/update - no updates to be performed";
+        exit 0;
+      else
+        exit $status
+      fi
+    fi
+
+    echo "Waiting for stack update to complete ..."
+    aws cloudformation wait stack-update-complete --profile $PROFILE \
+      --stack-name $STACK_NAME
+    echo "Finished create/update successfully!"
+
+    echo "Updating octagon-Datasets-$ENV DynamoDB entry"
+    KEYS_JSON=$( jq -n \
+                    --arg dn "$TEAM_NAME-$DATASET_NAME" \
+                    '{"name": {"S": $dn}}' )
+    ATTRIBUTES_JSON='{"#N": "name", "#P": "pipeline"}'
+    VALUES_JSON=$( jq -n \
+                      --arg pn "$PIPELINE_NAME" \
+                      '{":p": {"S": $pn}}' )
+    aws dynamodb update-item --profile $PROFILE \
+        --table-name octagon-Datasets-$ENV \
+        --key "$KEYS_JSON" \
+        --update-expression "SET #P = :p" \
+        --expression-attribute-names "$ATTRIBUTES_JSON" \
+        --expression-attribute-values "$VALUES_JSON" \
+        --condition-expression "attribute_exists(#N)"
+    echo "$TEAM_NAME-$DATASET_NAME DynamoDB Dataset entry updated"
+  fi
+done

--- a/sdlf-utils/pipeline-examples/alternative-sdlf-dataset/parameters/parameters-legislators.json
+++ b/sdlf-utils/pipeline-examples/alternative-sdlf-dataset/parameters/parameters-legislators.json
@@ -1,0 +1,14 @@
+[
+    {
+        "ParameterKey": "pTeamName",
+        "ParameterValue": "engineering"
+    },
+    {
+        "ParameterKey": "pPipelineName",
+        "ParameterValue": "main"
+    },
+    {
+        "ParameterKey": "pDatasetName",
+        "ParameterValue": "legislators"
+    }
+]

--- a/sdlf-utils/pipeline-examples/alternative-sdlf-dataset/tags.json
+++ b/sdlf-utils/pipeline-examples/alternative-sdlf-dataset/tags.json
@@ -1,0 +1,6 @@
+[
+  {
+    "Key": "Framework",
+    "Value": "sdlf"
+  }
+]

--- a/sdlf-utils/pipeline-examples/alternative-sdlf-dataset/template.yaml
+++ b/sdlf-utils/pipeline-examples/alternative-sdlf-dataset/template.yaml
@@ -1,0 +1,175 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: Contains all the resources necessary for a single dataset
+
+Parameters:
+  pAnalyticsBucket:
+    Description: The analytics bucket for the solution
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: /SDLF/S3/AnalyticsBucket
+  pApp:
+    Description: Name of the application
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: /SDLF/Misc/pApp
+  pCentralBucket:
+    Description: The central bucket for the solution
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: /SDLF/S3/CentralBucket
+  pDatasetName:
+    Description: The name of the dataset (all lowercase, no symbols or spaces)
+    Type: String
+    AllowedPattern: "[a-z0-9]{2,14}"
+  pEnvironment:
+    Description: Environment name
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: /SDLF/Misc/pEnv
+  pOrg:
+    Description: Name of the organization owning the datalake
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: /SDLF/Misc/pOrg
+  pPipelineBucket:
+    Description: The artifactory bucket used by CodeBuild and CodePipeline
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: /SDLF/S3/ArtifactsBucket
+  pPipelineName:
+    Description: The name of the pipeline (all lowercase, no symbols or spaces)
+    Type: String
+    AllowedPattern: "[a-z0-9]*"
+  pStageBucket:
+    Description: The stage bucket for the solution
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: /SDLF/S3/StageBucket
+  pTeamName:
+    Description: Name of the team owning the pipeline (all lowercase, no symbols or spaces)
+    Type: String
+    AllowedPattern: "[a-z0-9]*"
+  pCreateDatabase:
+    Description: Create a database if True, it will not create if False
+    Type: String
+    Default: "True"
+    AllowedValues:
+      - "True"
+      - "False"
+  pScheduleExpression:
+    Description: Schedule Expression i.e. cron(0 12 * * ? *)
+    Type: String
+    Default: "cron(0 12 * * ? *)"
+  pScheduleExpressionState:
+    Description: Schedule Expression will run if ENABLED
+    Type: String
+    Default: "ENABLED"
+
+Conditions:
+  CreateDatabase: !Equals [ !Ref pCreateDatabase, "True" ]
+
+Resources:
+  ######## SQS #########
+  rQueueRoutingPostStep:
+    Type: AWS::SQS::Queue
+    Properties:
+      QueueName: !Sub sdlf-${pTeamName}-${pDatasetName}-queue-b.fifo
+      FifoQueue: True
+      RedrivePolicy:
+        deadLetterTargetArn: !GetAtt rDeadLetterQueueRoutingPostStep.Arn
+        maxReceiveCount: 1
+      VisibilityTimeout: 60
+      KmsMasterKeyId: !Sub "{{resolve:ssm:/SDLF/KMS/${pTeamName}/InfraKeyId:1}}"
+
+  rDeadLetterQueueRoutingPostStep:
+    Type: AWS::SQS::Queue
+    Properties:
+      QueueName: !Sub sdlf-${pTeamName}-${pDatasetName}-dlq-b.fifo
+      FifoQueue: True
+      MessageRetentionPeriod: 1209600
+      VisibilityTimeout: 60
+      KmsMasterKeyId: !Sub "{{resolve:ssm:/SDLF/KMS/${pTeamName}/InfraKeyId:1}}"
+
+  ######## TRIGGERS #########
+  rPostStateRule:
+    Type: AWS::Events::Rule
+    Properties:
+      Name: !Sub sdlf-${pTeamName}-${pDatasetName}-rule-b
+      Description: Trigger StageB Routing Lambda depending on the dataset Schedule Expression
+      State: !Ref pScheduleExpressionState
+      ScheduleExpression: !Ref pScheduleExpression
+      Targets:
+        - Id: !Sub sdlf-${pTeamName}-${pDatasetName}-rule-b
+          Arn: !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:sdlf-${pTeamName}-${pPipelineName}-routing-b
+          Input: !Sub |
+            {
+              "team": "${pTeamName}",
+              "pipeline": "${pPipelineName}",
+              "pipeline_stage": "StageB",
+              "dataset": "${pDatasetName}",
+              "org": "${pOrg}",
+              "app": "${pApp}",
+              "env": "${pEnvironment}"
+            }
+
+  rPermissionEventsInvokeRoutingLambda:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Sub sdlf-${pTeamName}-${pPipelineName}-routing-b
+      Action: lambda:InvokeFunction
+      Principal: events.amazonaws.com
+      SourceArn: !GetAtt rPostStateRule.Arn
+
+  ######## GLUE #########
+  rGlueDataCatalog:
+    Condition: CreateDatabase
+    Type: AWS::Glue::Database
+    Properties:
+      CatalogId: !Ref AWS::AccountId
+      DatabaseInput:
+        Description: !Sub "${pTeamName} team ${pDatasetName} metadata catalog"
+        Name: !Sub ${pOrg}_${pApp}_${pEnvironment}_${pTeamName}_${pDatasetName}_db
+
+  rGlueCrawler:
+    Condition: CreateDatabase
+    Type: AWS::Glue::Crawler
+    Properties:
+      Role: !Sub "{{resolve:ssm:/SDLF/IAM/${pTeamName}/CrawlerRoleArn:1}}"
+      DatabaseName: !Ref rGlueDataCatalog
+      Name: !Sub sdlf-${pTeamName}-${pDatasetName}-post-stage-crawler
+      Targets:
+        S3Targets:
+          - Path: !Sub s3://${pStageBucket}/post-stage/${pTeamName}/${pDatasetName}
+
+  rGlueCrawlerLakeFormationPermissions:
+    Condition: CreateDatabase
+    Type: AWS::LakeFormation::Permissions
+    Properties:
+      DataLakePrincipal:
+        DataLakePrincipalIdentifier: !Sub "{{resolve:ssm:/SDLF/IAM/${pTeamName}/CrawlerRoleArn:1}}"
+      Permissions:
+        - CREATE_TABLE
+        - ALTER
+        - DROP
+      Resource:
+        DatabaseResource:
+          Name: !Ref rGlueDataCatalog
+
+  ######## SSM #########
+  rQueueRoutingPostStepSsm:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub /SDLF/SQS/${pTeamName}/${pDatasetName}StageBQueue
+      Type: String
+      Value: !GetAtt rQueueRoutingPostStep.QueueName
+      Description: !Sub "Name of the StageB ${pTeamName} ${pDatasetName} Queue"
+
+  rDeadLetterQueueRoutingPostStepSsm:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub /SDLF/SQS/${pTeamName}/${pDatasetName}StageBDLQ
+      Type: String
+      Value: !GetAtt rDeadLetterQueueRoutingPostStep.QueueName
+      Description: !Sub "Name of the StageB ${pTeamName} ${pDatasetName} DLQ"
+
+  rGlueDataCatalogSsm:
+    Condition: CreateDatabase
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub /SDLF/Glue/${pTeamName}/${pDatasetName}/DataCatalog
+      Type: String
+      Value: !Ref rGlueDataCatalog
+      Description: !Sub "${pTeamName} team ${pDatasetName} metadata catalog"


### PR DESCRIPTION
Issue #, if available:

Description of changes:

Usually you need to deploy not a single dataset but many, so to have a single parameters-$ENV.json file per environment forces you to change the json descriptor each time you need to deploy a new dataset, losing the Jsons that were used to deploy the above datasets.

In the day to day work with the framework, it is common the need to re-deploy the same dataset several times, after a minor change, specially in the dev environment, and rewrite the Json descriptor file each time is not an optimal way to do that.

Instead of having a single json, the present alternative propose to have a folder with one Json file per dataset.

That way the template creates the necessary resources for each dataset from the parameters defined in a parameters/parameters-$DATASET.json file in the parameters folder, the dataset will be deployed only if it has changed since the last commit, that way we have in the parameters folder the history of all the deployed datasets.

The resources will be created depending on the branch (dev, test, master) in the corresponding environment/account (dev,test,prod), so no specific environment is necessary in the parameters file name itself.