### PR TITLE
Deploy failed when you deploy a new environment

### DIFF
--- a/sdlf-cicd/template-cicd-child-foundations.yaml
+++ b/sdlf-cicd/template-cicd-child-foundations.yaml
@@ -301,6 +301,7 @@ Resources:
                   - sns:SetTopicAttributes
                   - sns:Subscribe
                   - sns:Unsubscribe
+                  - sns:TagResource
               - Resource: "*"
                 Effect: Allow
                 Action:


### PR DESCRIPTION
These was the error:


Resource handler returned message: "User:
arn:aws:sts::XXXXXXXXXXXX:a ssumed-role/sdlf-cicd-codebuild/AWSCodeBuild-ea3e3133-a258-45f6-b2f0-2300b7891f3 is not authorized to perform: SNS: TagResource on resource:
GERANSESTISSATES-
east-1:033756173027:sdlf-notifications because no identity-based policy allows the SNS:TagResource action (Service: Sns, Status Code: 403, Request ID:
f93cd922-18ec-5223-a32d-854529f9fe0c)"
(RequestToken: affe9cad-404a-9284-2a17-ea95c384f9a, HandlerErrorCode: ÁccessDenied)

The error was fixed manually adding the sns:TagResource to the role: sdlf-cicd-codebuild in IAM services. To avoid future problems is necessary add these permission in the template that create the role.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
