### PR TITLE
Enable NodeToNodeEncryptionOptions (CFN_Nag W85)

### DIFF
--- a/sdlf-foundations/nested-stacks/template-kibana.yaml
+++ b/sdlf-foundations/nested-stacks/template-kibana.yaml
@@ -733,6 +733,8 @@ Resources:
         DedicatedMasterCount: 3
       SnapshotOptions:
         AutomatedSnapshotStartHour: 1
+      NodeToNodeEncryptionOptions:
+        Enabled: true
       AccessPolicies:
         Version: 2012-10-17
         Statement:


### PR DESCRIPTION
W85 ElasticsearchcDomain should have NodeToNodeEncryptionOptions enabled

*Issue #, if available:*

*Description of changes:*
Enables node to node enryption

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
