### PR TITLE
FIX issue https://github.com/awslabs/aws-serverless-data-lake-framework/issues/76

### DIFF
--- a/sdlf-foundations/nested-stacks/template-s3.yaml
+++ b/sdlf-foundations/nested-stacks/template-s3.yaml
@@ -119,7 +119,7 @@ Resources:
     Type: AWS::LakeFormation::Resource
     Condition: CreateSingleBucket
     Properties:
-      ResourceArn: !Sub arn:aws:::s3:${rCentralBucket}/
+      ResourceArn: !Sub arn:aws:s3:::${rCentralBucket}/
       UseServiceLinkedRole: True
 
   rRawBucket:
@@ -172,7 +172,7 @@ Resources:
     Type: AWS::LakeFormation::Resource
     Condition: CreateMultipleBuckets
     Properties:
-      ResourceArn: !Sub arn:aws:::s3:${rRawBucket}/
+      ResourceArn: !Sub arn:aws:s3:::${rRawBucket}/
       UseServiceLinkedRole: True
 
   rStageBucket:
@@ -225,7 +225,7 @@ Resources:
     Type: AWS::LakeFormation::Resource
     Condition: CreateMultipleBuckets
     Properties:
-      ResourceArn: !Sub arn:aws:::s3:${rStageBucket}/
+      ResourceArn: !Sub arn:aws:s3:::${rStageBucket}/
       UseServiceLinkedRole: True
 
   rAnalyticsBucket:
@@ -278,7 +278,7 @@ Resources:
     Type: AWS::LakeFormation::Resource
     Condition: CreateMultipleBuckets
     Properties:
-      ResourceArn: !Sub arn:aws:::s3:${rAnalyticsBucket}/
+      ResourceArn: !Sub arn:aws:s3:::${rAnalyticsBucket}/
       UseServiceLinkedRole: True
 
   rDataQualityBucket:
@@ -321,7 +321,7 @@ Resources:
   rDataQualityBucketLakeFormationS3Registration:
     Type: AWS::LakeFormation::Resource
     Properties:
-      ResourceArn: !Sub arn:aws:::s3:${rDataQualityBucket}/
+      ResourceArn: !Sub arn:aws:s3:::${rDataQualityBucket}/
       UseServiceLinkedRole: True
 
   rAthenaBucket:


### PR DESCRIPTION
FIX to the issue: Get error Unsupported resource ARN Format (Service:Lake formation; status code:400 ; Error Code: InvalidInputException) on rXXBucketLakeFormationS3Registration resources

File sdlf-foundations/nested-stacks/template-s3.yaml

*Issue #, if available:*
https://github.com/awslabs/aws-serverless-data-lake-framework/issues/76

*Description of changes:*
Fix the ARN format on rXXBucketLakeFormationS3Registration resources

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
