### PR TITLE
Allow sdlf-team to create consistent user groups for a team

### DIFF
--- a/sdlf-cicd/template-cicd-child-foundations.yaml
+++ b/sdlf-cicd/template-cicd-child-foundations.yaml
@@ -200,6 +200,7 @@ Resources:
                   - iam:UntagRole
                   - iam:UpdateRole
                   - iam:UpdateRoleDescription
+                  - iam:UpdateAssumeRolePolicy # so we can update the management account access
               - Resource: !Sub arn:aws:iam::${AWS::AccountId}:policy/sdlf-*
                 Effect: Allow
                 Action:
@@ -209,6 +210,16 @@ Resources:
                   - iam:DeletePolicyVersion
                   - iam:GetPolicy
                   - iam:GetPolicyVersion
+              - Resource: !Sub arn:aws:iam::${AWS::AccountId}:group/sdlf-*
+                Effect: Allow
+                Action:
+                  - iam:CreateGroup
+                  - iam:DeleteGroup
+                  - iam:GetGroup*
+                  - iam:AttachGroupPolicy
+                  - iam:PutGroupPolicy
+                  - iam:DeleteGroupPolicy
+                  - iam:DetachGroupPolicy
               - Resource: "*"
                 Effect: "Allow"
                 Action: lambda:ListFunctions


### PR DESCRIPTION
*Issue #, if available: NA 

*Description of changes:*

This change enables the sdlf-team pipeline to create groups along with a team. 

*Why do I want this?*

I have created an SDLF datalake that caters to users from a number of different teams. Within each of those teams there are users with different perspectives / skillsets. The best way I have found to manage these users is to add them to groups based on their "type" e.g. *analyst*, *data-engineer* etc.

In order to create these groups consistently for each team I have added them to the `template-iam.yaml` in sdlf-teams. This is implementation specific so I won't include that in this PR. However, the permissions in `sdlf-cicd/template-cicd-child-foundations.yaml` that are required to create groups are generalised for this use case so I have included these in this PR.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
