### PR TITLE
Point-in-time recovery (PITR) enabled for DynamoDB tables

### DIFF
--- a/sdlf-cicd/template-cicd-child-foundations.yaml
+++ b/sdlf-cicd/template-cicd-child-foundations.yaml
@@ -147,6 +147,8 @@ Resources:
                   - dynamodb:UntagResource
                   - dynamodb:UpdateTable
                   - dynamodb:UpdateTimeToLive
+                  - dynamodb:DescribeContinuousBackups
+                  - dynamodb:UpdateContinuousBackups
               - Resource: !Sub arn:aws:events:${AWS::Region}:${AWS::AccountId}:rule/sdlf-*
                 Effect: Allow
                 Action:

--- a/sdlf-cicd/template-cicd-child-foundations.yaml
+++ b/sdlf-cicd/template-cicd-child-foundations.yaml
@@ -81,7 +81,7 @@ Resources:
               AWS: !Sub arn:aws:iam::${pSharedDevOpsAccountId}:root
             Action:
               - s3:Get*
-              - s3:Put*
+              - s3:PutObject
             Resource:
               - !Sub arn:aws:s3:::${rArtifactsBucket}/*
           - Effect: Deny

--- a/sdlf-foundations/nested-stacks/template-dynamo.yaml
+++ b/sdlf-foundations/nested-stacks/template-dynamo.yaml
@@ -26,6 +26,8 @@ Resources:
         SSEEnabled: True
         SSEType: KMS
         KMSMasterKeyId: !Ref pKMSKeyId
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: True
     UpdateReplacePolicy: Retain
     DeletionPolicy: Delete
 
@@ -44,6 +46,8 @@ Resources:
         SSEEnabled: True
         SSEType: KMS
         KMSMasterKeyId: !Ref pKMSKeyId
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: True
     UpdateReplacePolicy: Retain
     DeletionPolicy: Delete
 
@@ -114,6 +118,8 @@ Resources:
         SSEEnabled: True
         SSEType: KMS
         KMSMasterKeyId: !Ref pKMSKeyId
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: True
     UpdateReplacePolicy: Retain
     DeletionPolicy: Delete
 
@@ -168,6 +174,8 @@ Resources:
         SSEEnabled: True
         SSEType: KMS
         KMSMasterKeyId: !Ref pKMSKeyId
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: True
     UpdateReplacePolicy: Retain
     DeletionPolicy: Delete
 
@@ -195,6 +203,8 @@ Resources:
         SSEEnabled: True
         SSEType: KMS
         KMSMasterKeyId: !Ref pKMSKeyId
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: True
     UpdateReplacePolicy: Retain
     DeletionPolicy: Delete
 
@@ -213,6 +223,8 @@ Resources:
         SSEEnabled: True
         SSEType: KMS
         KMSMasterKeyId: !Ref pKMSKeyId
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: True
     UpdateReplacePolicy: Retain
     DeletionPolicy: Delete
 
@@ -231,6 +243,8 @@ Resources:
         SSEEnabled: True
         SSEType: KMS
         KMSMasterKeyId: !Ref pKMSKeyId
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: True
     UpdateReplacePolicy: Retain
     DeletionPolicy: Delete
 
@@ -285,6 +299,8 @@ Resources:
         SSEEnabled: True
         SSEType: KMS
         KMSMasterKeyId: !Ref pKMSKeyId
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: True
     UpdateReplacePolicy: Retain
     DeletionPolicy: Delete
 
@@ -375,6 +391,8 @@ Resources:
         SSEEnabled: True
         SSEType: KMS
         KMSMasterKeyId: !Ref pKMSKeyId
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: True
     UpdateReplacePolicy: Retain
     DeletionPolicy: Delete
 
@@ -395,8 +413,11 @@ Resources:
         SSEEnabled: True
         SSEType: KMS
         KMSMasterKeyId: !Ref pKMSKeyId
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: True
     UpdateReplacePolicy: Retain
     DeletionPolicy: Delete
+
 
   rDynamoOctagonQualitySuggestions:
     Type: AWS::DynamoDB::Table
@@ -422,8 +443,11 @@ Resources:
         SSEEnabled: True
         SSEType: KMS
         KMSMasterKeyId: !Ref pKMSKeyId
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: True
     UpdateReplacePolicy: Retain
     DeletionPolicy: Delete
+
 
   rDynamoOctagonQualityAnalysis:
     Type: AWS::DynamoDB::Table
@@ -449,8 +473,11 @@ Resources:
         SSEEnabled: True
         SSEType: KMS
         KMSMasterKeyId: !Ref pKMSKeyId
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: True
     UpdateReplacePolicy: Retain
     DeletionPolicy: Delete
+
 
   rDynamoOctagonManifests:
     Type: AWS::DynamoDB::Table
@@ -474,8 +501,11 @@ Resources:
         SSEEnabled: True
         SSEType: KMS
         KMSMasterKeyId: !Ref pKMSKeyId
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: True
     UpdateReplacePolicy: Retain
     DeletionPolicy: Delete
+
 
   rDynamoObjectMetadataSsm:
     Type: AWS::SSM::Parameter


### PR DESCRIPTION
*Issue #, if available:*
AWS Foundational Security Best Practices v1.0.0 
Control Failed:
[DynamoDB.2] This control checks whether point-in-time recovery (PITR) is enabled for a DynamoDB table


*Description of changes:*
1-Followed remediation instructions for Issue  [DynamoDB.2]  ( https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#dynamodb-2-remediation ) 
2-Added permissions to IAM role sdlf-cicd-codebuild to be able to update the backup settings on the dynamodb tables


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
