### PR TITLE
Team groups

### DIFF
--- a/sdlf-cicd/template-cicd-child-foundations.yaml
+++ b/sdlf-cicd/template-cicd-child-foundations.yaml
@@ -215,6 +215,7 @@ Resources:
                   - iam:CreateGroup
                   - iam:GetGroup*
                   - iam:PutGroupPolicy
+                  - iam:DeleteGroupPolicy
               - Resource: "*"
                 Effect: "Allow"
                 Action: lambda:ListFunctions

--- a/sdlf-cicd/template-cicd-child-foundations.yaml
+++ b/sdlf-cicd/template-cicd-child-foundations.yaml
@@ -200,6 +200,7 @@ Resources:
                   - iam:UntagRole
                   - iam:UpdateRole
                   - iam:UpdateRoleDescription
+                  - iam:UpdateAssumeRolePolicy # so we can update the management account access
               - Resource: !Sub arn:aws:iam::${AWS::AccountId}:policy/sdlf-*
                 Effect: Allow
                 Action:

--- a/sdlf-cicd/template-cicd-child-foundations.yaml
+++ b/sdlf-cicd/template-cicd-child-foundations.yaml
@@ -200,7 +200,6 @@ Resources:
                   - iam:UntagRole
                   - iam:UpdateRole
                   - iam:UpdateRoleDescription
-                  - iam:UpdateAssumeRolePolicy
               - Resource: !Sub arn:aws:iam::${AWS::AccountId}:policy/sdlf-*
                 Effect: Allow
                 Action:

--- a/sdlf-cicd/template-cicd-child-foundations.yaml
+++ b/sdlf-cicd/template-cicd-child-foundations.yaml
@@ -200,6 +200,7 @@ Resources:
                   - iam:UntagRole
                   - iam:UpdateRole
                   - iam:UpdateRoleDescription
+                  - iam:UpdateAssumeRolePolicy
               - Resource: !Sub arn:aws:iam::${AWS::AccountId}:policy/sdlf-*
                 Effect: Allow
                 Action:

--- a/sdlf-cicd/template-cicd-child-foundations.yaml
+++ b/sdlf-cicd/template-cicd-child-foundations.yaml
@@ -201,7 +201,8 @@ Resources:
                   - iam:UpdateRole
                   - iam:UpdateRoleDescription
                   - iam:UpdateAssumeRolePolicy # so we can update the management account access
-                  - iam:PutRolePermissionsBoundary # so we can add boundaries back in later?
+                  - iam:DeleteRolePermissionsBoundary # so we can delete boundaries
+                  - iam:PutRolePermissionsBoundary # so we can add boundaries back in later
               - Resource: !Sub arn:aws:iam::${AWS::AccountId}:policy/sdlf-*
                 Effect: Allow
                 Action:

--- a/sdlf-cicd/template-cicd-child-foundations.yaml
+++ b/sdlf-cicd/template-cicd-child-foundations.yaml
@@ -217,6 +217,7 @@ Resources:
                   - iam:AttachGroupPolicy
                   - iam:PutGroupPolicy
                   - iam:DeleteGroupPolicy
+                  - iam:DetachGroupPolicy
               - Resource: "*"
                 Effect: "Allow"
                 Action: lambda:ListFunctions

--- a/sdlf-cicd/template-cicd-child-foundations.yaml
+++ b/sdlf-cicd/template-cicd-child-foundations.yaml
@@ -201,6 +201,7 @@ Resources:
                   - iam:UpdateRole
                   - iam:UpdateRoleDescription
                   - iam:UpdateAssumeRolePolicy # so we can update the management account access
+                  - iam:PutRolePermissionsBoundary # so we can add boundaries back in later?
               - Resource: !Sub arn:aws:iam::${AWS::AccountId}:policy/sdlf-*
                 Effect: Allow
                 Action:

--- a/sdlf-cicd/template-cicd-child-foundations.yaml
+++ b/sdlf-cicd/template-cicd-child-foundations.yaml
@@ -209,6 +209,12 @@ Resources:
                   - iam:DeletePolicyVersion
                   - iam:GetPolicy
                   - iam:GetPolicyVersion
+              - Resource: !Sub arn:aws:iam::${AWS::AccountId}:group/sdlf-*
+                Effect: Allow
+                Action:
+                  - iam:CreateGroup
+                  - iam:GetGroup*
+                  - iam:PutGroupPolicy
               - Resource: "*"
                 Effect: "Allow"
                 Action: lambda:ListFunctions

--- a/sdlf-cicd/template-cicd-child-foundations.yaml
+++ b/sdlf-cicd/template-cicd-child-foundations.yaml
@@ -214,6 +214,7 @@ Resources:
                 Action:
                   - iam:CreateGroup
                   - iam:GetGroup*
+                  - iam:AttachGroupPolicy
                   - iam:PutGroupPolicy
                   - iam:DeleteGroupPolicy
               - Resource: "*"

--- a/sdlf-cicd/template-cicd-child-foundations.yaml
+++ b/sdlf-cicd/template-cicd-child-foundations.yaml
@@ -213,6 +213,7 @@ Resources:
                 Effect: Allow
                 Action:
                   - iam:CreateGroup
+                  - iam:DeleteGroup
                   - iam:GetGroup*
                   - iam:AttachGroupPolicy
                   - iam:PutGroupPolicy

--- a/sdlf-team/nested-stacks/template-iam.yaml
+++ b/sdlf-team/nested-stacks/template-iam.yaml
@@ -28,6 +28,10 @@ Parameters:
     Type: String
   pTeamName:
     Type: String
+  pAthenaBucket:
+    Description: The athena bucket for the solution
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: /SDLF/S3/AthenaBucket
 
 Conditions:
   CreateMultipleBuckets:
@@ -63,6 +67,7 @@ Resources:
                 !Sub "arn:aws:s3:::${pCentralBucket}",
                 !Sub "arn:aws:s3:::${pStageBucket}",
                 !Sub "arn:aws:s3:::${pAnalyticsBucket}",
+                !Sub "arn:aws:s3:::${pAthenaBucket}"
               ]
           - Sid: AllowTeamPrefixActions
             Effect: Allow
@@ -85,6 +90,11 @@ Resources:
                   CreateMultipleBuckets,
                   !Sub "arn:aws:s3:::${pAnalyticsBucket}/${pTeamName}/*",
                   !Sub "arn:aws:s3:::${pAnalyticsBucket}/analytics/${pTeamName}/*",
+                ]
+              - !If [
+                  CreateMultipleBuckets,
+                  !Sub "arn:aws:s3:::${pAthenaBucket}/${pTeamName}*",
+                  !Sub "arn:aws:s3:::${pAthenaBucket}/analytics/${pTeamName}/*",
                 ]
           - Sid: AllowFullCodeCommitOnTeamRepositories
             Effect: Allow
@@ -182,6 +192,19 @@ Resources:
               - cloudformation:DescribeStackResources
             Resource:
               - !Sub arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack:sdlf-${pTeamName}:*
+          - Sid: AllowAthenaFullAccess
+            Effect: "Allow"
+            Action:
+              - athena:*
+              - lakeformation:GetDataAccess
+              - glue:GetTable
+              - glue:GetTables
+              - glue:SearchTables
+              - glue:GetDatabase
+              - glue:GetDatabases
+              - glue:GetPartitions
+            Resource:
+              - "*"
 
   rCodePipelineRole:
     Type: AWS::IAM::Role
@@ -1085,6 +1108,48 @@ Resources:
                 Resource:
                   - !Ref pKMSDataKeyId
 
+########## User Management ##########
+  rAnalystsGroup:
+    Type: AWS::IAM::Group
+    Properties:
+      GroupName: !Sub sdlf-${pTeamName}-analysts-group
+      Policies:
+        - PolicyName: !Sub 'sdlf-${pTeamName}-assume-analysts-role'
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: "Allow"
+                Action: "sts:AssumeRole"
+                Resource:
+                  - !GetAtt rAnalystsRole.Arn
+
+  rAnalystsRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: !Sub sdlf-${pTeamName}-analysts-role
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: "Allow"
+            Principal:
+              AWS: !Ref "AWS::AccountId"
+            Action:
+              - "sts:AssumeRole"
+      Description: "Role for SDLF analysts"
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/AmazonAthenaFullAccess
+      MaxSessionDuration: 43200
+      PermissionsBoundary: !Ref rTeamIAMManagedPolicy
+      Policies:
+        - PolicyName: !Sub 'sdlf-${pTeamName}-athena-policy'
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: "Allow"
+                Action: "s3:*"
+                Resource:
+                  - !Sub arn:aws:s3:::${pAthenaBucket}/${pTeamName}* # athena saved views etc should be named teamname-blahblah
+
   ####### SSM #######
   rTeamIAMManagedPolicySsm:
     Type: AWS::SSM::Parameter
@@ -1128,7 +1193,14 @@ Resources:
       Type: String
       Value: !GetAtt rDatalakeCrawlerRole.Arn
       Description: The ARN of the Crawler role
-
+  rAnalystsRoleArnSsm:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub /SDLF/IAM/${pTeamName}/AnalystsRoleArn
+      Type: String
+      Value: !GetAtt rAnalystsRole.Arn
+      Description: The ARN of the Analysts role
+      
 Outputs:
   oCodePipelineRoleArn:
     Description: The ARN of the role used by CodePipeline


### PR DESCRIPTION
*Description of changes:*

This change enables sdlf-cicd-team pipeline to create IAM groups so when a new team is provisioned an analysts group is created. Members of this group will be able to access team glue catalogs through Athena console.

The use case that gave rise to this change was:
1. Users from multiple organisations with their own unique SSO solutions contributing to a data lake - requiring user management to done through IAM users and groups
2. Analyst users for each organisation are simply created as an IAM user then added to an sdlf-<team>-analysts-group which can assume an sdlf-<team>-analysts-role which has access to Athena console and their teams glue catalog and athena query s3 location
3. When a new dataset is provisioned for the team LF tagging is used through lake formation console to provide the sdfl-<team>-analysts-role access to the tables.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
