### PR TITLE
Lambda cloudwatch log encryption retention

### DIFF
--- a/sdlf-foundations/nested-stacks/template-glue.yaml
+++ b/sdlf-foundations/nested-stacks/template-glue.yaml
@@ -168,6 +168,7 @@ Resources:
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaStep1}
       RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
+      KmsKeyId: !Ref pKMSKeyId
 
   rLambdaJobCheckStep:
     Type: AWS::Serverless::Function
@@ -184,6 +185,7 @@ Resources:
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaJobCheckStep}
       RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
+      KmsKeyId: !Ref pKMSKeyId
 
   rLambdaStep2:
     Type: AWS::Serverless::Function
@@ -200,6 +202,7 @@ Resources:
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaStep2}
       RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
+      KmsKeyId: !Ref pKMSKeyId
 
   rLambdaReplicate:
     Type: AWS::Serverless::Function
@@ -219,6 +222,7 @@ Resources:
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaReplicate}
       RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
+      KmsKeyId: !Ref pKMSKeyId
 
   rEventsInvokeLambdaPermission:
     Type: AWS::Lambda::Permission

--- a/sdlf-foundations/nested-stacks/template-glue.yaml
+++ b/sdlf-foundations/nested-stacks/template-glue.yaml
@@ -17,6 +17,8 @@ Parameters:
     Type: String
   pPipelineBucket:
     Type: String
+  pCloudWatchLogsRetentionInDays:
+    Type: Number
 
 Globals:
   Function:
@@ -165,6 +167,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaStep1}
+      RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
 
   rLambdaJobCheckStep:
     Type: AWS::Serverless::Function
@@ -180,6 +183,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaJobCheckStep}
+      RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
 
   rLambdaStep2:
     Type: AWS::Serverless::Function
@@ -195,6 +199,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaStep2}
+      RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
 
   rLambdaReplicate:
     Type: AWS::Serverless::Function
@@ -213,6 +218,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaReplicate}
+      RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
 
   rEventsInvokeLambdaPermission:
     Type: AWS::Lambda::Permission

--- a/sdlf-foundations/nested-stacks/template-glue.yaml
+++ b/sdlf-foundations/nested-stacks/template-glue.yaml
@@ -155,7 +155,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       CodeUri: ../lambda/initial-check/src
-      FunctionName: !Sub sdlf-data-quality-initial-check
+      FunctionName: sdlf-data-quality-initial-check
       Description: Performs checks and determines which Data Quality job to run
       MemorySize: 256
       Timeout: 300
@@ -170,7 +170,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       CodeUri: ../lambda/check-job/src
-      FunctionName: !Sub sdlf-data-quality-check-job
+      FunctionName: sdlf-data-quality-check-job
       Description: Checks if job has finished (success/failure)
       MemorySize: 256
       Timeout: 300
@@ -185,7 +185,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       CodeUri: ../lambda/crawl-data/src
-      FunctionName: !Sub sdlf-data-quality-crawl-data
+      FunctionName: sdlf-data-quality-crawl-data
       Description: Glue crawler
       MemorySize: 256
       Timeout: 120

--- a/sdlf-foundations/nested-stacks/template-s3.yaml
+++ b/sdlf-foundations/nested-stacks/template-s3.yaml
@@ -15,6 +15,8 @@ Parameters:
     Type: String
   pOrganizationName:
     Type: String
+  pCloudWatchLogsRetentionInDays:
+    Type: Number
 
 Conditions:
   CreateMultipleBuckets: !Equals [!Ref pNumBuckets, "3"]
@@ -448,6 +450,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaRouting}
+      RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
 
   rLambdaCatalogRedrive:
     Type: AWS::Serverless::Function
@@ -467,6 +470,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaCatalogRedrive}
+      RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
 
   rLambdaRoutingRedrive:
     Type: AWS::Serverless::Function
@@ -485,6 +489,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaRoutingRedrive}
+      RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
 
   rQueueCatalogPolicy:
     Type: AWS::SQS::QueuePolicy

--- a/sdlf-foundations/nested-stacks/template-s3.yaml
+++ b/sdlf-foundations/nested-stacks/template-s3.yaml
@@ -451,6 +451,7 @@ Resources:
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaRouting}
       RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
+      KmsKeyId: !Ref pKMSKeyId
 
   rLambdaCatalogRedrive:
     Type: AWS::Serverless::Function
@@ -471,6 +472,7 @@ Resources:
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaCatalogRedrive}
       RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
+      KmsKeyId: !Ref pKMSKeyId
 
   rLambdaRoutingRedrive:
     Type: AWS::Serverless::Function
@@ -490,6 +492,7 @@ Resources:
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaRoutingRedrive}
       RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
+      KmsKeyId: !Ref pKMSKeyId
 
   rQueueCatalogPolicy:
     Type: AWS::SQS::QueuePolicy

--- a/sdlf-foundations/template.yaml
+++ b/sdlf-foundations/template.yaml
@@ -51,6 +51,30 @@ Parameters:
     Description: Email address for SNS notifications
     Type: String
     Default: nobody@amazon.com
+  pCloudWatchLogsRetentionInDays:
+    Description: The number of days log events are kept in CloudWatch Logs
+    Type: Number
+    Default: 30
+    AllowedValues:
+      [
+        1,
+        3,
+        5,
+        7,
+        14,
+        30,
+        60,
+        90,
+        120,
+        150,
+        180,
+        365,
+        400,
+        545,
+        731,
+        1827,
+        3653,
+      ]
 
 Conditions:
   DeployCloudTrail: !Equals [!Ref pCloudTrailEnabled, "true"]
@@ -78,6 +102,7 @@ Resources:
         pKMSKeyId: !GetAtt [rKMSStack, Outputs.oKMSKeyId]
         pNumBuckets: !Ref pNumBuckets
         pOrganizationName: !Ref pOrganizationName
+        pCloudWatchLogsRetentionInDays: !Ref pCloudWatchLogsRetentionInDays
       Tags:
         - Key: tagging-policy
           Value: !Sub ${pOrganizationName}-${pApplicationName}-${pEnvironment}-foundations
@@ -142,6 +167,7 @@ Resources:
         pKMSKeyId: !GetAtt [rKMSStack, Outputs.oKMSKeyId]
         pOrganizationName: !Ref pOrganizationName
         pPipelineBucket: !GetAtt [rS3Stack, Outputs.oPipelineBucket]
+        pCloudWatchLogsRetentionInDays: !Ref pCloudWatchLogsRetentionInDays
       Tags:
         - Key: tagging-policy
           Value: !Sub ${pOrganizationName}-${pApplicationName}-${pEnvironment}-foundations

--- a/sdlf-stageA/template.yaml
+++ b/sdlf-stageA/template.yaml
@@ -67,6 +67,30 @@ Parameters:
   pSNSTopic:
     Description: The team SNS topic
     Type: String
+  pCloudWatchLogsRetentionInDays:
+    Description: The number of days log events are kept in CloudWatch Logs
+    Type: Number
+    Default: 30
+    AllowedValues:
+      [
+        1,
+        3,
+        5,
+        7,
+        14,
+        30,
+        60,
+        90,
+        120,
+        150,
+        180,
+        365,
+        400,
+        545,
+        731,
+        1827,
+        3653,
+      ]
 
 Conditions:
   DeployElasticSearch: !Equals [!Ref pElasticSearchEnabled, "true"]
@@ -437,6 +461,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaRoutingStep}
+      RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
 
   rUpdateSubscriptionFilterRoutingStep:
     Type: Custom::UpdateSubscriptionFilter
@@ -471,6 +496,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaRedriveStep}
+      RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
 
   rUpdateSubscriptionFilterRedriveStep:
     Type: Custom::UpdateSubscriptionFilter
@@ -486,6 +512,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaStep1}
+      RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
 
   rUpdateSubscriptionFilterStep1:
     Type: Custom::UpdateSubscriptionFilter
@@ -516,6 +543,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaStep3}
+      RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
 
   rUpdateSubscriptionFilterStep3:
     Type: Custom::UpdateSubscriptionFilter
@@ -531,6 +559,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaErrorStep}
+      RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
 
   rUpdateSubscriptionFilterErrorStep:
     Type: Custom::UpdateSubscriptionFilter

--- a/sdlf-stageA/template.yaml
+++ b/sdlf-stageA/template.yaml
@@ -528,6 +528,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaStep2}
+      RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
 
   rUpdateSubscriptionFilterStep2:
     Type: Custom::UpdateSubscriptionFilter

--- a/sdlf-stageA/template.yaml
+++ b/sdlf-stageA/template.yaml
@@ -462,6 +462,7 @@ Resources:
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaRoutingStep}
       RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
+      KmsKeyId: !Ref pKMSInfraKeyId
 
   rUpdateSubscriptionFilterRoutingStep:
     Type: Custom::UpdateSubscriptionFilter
@@ -497,6 +498,7 @@ Resources:
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaRedriveStep}
       RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
+      KmsKeyId: !Ref pKMSInfraKeyId
 
   rUpdateSubscriptionFilterRedriveStep:
     Type: Custom::UpdateSubscriptionFilter
@@ -513,6 +515,7 @@ Resources:
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaStep1}
       RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
+      KmsKeyId: !Ref pKMSInfraKeyId
 
   rUpdateSubscriptionFilterStep1:
     Type: Custom::UpdateSubscriptionFilter
@@ -529,6 +532,7 @@ Resources:
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaStep2}
       RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
+      KmsKeyId: !Ref pKMSInfraKeyId
 
   rUpdateSubscriptionFilterStep2:
     Type: Custom::UpdateSubscriptionFilter
@@ -545,6 +549,7 @@ Resources:
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaStep3}
       RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
+      KmsKeyId: !Ref pKMSInfraKeyId
 
   rUpdateSubscriptionFilterStep3:
     Type: Custom::UpdateSubscriptionFilter
@@ -561,6 +566,7 @@ Resources:
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaErrorStep}
       RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
+      KmsKeyId: !Ref pKMSInfraKeyId
 
   rUpdateSubscriptionFilterErrorStep:
     Type: Custom::UpdateSubscriptionFilter

--- a/sdlf-stageB/template.yaml
+++ b/sdlf-stageB/template.yaml
@@ -417,6 +417,7 @@ Resources:
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaRoutingStep}
       RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
+      KmsKeyId: !Ref pKMSInfraKeyId
 
   rUpdateSubscriptionFilterRoutingStep:
     Type: Custom::UpdateSubscriptionFilter
@@ -452,6 +453,7 @@ Resources:
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaRedriveStep}
       RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
+      KmsKeyId: !Ref pKMSInfraKeyId
 
   rUpdateSubscriptionFilterRedriveStep:
     Type: Custom::UpdateSubscriptionFilter
@@ -468,6 +470,7 @@ Resources:
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaStep1}
       RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
+      KmsKeyId: !Ref pKMSInfraKeyId
 
   rUpdateSubscriptionFilterStep1:
     Type: Custom::UpdateSubscriptionFilter
@@ -484,6 +487,7 @@ Resources:
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaJobCheckStep}
       RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
+      KmsKeyId: !Ref pKMSInfraKeyId
 
   rUpdateSubscriptionFilterJobCheckStep:
     Type: Custom::UpdateSubscriptionFilter
@@ -500,6 +504,7 @@ Resources:
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaStep2}
       RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
+      KmsKeyId: !Ref pKMSInfraKeyId
 
   rUpdateSubscriptionFilterStep2:
     Type: Custom::UpdateSubscriptionFilter
@@ -516,6 +521,7 @@ Resources:
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaStep3}
       RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
+      KmsKeyId: !Ref pKMSInfraKeyId
 
   rUpdateSubscriptionFilterStep3:
     Type: Custom::UpdateSubscriptionFilter
@@ -532,6 +538,7 @@ Resources:
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaErrorStep}
       RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
+      KmsKeyId: !Ref pKMSInfraKeyId
 
   rUpdateSubscriptionFilterErrorStep:
     Type: Custom::UpdateSubscriptionFilter

--- a/sdlf-stageB/template.yaml
+++ b/sdlf-stageB/template.yaml
@@ -67,6 +67,30 @@ Parameters:
   pSNSTopic:
     Description: The team SNS topic
     Type: String
+  pCloudWatchLogsRetentionInDays:
+    Description: The number of days log events are kept in CloudWatch Logs
+    Type: Number
+    Default: 30
+    AllowedValues:
+      [
+        1,
+        3,
+        5,
+        7,
+        14,
+        30,
+        60,
+        90,
+        120,
+        150,
+        180,
+        365,
+        400,
+        545,
+        731,
+        1827,
+        3653,
+      ]
 
 Conditions:
   DeployElasticSearch: !Equals [!Ref pElasticSearchEnabled, "true"]
@@ -392,6 +416,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaRoutingStep}
+      RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
 
   rUpdateSubscriptionFilterRoutingStep:
     Type: Custom::UpdateSubscriptionFilter
@@ -426,6 +451,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaRedriveStep}
+      RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
 
   rUpdateSubscriptionFilterRedriveStep:
     Type: Custom::UpdateSubscriptionFilter
@@ -441,6 +467,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaStep1}
+      RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
 
   rUpdateSubscriptionFilterStep1:
     Type: Custom::UpdateSubscriptionFilter
@@ -456,6 +483,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaJobCheckStep}
+      RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
 
   rUpdateSubscriptionFilterJobCheckStep:
     Type: Custom::UpdateSubscriptionFilter
@@ -471,6 +499,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaStep2}
+      RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
 
   rUpdateSubscriptionFilterStep2:
     Type: Custom::UpdateSubscriptionFilter
@@ -486,6 +515,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaStep3}
+      RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
 
   rUpdateSubscriptionFilterStep3:
     Type: Custom::UpdateSubscriptionFilter
@@ -501,6 +531,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaErrorStep}
+      RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
 
   rUpdateSubscriptionFilterErrorStep:
     Type: Custom::UpdateSubscriptionFilter

--- a/sdlf-team/nested-stacks/template-iam.yaml
+++ b/sdlf-team/nested-stacks/template-iam.yaml
@@ -405,6 +405,7 @@ Resources:
                   - logs:DeleteLogGroup
                   - logs:DescribeLogStreams
                   - logs:PutLogEvents
+                  - logs:PutRetentionPolicy
                   - logs:TagLogGroup
                 Resource:
                   - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/sdlf-${pTeamName}-*:log-stream:*

--- a/sdlf-utils/pipeline-examples/cloudfront/template.yaml
+++ b/sdlf-utils/pipeline-examples/cloudfront/template.yaml
@@ -67,6 +67,30 @@ Parameters:
   pSNSTopic:
     Description: The team SNS topic
     Type: String
+  pCloudWatchLogsRetentionInDays:
+    Description: The number of days log events are kept in CloudWatch Logs
+    Type: Number
+    Default: 30
+    AllowedValues:
+      [
+        1,
+        3,
+        5,
+        7,
+        14,
+        30,
+        60,
+        90,
+        120,
+        150,
+        180,
+        365,
+        400,
+        545,
+        731,
+        1827,
+        3653,
+      ]
 
 Conditions:
   DeployElasticSearch: !Equals [!Ref pElasticSearchEnabled, "true"]
@@ -385,6 +409,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaRoutingStep}
+      RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
 
   rUpdateSubscriptionFilterRoutingStep:
     Type: Custom::UpdateSubscriptionFilter
@@ -419,6 +444,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaRedriveStep}
+      RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
 
   rUpdateSubscriptionFilterRedriveStep:
     Type: Custom::UpdateSubscriptionFilter
@@ -434,6 +460,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaStep1}
+      RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
 
   rUpdateSubscriptionFilterStep1:
     Type: Custom::UpdateSubscriptionFilter
@@ -449,6 +476,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaStep2}
+      RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
 
   rUpdateSubscriptionFilterStep2:
     Type: Custom::UpdateSubscriptionFilter
@@ -464,6 +492,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaStep3}
+      RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
 
   rUpdateSubscriptionFilterStep3:
     Type: Custom::UpdateSubscriptionFilter
@@ -479,6 +508,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaErrorStep}
+      RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
 
   rUpdateSubscriptionFilterErrorStep:
     Type: Custom::UpdateSubscriptionFilter

--- a/sdlf-utils/pipeline-examples/cloudfront/template.yaml
+++ b/sdlf-utils/pipeline-examples/cloudfront/template.yaml
@@ -410,6 +410,7 @@ Resources:
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaRoutingStep}
       RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
+      KmsKeyId: !Ref pKMSInfraKeyId
 
   rUpdateSubscriptionFilterRoutingStep:
     Type: Custom::UpdateSubscriptionFilter
@@ -445,6 +446,7 @@ Resources:
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaRedriveStep}
       RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
+      KmsKeyId: !Ref pKMSInfraKeyId
 
   rUpdateSubscriptionFilterRedriveStep:
     Type: Custom::UpdateSubscriptionFilter
@@ -461,6 +463,7 @@ Resources:
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaStep1}
       RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
+      KmsKeyId: !Ref pKMSInfraKeyId
 
   rUpdateSubscriptionFilterStep1:
     Type: Custom::UpdateSubscriptionFilter
@@ -477,6 +480,7 @@ Resources:
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaStep2}
       RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
+      KmsKeyId: !Ref pKMSInfraKeyId
 
   rUpdateSubscriptionFilterStep2:
     Type: Custom::UpdateSubscriptionFilter
@@ -493,6 +497,7 @@ Resources:
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaStep3}
       RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
+      KmsKeyId: !Ref pKMSInfraKeyId
 
   rUpdateSubscriptionFilterStep3:
     Type: Custom::UpdateSubscriptionFilter
@@ -509,6 +514,7 @@ Resources:
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaErrorStep}
       RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
+      KmsKeyId: !Ref pKMSInfraKeyId
 
   rUpdateSubscriptionFilterErrorStep:
     Type: Custom::UpdateSubscriptionFilter

--- a/sdlf-utils/pipeline-examples/dataset-dependency/stageA/template.yaml
+++ b/sdlf-utils/pipeline-examples/dataset-dependency/stageA/template.yaml
@@ -246,6 +246,7 @@ Resources:
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaStep1}
       RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
+      KmsKeyId: !Ref pKMSInfraKeyId
 
   rUpdateSubscriptionFilterStep1:
     Type: Custom::UpdateSubscriptionFilter
@@ -262,6 +263,7 @@ Resources:
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaJobCheckStep}
       RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
+      KmsKeyId: !Ref pKMSInfraKeyId
 
   rUpdateSubscriptionFilterJobCheckStep:
     Type: Custom::UpdateSubscriptionFilter
@@ -278,6 +280,7 @@ Resources:
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaStep2}
       RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
+      KmsKeyId: !Ref pKMSInfraKeyId
 
   rUpdateSubscriptionFilterStep2:
     Type: Custom::UpdateSubscriptionFilter

--- a/sdlf-utils/pipeline-examples/dataset-dependency/stageA/template.yaml
+++ b/sdlf-utils/pipeline-examples/dataset-dependency/stageA/template.yaml
@@ -67,6 +67,30 @@ Parameters:
   pSNSTopic:
     Description: The team SNS topic
     Type: String
+  pCloudWatchLogsRetentionInDays:
+    Description: The number of days log events are kept in CloudWatch Logs
+    Type: Number
+    Default: 30
+    AllowedValues:
+      [
+        1,
+        3,
+        5,
+        7,
+        14,
+        30,
+        60,
+        90,
+        120,
+        150,
+        180,
+        365,
+        400,
+        545,
+        731,
+        1827,
+        3653,
+      ]
 
 Conditions:
   DeployElasticSearch: !Equals [!Ref pElasticSearchEnabled, "true"]
@@ -221,6 +245,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaStep1}
+      RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
 
   rUpdateSubscriptionFilterStep1:
     Type: Custom::UpdateSubscriptionFilter
@@ -236,6 +261,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaJobCheckStep}
+      RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
 
   rUpdateSubscriptionFilterJobCheckStep:
     Type: Custom::UpdateSubscriptionFilter
@@ -251,6 +277,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaStep2}
+      RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
 
   rUpdateSubscriptionFilterStep2:
     Type: Custom::UpdateSubscriptionFilter
@@ -271,5 +298,5 @@ Resources:
       DefinitionSubstitutions:
         lStep1: !GetAtt rLambdaStep1.Arn
         lStep2: !GetAtt rLambdaStep2.Arn
-        lstep3: !GetAtt rLambdaJobCheckStep.Arn        
+        lstep3: !GetAtt rLambdaJobCheckStep.Arn
       Role: !Ref pStatesExecutionRole

--- a/sdlf-utils/pipeline-examples/manifests/stageA/template.yaml
+++ b/sdlf-utils/pipeline-examples/manifests/stageA/template.yaml
@@ -708,6 +708,7 @@ Resources:
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaRoutingStep}
       RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
+      KmsKeyId: !Ref pKMSInfraKeyId
 
   rUpdateSubscriptionFilterRoutingStep:
     Type: Custom::UpdateSubscriptionFilter
@@ -743,6 +744,7 @@ Resources:
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaRedriveStep}
       RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
+      KmsKeyId: !Ref pKMSInfraKeyId
 
   rUpdateSubscriptionFilterRedriveStep:
     Type: Custom::UpdateSubscriptionFilter
@@ -759,6 +761,7 @@ Resources:
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaStep1}
       RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
+      KmsKeyId: !Ref pKMSInfraKeyId
 
   rUpdateSubscriptionFilterStep1:
     Type: Custom::UpdateSubscriptionFilter
@@ -775,6 +778,7 @@ Resources:
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaStep2}
       RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
+      KmsKeyId: !Ref pKMSInfraKeyId
 
   rUpdateSubscriptionFilterStep2:
     Type: Custom::UpdateSubscriptionFilter
@@ -791,6 +795,7 @@ Resources:
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaStep3}
       RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
+      KmsKeyId: !Ref pKMSInfraKeyId
 
   rUpdateSubscriptionFilterStep3:
     Type: Custom::UpdateSubscriptionFilter
@@ -807,6 +812,7 @@ Resources:
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaStep4}
       RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
+      KmsKeyId: !Ref pKMSInfraKeyId
 
   rUpdateSubscriptionFilterStep4:
     Type: Custom::UpdateSubscriptionFilter
@@ -823,6 +829,7 @@ Resources:
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaStep5}
       RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
+      KmsKeyId: !Ref pKMSInfraKeyId
 
   rUpdateSubscriptionFilterStep5:
     Type: Custom::UpdateSubscriptionFilter
@@ -839,6 +846,7 @@ Resources:
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaStep6}
       RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
+      KmsKeyId: !Ref pKMSInfraKeyId
 
   rUpdateSubscriptionFilterStep6:
     Type: Custom::UpdateSubscriptionFilter
@@ -855,6 +863,7 @@ Resources:
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaStep7}
       RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
+      KmsKeyId: !Ref pKMSInfraKeyId
 
   rUpdateSubscriptionFilterStep7:
     Type: Custom::UpdateSubscriptionFilter
@@ -871,6 +880,7 @@ Resources:
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaErrorStep}
       RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
+      KmsKeyId: !Ref pKMSInfraKeyId
 
   rUpdateSubscriptionFilterErrorStep:
     Type: Custom::UpdateSubscriptionFilter

--- a/sdlf-utils/pipeline-examples/manifests/stageA/template.yaml
+++ b/sdlf-utils/pipeline-examples/manifests/stageA/template.yaml
@@ -67,6 +67,30 @@ Parameters:
   pSNSTopic:
     Description: The team SNS topic
     Type: String
+  pCloudWatchLogsRetentionInDays:
+    Description: The number of days log events are kept in CloudWatch Logs
+    Type: Number
+    Default: 30
+    AllowedValues:
+      [
+        1,
+        3,
+        5,
+        7,
+        14,
+        30,
+        60,
+        90,
+        120,
+        150,
+        180,
+        365,
+        400,
+        545,
+        731,
+        1827,
+        3653,
+      ]
 
 Conditions:
   DeployElasticSearch: !Equals [!Ref pElasticSearchEnabled, "true"]
@@ -683,6 +707,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaRoutingStep}
+      RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
 
   rUpdateSubscriptionFilterRoutingStep:
     Type: Custom::UpdateSubscriptionFilter
@@ -717,6 +742,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaRedriveStep}
+      RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
 
   rUpdateSubscriptionFilterRedriveStep:
     Type: Custom::UpdateSubscriptionFilter
@@ -732,6 +758,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaStep1}
+      RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
 
   rUpdateSubscriptionFilterStep1:
     Type: Custom::UpdateSubscriptionFilter
@@ -747,6 +774,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaStep2}
+      RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
 
   rUpdateSubscriptionFilterStep2:
     Type: Custom::UpdateSubscriptionFilter
@@ -762,6 +790,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaStep3}
+      RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
 
   rUpdateSubscriptionFilterStep3:
     Type: Custom::UpdateSubscriptionFilter
@@ -777,6 +806,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaStep4}
+      RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
 
   rUpdateSubscriptionFilterStep4:
     Type: Custom::UpdateSubscriptionFilter
@@ -792,6 +822,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaStep5}
+      RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
 
   rUpdateSubscriptionFilterStep5:
     Type: Custom::UpdateSubscriptionFilter
@@ -807,6 +838,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaStep6}
+      RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
 
   rUpdateSubscriptionFilterStep6:
     Type: Custom::UpdateSubscriptionFilter
@@ -822,6 +854,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaStep7}
+      RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
 
   rUpdateSubscriptionFilterStep7:
     Type: Custom::UpdateSubscriptionFilter
@@ -837,6 +870,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaErrorStep}
+      RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
 
   rUpdateSubscriptionFilterErrorStep:
     Type: Custom::UpdateSubscriptionFilter

--- a/sdlf-utils/pipeline-examples/topic-modelling/stageA/template.yaml
+++ b/sdlf-utils/pipeline-examples/topic-modelling/stageA/template.yaml
@@ -465,6 +465,7 @@ Resources:
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaRoutingStep}
       RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
+      KmsKeyId: !Ref pKMSInfraKeyId
 
   rUpdateSubscriptionFilterRoutingStep:
     Type: Custom::UpdateSubscriptionFilter
@@ -500,6 +501,7 @@ Resources:
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaRedriveStep}
       RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
+      KmsKeyId: !Ref pKMSInfraKeyId
 
   rUpdateSubscriptionFilterRedriveStep:
     Type: Custom::UpdateSubscriptionFilter
@@ -516,6 +518,7 @@ Resources:
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaStep1}
       RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
+      KmsKeyId: !Ref pKMSInfraKeyId
 
   rUpdateSubscriptionFilterStep1:
     Type: Custom::UpdateSubscriptionFilter
@@ -532,6 +535,7 @@ Resources:
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaStep2}
       RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
+      KmsKeyId: !Ref pKMSInfraKeyId
 
   rUpdateSubscriptionFilterStep2:
     Type: Custom::UpdateSubscriptionFilter
@@ -548,6 +552,7 @@ Resources:
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaStep3}
       RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
+      KmsKeyId: !Ref pKMSInfraKeyId
 
   rUpdateSubscriptionFilterStep3:
     Type: Custom::UpdateSubscriptionFilter
@@ -564,6 +569,7 @@ Resources:
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaErrorStep}
       RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
+      KmsKeyId: !Ref pKMSInfraKeyId
 
   rUpdateSubscriptionFilterErrorStep:
     Type: Custom::UpdateSubscriptionFilter

--- a/sdlf-utils/pipeline-examples/topic-modelling/stageA/template.yaml
+++ b/sdlf-utils/pipeline-examples/topic-modelling/stageA/template.yaml
@@ -67,6 +67,30 @@ Parameters:
   pSNSTopic:
     Description: The team SNS topic
     Type: String
+  pCloudWatchLogsRetentionInDays:
+    Description: The number of days log events are kept in CloudWatch Logs
+    Type: Number
+    Default: 30
+    AllowedValues:
+      [
+        1,
+        3,
+        5,
+        7,
+        14,
+        30,
+        60,
+        90,
+        120,
+        150,
+        180,
+        365,
+        400,
+        545,
+        731,
+        1827,
+        3653,
+      ]
 
 Conditions:
   DeployElasticSearch: !Equals [!Ref pElasticSearchEnabled, "true"]
@@ -440,6 +464,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaRoutingStep}
+      RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
 
   rUpdateSubscriptionFilterRoutingStep:
     Type: Custom::UpdateSubscriptionFilter
@@ -474,6 +499,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaRedriveStep}
+      RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
 
   rUpdateSubscriptionFilterRedriveStep:
     Type: Custom::UpdateSubscriptionFilter
@@ -489,6 +515,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaStep1}
+      RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
 
   rUpdateSubscriptionFilterStep1:
     Type: Custom::UpdateSubscriptionFilter
@@ -504,6 +531,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaStep2}
+      RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
 
   rUpdateSubscriptionFilterStep2:
     Type: Custom::UpdateSubscriptionFilter
@@ -519,6 +547,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaStep3}
+      RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
 
   rUpdateSubscriptionFilterStep3:
     Type: Custom::UpdateSubscriptionFilter
@@ -534,6 +563,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaErrorStep}
+      RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
 
   rUpdateSubscriptionFilterErrorStep:
     Type: Custom::UpdateSubscriptionFilter

--- a/sdlf-utils/pipeline-examples/topic-modelling/stageB/template.yaml
+++ b/sdlf-utils/pipeline-examples/topic-modelling/stageB/template.yaml
@@ -638,6 +638,7 @@ Resources:
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaRoutingStep}
       RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
+      KmsKeyId: !Ref pKMSInfraKeyId
 
   rUpdateSubscriptionFilterRoutingStep:
     Type: Custom::UpdateSubscriptionFilter
@@ -673,6 +674,7 @@ Resources:
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaRedriveStep}
       RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
+      KmsKeyId: !Ref pKMSInfraKeyId
 
   rUpdateSubscriptionFilterRedriveStep:
     Type: Custom::UpdateSubscriptionFilter
@@ -689,6 +691,7 @@ Resources:
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaStep1}
       RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
+      KmsKeyId: !Ref pKMSInfraKeyId
 
   rUpdateSubscriptionFilterStep1:
     Type: Custom::UpdateSubscriptionFilter
@@ -705,6 +708,7 @@ Resources:
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaJobCheckStep}
       RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
+      KmsKeyId: !Ref pKMSInfraKeyId
 
   rUpdateSubscriptionFilterJobCheckStep:
     Type: Custom::UpdateSubscriptionFilter
@@ -721,6 +725,7 @@ Resources:
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaStep2}
       RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
+      KmsKeyId: !Ref pKMSInfraKeyId
 
   rUpdateSubscriptionFilterStep2:
     Type: Custom::UpdateSubscriptionFilter
@@ -737,6 +742,7 @@ Resources:
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaStep3}
       RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
+      KmsKeyId: !Ref pKMSInfraKeyId
 
   rUpdateSubscriptionFilterStep3:
     Type: Custom::UpdateSubscriptionFilter
@@ -754,6 +760,7 @@ Resources:
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaStep4}
       RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
+      KmsKeyId: !Ref pKMSInfraKeyId
 
   rUpdateSubscriptionFilterStep4:
     Type: Custom::UpdateSubscriptionFilter
@@ -771,6 +778,7 @@ Resources:
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaStep5}
       RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
+      KmsKeyId: !Ref pKMSInfraKeyId
 
   rUpdateSubscriptionFilterStep5:
     Type: Custom::UpdateSubscriptionFilter
@@ -788,6 +796,7 @@ Resources:
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaStep6}
       RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
+      KmsKeyId: !Ref pKMSInfraKeyId
 
   rUpdateSubscriptionFilterStep6:
     Type: Custom::UpdateSubscriptionFilter
@@ -805,6 +814,7 @@ Resources:
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaStep7}
       RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
+      KmsKeyId: !Ref pKMSInfraKeyId
 
   rUpdateSubscriptionFilterStep7:
     Type: Custom::UpdateSubscriptionFilter
@@ -821,6 +831,7 @@ Resources:
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaErrorStep}
       RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
+      KmsKeyId: !Ref pKMSInfraKeyId
 
   rUpdateSubscriptionFilterErrorStep:
     Type: Custom::UpdateSubscriptionFilter

--- a/sdlf-utils/pipeline-examples/topic-modelling/stageB/template.yaml
+++ b/sdlf-utils/pipeline-examples/topic-modelling/stageB/template.yaml
@@ -67,6 +67,30 @@ Parameters:
   pSNSTopic:
     Description: The team SNS topic
     Type: String
+  pCloudWatchLogsRetentionInDays:
+    Description: The number of days log events are kept in CloudWatch Logs
+    Type: Number
+    Default: 30
+    AllowedValues:
+      [
+        1,
+        3,
+        5,
+        7,
+        14,
+        30,
+        60,
+        90,
+        120,
+        150,
+        180,
+        365,
+        400,
+        545,
+        731,
+        1827,
+        3653,
+      ]
 
 Conditions:
   DeployElasticSearch: !Equals [!Ref pElasticSearchEnabled, "true"]
@@ -613,6 +637,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaRoutingStep}
+      RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
 
   rUpdateSubscriptionFilterRoutingStep:
     Type: Custom::UpdateSubscriptionFilter
@@ -647,6 +672,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaRedriveStep}
+      RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
 
   rUpdateSubscriptionFilterRedriveStep:
     Type: Custom::UpdateSubscriptionFilter
@@ -662,6 +688,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaStep1}
+      RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
 
   rUpdateSubscriptionFilterStep1:
     Type: Custom::UpdateSubscriptionFilter
@@ -677,6 +704,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaJobCheckStep}
+      RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
 
   rUpdateSubscriptionFilterJobCheckStep:
     Type: Custom::UpdateSubscriptionFilter
@@ -692,6 +720,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaStep2}
+      RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
 
   rUpdateSubscriptionFilterStep2:
     Type: Custom::UpdateSubscriptionFilter
@@ -707,6 +736,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaStep3}
+      RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
 
   rUpdateSubscriptionFilterStep3:
     Type: Custom::UpdateSubscriptionFilter
@@ -723,6 +753,7 @@ Resources:
     Condition: DeployElasticSearch
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaStep4}
+      RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
 
   rUpdateSubscriptionFilterStep4:
     Type: Custom::UpdateSubscriptionFilter
@@ -739,6 +770,7 @@ Resources:
     Condition: DeployElasticSearch
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaStep5}
+      RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
 
   rUpdateSubscriptionFilterStep5:
     Type: Custom::UpdateSubscriptionFilter
@@ -755,6 +787,7 @@ Resources:
     Condition: DeployElasticSearch
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaStep6}
+      RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
 
   rUpdateSubscriptionFilterStep6:
     Type: Custom::UpdateSubscriptionFilter
@@ -771,6 +804,7 @@ Resources:
     Condition: DeployElasticSearch
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaStep7}
+      RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
 
   rUpdateSubscriptionFilterStep7:
     Type: Custom::UpdateSubscriptionFilter
@@ -786,6 +820,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaErrorStep}
+      RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
 
   rUpdateSubscriptionFilterErrorStep:
     Type: Custom::UpdateSubscriptionFilter
@@ -831,7 +866,7 @@ Resources:
         lStep7: !GetAtt rLambdaStep7.Arn
         lCheckJob: !GetAtt rLambdaJobCheckStep.Arn
         lError: !GetAtt rLambdaErrorStep.Arn
-        smDataQuality: "{{resolve:ssm:/SDLF/SM/DataQualityStateMachine:1}}"        
+        smDataQuality: "{{resolve:ssm:/SDLF/SM/DataQualityStateMachine:1}}"
       Role: !Ref pStatesExecutionRole
 
   ######## SSM OUTPUTS #########


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:*
- ensuring Lambda Functions that have CloudWatch log group resources associated with them have both:
  - log retention in days set
  - the logs are encrypted
- **Note**: this does not cover log groups for Lambda functions that do not have an explicit CloudWatch log group resource. This is primarily because adding an explicit log group resource would likely cause a failure as there would already be an automatically generated one.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
