### PR TITLE
update codebuild image from standard:4.0 to amazonlinux2-x86_64-standard:4.0

### DIFF
--- a/sdlf-cicd/template-cicd-child-foundations.yaml
+++ b/sdlf-cicd/template-cicd-child-foundations.yaml
@@ -628,7 +628,7 @@ Resources:
       EncryptionKey: !Ref pSharedDevOpsAccountKmsKeyArn
       Environment:
         ComputeType: BUILD_GENERAL1_SMALL
-        Image: aws/codebuild/standard:4.0
+        Image: aws/codebuild/amazonlinux2-x86_64-standard:4.0
         Type: LINUX_CONTAINER
       ServiceRole: !Ref rCodeBuildRole
       TimeoutInMinutes: 40
@@ -666,7 +666,7 @@ Resources:
       EncryptionKey: !Ref pSharedDevOpsAccountKmsKeyArn
       Environment:
         ComputeType: BUILD_GENERAL1_SMALL
-        Image: aws/codebuild/standard:4.0
+        Image: aws/codebuild/amazonlinux2-x86_64-standard:4.0
         Type: LINUX_CONTAINER
         EnvironmentVariables:
           - Name: ENV

--- a/sdlf-cicd/template-cicd-team-repos.yaml
+++ b/sdlf-cicd/template-cicd-team-repos.yaml
@@ -124,7 +124,7 @@ Resources:
       BadgeEnabled: false
       Environment:
         ComputeType: BUILD_GENERAL1_SMALL
-        Image: aws/codebuild/standard:4.0
+        Image: aws/codebuild/amazonlinux2-x86_64-standard:4.0
         Type: LINUX_CONTAINER
       ServiceRole: !Ref rTeamReposCodeBuildRole
       TimeoutInMinutes: 20

--- a/sdlf-cicd/template-codecommit-pr-check.yaml
+++ b/sdlf-cicd/template-codecommit-pr-check.yaml
@@ -189,7 +189,7 @@ Resources:
       EncryptionKey: !Ref pKMSKeyArn
       Environment:
         ComputeType: BUILD_GENERAL1_SMALL
-        Image: aws/codebuild/standard:4.0
+        Image: aws/codebuild/amazonlinux2-x86_64-standard:4.0
         Type: LINUX_CONTAINER
       ServiceRole: !GetAtt rCodeBuildRole.Arn
       Source:

--- a/sdlf-team/nested-stacks/template-cicd.yaml
+++ b/sdlf-team/nested-stacks/template-cicd.yaml
@@ -134,7 +134,7 @@ Resources:
             Type: PLAINTEXT
             Value: !Ref pCodeBuildPublishLayerRoleArn
         ComputeType: BUILD_GENERAL1_SMALL
-        Image: aws/codebuild/standard:4.0
+        Image: aws/codebuild/amazonlinux2-x86_64-standard:4.0
         Type: LINUX_CONTAINER
       QueuedTimeoutInMinutes: 60
       ServiceRole: !Ref pCodeBuildServiceRoleArn
@@ -183,7 +183,7 @@ Resources:
             Type: PLAINTEXT
             Value: !Ref pCodeBuildPublishLayerRoleArn
         ComputeType: BUILD_GENERAL1_SMALL
-        Image: aws/codebuild/standard:4.0
+        Image: aws/codebuild/amazonlinux2-x86_64-standard:4.0
         Type: LINUX_CONTAINER
       QueuedTimeoutInMinutes: 60
       ServiceRole: !Ref pCodeBuildServiceRoleArn
@@ -224,7 +224,7 @@ Resources:
             Type: PLAINTEXT
             Value: !Ref pMinimumTestCoverage
         ComputeType: BUILD_GENERAL1_SMALL
-        Image: aws/codebuild/standard:4.0
+        Image: aws/codebuild/amazonlinux2-x86_64-standard:4.0
         Type: LINUX_CONTAINER
       ServiceRole: !Ref pCodeBuildServiceRoleArn
       TimeoutInMinutes: 20
@@ -281,7 +281,7 @@ Resources:
             Type: PLAINTEXT
             Value: !Ref pCodeBuildPublishLayerRoleArn
         ComputeType: BUILD_GENERAL1_SMALL
-        Image: aws/codebuild/standard:4.0
+        Image: aws/codebuild/amazonlinux2-x86_64-standard:4.0
         Type: LINUX_CONTAINER
       QueuedTimeoutInMinutes: 60
       ServiceRole: !Ref pCodeBuildServiceRoleArn
@@ -332,7 +332,7 @@ Resources:
             Type: PLAINTEXT
             Value: !Ref pTeamName
         ComputeType: BUILD_GENERAL1_SMALL
-        Image: aws/codebuild/standard:4.0
+        Image: aws/codebuild/amazonlinux2-x86_64-standard:4.0
         Type: LINUX_CONTAINER
       QueuedTimeoutInMinutes: 60
       ServiceRole: !Ref pTransformValidateRoleArn
@@ -363,7 +363,7 @@ Resources:
       EncryptionKey: !Ref pKMSInfraKeyId
       Environment:
         ComputeType: BUILD_GENERAL1_SMALL
-        Image: aws/codebuild/standard:4.0
+        Image: aws/codebuild/amazonlinux2-x86_64-standard:4.0
         Type: LINUX_CONTAINER
       ServiceRole: !Ref pCICDCodeBuildRoleArn
       TimeoutInMinutes: 20
@@ -401,7 +401,7 @@ Resources:
       EncryptionKey: !Ref pKMSInfraKeyId
       Environment:
         ComputeType: BUILD_GENERAL1_SMALL
-        Image: aws/codebuild/standard:4.0
+        Image: aws/codebuild/amazonlinux2-x86_64-standard:4.0
         Type: LINUX_CONTAINER
       ServiceRole: !Ref pCICDCodeBuildRoleArn
       TimeoutInMinutes: 20


### PR DESCRIPTION
ubuntu 18.04 to ubuntu 22.04

https://docs.aws.amazon.com/codebuild/latest/userguide/build-env-ref-available.html

*Issue #, if available:*
- #111 

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
