### PR TITLE
AWS Partition Support

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -103,6 +103,7 @@ fi
 
 DEVOPS_ACCOUNT=$(aws sts get-caller-identity --query 'Account' --output text --profile "$DEVOPS_PROFILE")
 CHILD_ACCOUNT=$(aws sts get-caller-identity --query 'Account' --output text --profile "$CHILD_PROFILE")
+AWS_PARTITION=$(aws sts get-caller-identity --query 'Arn' --output text --profile "$DEVOPS_PROFILE" | cut -d':' -f2)
 
 function bootstrap_repository()
 {
@@ -242,7 +243,7 @@ fi
 if "$cflag"
 then
     # Increase SSM Parameter Store throughput to 1,000 requests/second
-    aws ssm update-service-setting --setting-id arn:aws:ssm:"$REGION:$CHILD_ACCOUNT":servicesetting/ssm/parameter-store/high-throughput-enabled --setting-value true --region "$REGION" --profile "$CHILD_PROFILE"
+    aws ssm update-service-setting --setting-id arn:"$AWS_PARTITION":ssm:"$REGION:$CHILD_ACCOUNT":servicesetting/ssm/parameter-store/high-throughput-enabled --setting-value true --region "$REGION" --profile "$CHILD_PROFILE"
     DEVOPS_ACCOUNT_KMS=$(aws ssm get-parameter --name /SDLF/KMS/"$ENV"/CICDKeyId --region "$REGION" --profile "$DEVOPS_PROFILE" --query "Parameter.Value" --output text)
     STACK_NAME=sdlf-cicd-child-foundations
     aws cloudformation deploy \

--- a/sdlf-cicd/template-cicd-child-foundations.yaml
+++ b/sdlf-cicd/template-cicd-child-foundations.yaml
@@ -70,26 +70,26 @@ Resources:
         Statement:
           - Effect: Allow
             Principal:
-              AWS: !Sub arn:aws:iam::${pSharedDevOpsAccountId}:root
+              AWS: !Sub arn:${AWS::Partition}:iam::${pSharedDevOpsAccountId}:root
             Action:
               - s3:GetBucketLocation
               - s3:ListBucket
             Resource:
-              - !Sub arn:aws:s3:::${rArtifactsBucket}
+              - !Sub arn:${AWS::Partition}:s3:::${rArtifactsBucket}
           - Effect: Allow
             Principal:
-              AWS: !Sub arn:aws:iam::${pSharedDevOpsAccountId}:root
+              AWS: !Sub arn:${AWS::Partition}:iam::${pSharedDevOpsAccountId}:root
             Action:
               - s3:Get*
               - s3:PutObject
             Resource:
-              - !Sub arn:aws:s3:::${rArtifactsBucket}/*
+              - !Sub arn:${AWS::Partition}:s3:::${rArtifactsBucket}/*
           - Effect: Deny
             Principal: "*"
             Action: s3:*
             Resource:
-              - !Sub arn:aws:s3:::${rArtifactsBucket}/*
-              - !Sub arn:aws:s3:::${rArtifactsBucket}
+              - !Sub arn:${AWS::Partition}:s3:::${rArtifactsBucket}/*
+              - !Sub arn:${AWS::Partition}:s3:::${rArtifactsBucket}
             Condition:
               Bool:
                 aws:SecureTransport: False
@@ -111,12 +111,12 @@ Resources:
           PolicyDocument:
             Version: 2012-10-17
             Statement:
-              - Resource: !Sub arn:aws:iam::${pSharedDevOpsAccountId}:role/sdlf-cicd-foundations-codecommit-${pEnvironment}
+              - Resource: !Sub arn:${AWS::Partition}:iam::${pSharedDevOpsAccountId}:role/sdlf-cicd-foundations-codecommit-${pEnvironment}
                 Effect: Allow
                 Action: sts:AssumeRole
               - Resource:
-                  - !Sub arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/sdlf-*
-                  - !Sub arn:aws:cloudformation:${AWS::Region}:aws:transform/*
+                  - !Sub arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/sdlf-*
+                  - !Sub arn:${AWS::Partition}:cloudformation:${AWS::Region}:aws:transform/*
                 Effect: Allow
                 Action:
                   - cloudformation:CreateChangeSet
@@ -135,7 +135,7 @@ Resources:
                   - cloudformation:GetTemplateSummary
                   - cloudformation:ListStacks
                   - cloudformation:ValidateTemplate
-              - Resource: !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/octagon-*
+              - Resource: !Sub arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/octagon-*
                 Effect: Allow
                 Action:
                   - dynamodb:CreateTable
@@ -149,7 +149,7 @@ Resources:
                   - dynamodb:UpdateTimeToLive
                   - dynamodb:DescribeContinuousBackups
                   - dynamodb:UpdateContinuousBackups
-              - Resource: !Sub arn:aws:events:${AWS::Region}:${AWS::AccountId}:rule/sdlf-*
+              - Resource: !Sub arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:rule/sdlf-*
                 Effect: Allow
                 Action:
                   - events:DeleteRule
@@ -159,7 +159,7 @@ Resources:
                   - events:PutRule
                   - events:PutTargets
                   - events:RemoveTargets
-              - Resource: !Sub arn:aws:iam::${AWS::AccountId}:role/*
+              - Resource: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/*
                 Effect: Allow
                 Action: iam:PassRole
                 Condition:
@@ -178,14 +178,14 @@ Resources:
                   - iam:ListPolicyVersions
                   - iam:ListRoles
                   - iam:ListRolePolicies
-              - Resource: !Sub arn:aws:iam::${pSharedDevOpsAccountId}:role/sdlf-cicd-team-codecommit-${pEnvironment}-*
+              - Resource: !Sub arn:${AWS::Partition}:iam::${pSharedDevOpsAccountId}:role/sdlf-cicd-team-codecommit-${pEnvironment}-*
                 Effect: Allow
                 Action: iam:PassRole
               - Resource:
-                  - !Sub arn:aws:iam::${AWS::AccountId}:role/sdlf-*
-                  - !Sub arn:aws:iam::${AWS::AccountId}:role/aws-service-role/*
-                  - !Sub arn:aws:iam::${AWS::AccountId}:role/service-role/*
-                  - !Sub arn:aws:iam::${AWS::AccountId}:role/state-machine/sdlf-*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/sdlf-*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/aws-service-role/*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/service-role/*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/state-machine/sdlf-*
                 Effect: Allow
                 Action:
                   - iam:AttachRolePolicy
@@ -200,7 +200,7 @@ Resources:
                   - iam:UntagRole
                   - iam:UpdateRole
                   - iam:UpdateRoleDescription
-              - Resource: !Sub arn:aws:iam::${AWS::AccountId}:policy/sdlf-*
+              - Resource: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:policy/sdlf-*
                 Effect: Allow
                 Action:
                   - iam:CreatePolicy
@@ -212,7 +212,7 @@ Resources:
               - Resource: "*"
                 Effect: "Allow"
                 Action: lambda:ListFunctions
-              - Resource: !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:sdlf-*
+              - Resource: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:sdlf-*
                 Effect: Allow
                 Action:
                   - lambda:AddPermission
@@ -252,7 +252,7 @@ Resources:
                   - states:ListStateMachines
                   - states:TagResource
                   - states:UntagResource
-              - Resource: !Sub "arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:sdlf-*"
+              - Resource: !Sub "arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:stateMachine:sdlf-*"
                 Effect: Allow
                 Action:
                   - states:DeleteStateMachine
@@ -264,9 +264,9 @@ Resources:
                   - logs:CreateLogGroup
                   - logs:DescribeLogGroups
               - Resource:
-                  - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:sdlf-*:log-stream:*
-                  - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/sdlf-*:log-stream:*
-                  - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/sdlf-*:log-stream:*
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:sdlf-*:log-stream:*
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/sdlf-*:log-stream:*
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/sdlf-*:log-stream:*
                 Effect: Allow
                 Action:
                   - logs:PutRetentionPolicy
@@ -277,7 +277,7 @@ Resources:
                   - logs:PutLogEvents
                   - logs:TagLogGroup
                   - logs:UntagLogGroup
-              - Resource: !Sub arn:aws:cloudwatch:${AWS::Region}:${AWS::AccountId}:alarm:sdlf-*
+              - Resource: !Sub arn:${AWS::Partition}:cloudwatch:${AWS::Region}:${AWS::AccountId}:alarm:sdlf-*
                 Effect: Allow
                 Action:
                   - cloudwatch:DeleteAlarms
@@ -288,10 +288,10 @@ Resources:
                   - cloudwatch:PutMetricAlarm
                   - cloudwatch:PutMetricData
                   - cloudwatch:SetAlarmState
-              - Resource: !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:*
+              - Resource: !Sub arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:*
                 Effect: Allow
                 Action: sns:ListTopics
-              - Resource: !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:sdlf-*
+              - Resource: !Sub arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:sdlf-*
                 Effect: Allow
                 Action:
                   - sns:CreateTopic
@@ -312,7 +312,7 @@ Resources:
                   - s3:List*
                   - s3:Put*
                   - s3:SetBucketEncryption
-              - Resource: !Sub arn:aws:codebuild:${AWS::Region}:${AWS::AccountId}:project/sdlf-*
+              - Resource: !Sub arn:${AWS::Partition}:codebuild:${AWS::Region}:${AWS::AccountId}:project/sdlf-*
                 Effect: Allow
                 Action:
                   - codebuild:BatchGetProjects
@@ -320,7 +320,7 @@ Resources:
                   - codebuild:CreateProject
                   - codebuild:DeleteProject
                   - codebuild:UpdateProject
-              - Resource: !Sub arn:aws:codepipeline:${AWS::Region}:${AWS::AccountId}:sdlf-*
+              - Resource: !Sub arn:${AWS::Partition}:codepipeline:${AWS::Region}:${AWS::AccountId}:sdlf-*
                 Effect: Allow
                 Action:
                   - codepipeline:CreatePipeline
@@ -328,10 +328,10 @@ Resources:
                   - codepipeline:GetPipelineState
                   - codepipeline:GetPipeline
                   - codepipeline:UpdatePipeline
-              - Resource: !Sub arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:*
+              - Resource: !Sub arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:*
                 Effect: Allow
                 Action: sqs:ListQueues
-              - Resource: !Sub arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:sdlf-*
+              - Resource: !Sub arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:sdlf-*
                 Effect: Allow
                 Action:
                   - sqs:AddPermission
@@ -349,7 +349,7 @@ Resources:
                   - sqs:SetQueueAttributes
                   - sqs:TagQueue
                   - sqs:UntagQueue
-              - Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/*
+              - Resource: !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/*
                 Effect: Allow
                 Action:
                   - ssm:AddTagsToResource
@@ -378,7 +378,7 @@ Resources:
                 Effect: Allow
                 Action:
                   - cloudtrail:DescribeTrails
-              - Resource: !Sub arn:aws:cloudtrail:${AWS::Region}:${AWS::AccountId}:trail/sdlf-*
+              - Resource: !Sub arn:${AWS::Partition}:cloudtrail:${AWS::Region}:${AWS::AccountId}:trail/sdlf-*
                 Effect: Allow
                 Action:
                   - cloudtrail:AddTags
@@ -403,8 +403,8 @@ Resources:
                   - kms:ListResourceTags
                   - kms:UpdateAlias
               - Resource:
-                  - !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/*
-                  - !Sub arn:aws:kms:${AWS::Region}:${pSharedDevOpsAccountId}:key/*
+                  - !Sub arn:${AWS::Partition}:kms:${AWS::Region}:${AWS::AccountId}:key/*
+                  - !Sub arn:${AWS::Partition}:kms:${AWS::Region}:${pSharedDevOpsAccountId}:key/*
                 Effect: Allow
                 Action:
                   - kms:CreateGrant
@@ -455,14 +455,14 @@ Resources:
                   - glue:UpdateCrawler
                   - glue:UpdateDatabase
                   - glue:UpdateJob
-              - Resource: !Sub arn:aws:es:${AWS::Region}:${AWS::AccountId}:domain/*
+              - Resource: !Sub arn:${AWS::Partition}:es:${AWS::Region}:${AWS::AccountId}:domain/*
                 Effect: Allow
                 Action:
                   - es:AddTags
                   - es:ListDomainNames
                   - es:ListTags
                   - es:RemoveTags
-              - Resource: !Sub arn:aws:es:${AWS::Region}:${AWS::AccountId}:domain/sdlf
+              - Resource: !Sub arn:${AWS::Partition}:es:${AWS::Region}:${AWS::AccountId}:domain/sdlf
                 Effect: Allow
                 Action:
                   - es:CreateElasticsearchDomain
@@ -509,8 +509,8 @@ Resources:
             Version: 2012-10-17
             Statement:
               - Resource:
-                  - !Sub arn:aws:s3:::${rArtifactsBucket}
-                  - !Sub arn:aws:s3:::${rArtifactsBucket}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${rArtifactsBucket}
+                  - !Sub arn:${AWS::Partition}:s3:::${rArtifactsBucket}/*
                 Effect: Allow
                 Action:
                   - s3:Get*
@@ -532,7 +532,7 @@ Resources:
                 Action:
                   - codebuild:StartBuild
                   - codebuild:BatchGetBuilds
-              - Resource: !Sub arn:aws:iam::${pSharedDevOpsAccountId}:role/sdlf-cicd-foundations-codecommit-${pEnvironment}
+              - Resource: !Sub arn:${AWS::Partition}:iam::${pSharedDevOpsAccountId}:role/sdlf-cicd-foundations-codecommit-${pEnvironment}
                 Effect: Allow
                 Action: sts:AssumeRole
 
@@ -557,8 +557,8 @@ Resources:
               - Effect: Allow
                 Action: codepipeline:StartPipelineExecution
                 Resource:
-                  - !Sub arn:aws:codepipeline:${AWS::Region}:${AWS::AccountId}:${rFoundationsCodePipeline}
-                  - !Sub arn:aws:codepipeline:${AWS::Region}:${AWS::AccountId}:${rTeamCodePipeline}
+                  - !Sub arn:${AWS::Partition}:codepipeline:${AWS::Region}:${AWS::AccountId}:${rFoundationsCodePipeline}
+                  - !Sub arn:${AWS::Partition}:codepipeline:${AWS::Region}:${AWS::AccountId}:${rTeamCodePipeline}
 
   # Role defined upstream due to Lake Formation PutDataLakeSettings constraints
   rDataLakeAdminRole:
@@ -576,9 +576,9 @@ Resources:
             Action:
               - sts:AssumeRole
       ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/service-role/AWSGlueServiceRole
-        - arn:aws:iam::aws:policy/AmazonS3FullAccess
-        - arn:aws:iam::aws:policy/AWSLakeFormationDataAdmin
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSGlueServiceRole
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/AmazonS3FullAccess
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/AWSLakeFormationDataAdmin
       Policies:
         - PolicyName: sdlf-lakeformation-admin
           PolicyDocument:
@@ -596,8 +596,8 @@ Resources:
                   - logs:CreateLogStream
                   - logs:PutLogEvents
                 Resource:
-                  - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/sdlf-*
-                  - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/glue/*
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/sdlf-*
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/glue/*
               - Sid: DynamoDBAccess
                 Effect: Allow
                 Action:
@@ -611,13 +611,13 @@ Resources:
                   - dynamodb:Scan
                   - dynamodb:UpdateItem
                 Resource:
-                  - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/octagon-*
+                  - !Sub arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/octagon-*
               - Sid: SSMAccess
                 Effect: Allow
                 Action:
                   - ssm:GetParameter
                   - ssm:GetParameters
-                Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/IAM/DataLakeAdminRoleArn
+                Resource: !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/IAM/DataLakeAdminRoleArn
 
   ######## CODEBUILD #########
   rFoundationsCodeBuildProject:
@@ -678,7 +678,7 @@ Resources:
           - Name: CHILD_ACCOUNT_ID
             Value: !Ref AWS::AccountId
           - Name: CROSS_ACCOUNT_ROLE_ARN
-            Value: !Sub arn:aws:iam::${pSharedDevOpsAccountId}:role/sdlf-cicd-foundations-codecommit-${pEnvironment}
+            Value: !Sub arn:${AWS::Partition}:iam::${pSharedDevOpsAccountId}:role/sdlf-cicd-foundations-codecommit-${pEnvironment}
       ServiceRole: !Ref rCodeBuildRole
       TimeoutInMinutes: 20
       Source:
@@ -719,7 +719,7 @@ Resources:
         - Name: Source
           Actions:
             - Name: cicd-foundations
-              RoleArn: !Sub arn:aws:iam::${pSharedDevOpsAccountId}:role/sdlf-cicd-foundations-codecommit-${pEnvironment}
+              RoleArn: !Sub arn:${AWS::Partition}:iam::${pSharedDevOpsAccountId}:role/sdlf-cicd-foundations-codecommit-${pEnvironment}
               ActionTypeId:
                 Category: Source
                 Owner: AWS
@@ -765,7 +765,7 @@ Resources:
         - Name: Source
           Actions:
             - Name: cicd-team
-              RoleArn: !Sub arn:aws:iam::${pSharedDevOpsAccountId}:role/sdlf-cicd-foundations-codecommit-${pEnvironment}
+              RoleArn: !Sub arn:${AWS::Partition}:iam::${pSharedDevOpsAccountId}:role/sdlf-cicd-foundations-codecommit-${pEnvironment}
               ActionTypeId:
                 Category: Source
                 Owner: AWS
@@ -821,7 +821,7 @@ Resources:
         detail-type:
           - CodeCommit Repository State Change
         resources:
-          - !Sub arn:aws:codecommit:${AWS::Region}:${pSharedDevOpsAccountId}:${pFoundationsRepository}
+          - !Sub arn:${AWS::Partition}:codecommit:${AWS::Region}:${pSharedDevOpsAccountId}:${pFoundationsRepository}
         detail:
           event:
             - referenceCreated
@@ -831,7 +831,7 @@ Resources:
           referenceName:
             - !FindInMap [pCodeCommitBranch, !Ref pEnvironment, branch]
       Targets:
-        - Arn: !Sub arn:aws:codepipeline:${AWS::Region}:${AWS::AccountId}:${rFoundationsCodePipeline}
+        - Arn: !Sub arn:${AWS::Partition}:codepipeline:${AWS::Region}:${AWS::AccountId}:${rFoundationsCodePipeline}
           RoleArn: !GetAtt rCloudWatchRepositoryTriggerRole.Arn
           Id: sdlf-cicd-foundations
 
@@ -845,7 +845,7 @@ Resources:
         detail-type:
           - CodeCommit Repository State Change
         resources:
-          - !Sub arn:aws:codecommit:${AWS::Region}:${pSharedDevOpsAccountId}:${pTeamFoundationsRepository}
+          - !Sub arn:${AWS::Partition}:codecommit:${AWS::Region}:${pSharedDevOpsAccountId}:${pTeamFoundationsRepository}
         detail:
           event:
             - referenceCreated
@@ -855,7 +855,7 @@ Resources:
           referenceName:
             - !FindInMap [pCodeCommitBranch, !Ref pEnvironment, branch]
       Targets:
-        - Arn: !Sub arn:aws:codepipeline:${AWS::Region}:${AWS::AccountId}:${rTeamCodePipeline}
+        - Arn: !Sub arn:${AWS::Partition}:codepipeline:${AWS::Region}:${AWS::AccountId}:${rTeamCodePipeline}
           RoleArn: !GetAtt rCloudWatchRepositoryTriggerRole.Arn
           Id: sdlf-cicd-team
 

--- a/sdlf-cicd/template-cicd-shared-foundations.yaml
+++ b/sdlf-cicd/template-cicd-shared-foundations.yaml
@@ -44,13 +44,13 @@ Resources:
           - Sid: Allow administration of the key
             Effect: Allow
             Principal:
-              AWS: !Sub arn:aws:iam::${AWS::AccountId}:root
+              AWS: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:root
             Action: kms:*
             Resource: "*"
           - Sid: Allow child account use
             Effect: Allow
             Principal:
-              AWS: !Sub arn:aws:iam::${pChildAccountId}:root
+              AWS: !Sub arn:${AWS::Partition}:iam::${pChildAccountId}:root
             Action:
               - kms:Encrypt
               - kms:Decrypt
@@ -63,7 +63,7 @@ Resources:
           - Sid: Allow child account grant
             Effect: Allow
             Principal:
-              AWS: !Sub arn:aws:iam::${pChildAccountId}:root
+              AWS: !Sub arn:${AWS::Partition}:iam::${pChildAccountId}:root
             Action:
               - kms:CreateGrant
               - kms:ListGrants
@@ -104,7 +104,7 @@ Resources:
           - Effect: Allow
             Principal:
               AWS:
-                - !Sub arn:aws:iam::${pChildAccountId}:root
+                - !Sub arn:${AWS::Partition}:iam::${pChildAccountId}:root
             Action:
               - sts:AssumeRole
       Policies:
@@ -136,16 +136,16 @@ Resources:
                   - codecommit:List*
                   - codecommit:UploadArchive
                 Resource:
-                  - !Sub arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:${pFoundationsRepository}
-                  - !Sub arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:${pTeamFoundationsRepository}
+                  - !Sub arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:${pFoundationsRepository}
+                  - !Sub arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:${pTeamFoundationsRepository}
               - Effect: Allow
                 Action:
                   - s3:Get*
                   - s3:ListBucket*
                   - s3:Put*
                 Resource:
-                  - !Sub arn:aws:s3:::sdlf-cfn-artifacts-${AWS::Region}-${pChildAccountId}
-                  - !Sub arn:aws:s3:::sdlf-cfn-artifacts-${AWS::Region}-${pChildAccountId}/*
+                  - !Sub arn:${AWS::Partition}:s3:::sdlf-cfn-artifacts-${AWS::Region}-${pChildAccountId}
+                  - !Sub arn:${AWS::Partition}:s3:::sdlf-cfn-artifacts-${AWS::Region}-${pChildAccountId}/*
               - Effect: Allow
                 Action:
                   - kms:Decrypt
@@ -158,7 +158,7 @@ Resources:
               - Effect: Allow
                 Action:
                   - iam:GetRole
-                Resource: !Sub arn:aws:iam::${AWS::AccountId}:role/sdlf-cicd-team-codecommit-*
+                Resource: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/sdlf-cicd-team-codecommit-*
 
   rCodeCommitTriggerRule:
     Condition: CrossAccount
@@ -170,8 +170,8 @@ Resources:
         detail-type:
           - CodeCommit Repository State Change
         resources:
-          - !Sub arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:${pFoundationsRepository}
-          - !Sub arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:${pTeamFoundationsRepository}
+          - !Sub arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:${pFoundationsRepository}
+          - !Sub arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:${pTeamFoundationsRepository}
         detail:
           event:
             - referenceCreated
@@ -182,7 +182,7 @@ Resources:
             - !FindInMap [pCodeCommitBranch, !Ref pEnvironment, branch]
       State: ENABLED
       Targets:
-        - Arn: !Sub arn:aws:events:${AWS::Region}:${pChildAccountId}:event-bus/default
+        - Arn: !Sub arn:${AWS::Partition}:events:${AWS::Region}:${pChildAccountId}:event-bus/default
           Id: !Sub sdlf-cicd-foundations-codecommit-${pEnvironment}
           RoleArn: !GetAtt rEventBusRole.Arn
 
@@ -206,7 +206,7 @@ Resources:
             Statement:
               - Effect: Allow
                 Action: events:PutEvents
-                Resource: !Sub arn:aws:events:${AWS::Region}:${pChildAccountId}:event-bus/default
+                Resource: !Sub arn:${AWS::Partition}:events:${AWS::Region}:${pChildAccountId}:event-bus/default
 
   rKMSKeySsm:
     Type: AWS::SSM::Parameter

--- a/sdlf-cicd/template-cicd-team-repos.yaml
+++ b/sdlf-cicd/template-cicd-team-repos.yaml
@@ -36,7 +36,7 @@ Resources:
                   - codecommit:UploadArchive
                   - codecommit:AssociateApprovalRuleTemplateWithRepository
                   - codecommit:CreateApprovalRuleTemplate
-              - Resource: !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:sdlf-repo-notifications-*
+              - Resource: !Sub arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:sdlf-repo-notifications-*
                 Effect: Allow
                 Action:
                   - SNS:GetTopicAttributes
@@ -44,7 +44,7 @@ Resources:
                   - SNS:Subscribe
                   - SNS:SetTopicAttributes
                   - SNS:ListSubscriptionsByTopic
-              - Resource: !Sub arn:aws:events:${AWS::Region}:${AWS::AccountId}:rule/sdlf-pr-created-*
+              - Resource: !Sub arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:rule/sdlf-pr-created-*
                 Effect: Allow
                 Action:
                   - events:DescribeRule
@@ -52,7 +52,7 @@ Resources:
                   - events:PutRule
                   - events:PutTargets
                   - events:RemoveTargets
-              - Resource: !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:sdlf-cr-sns-topic-endpoints-subscription
+              - Resource: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:sdlf-cr-sns-topic-endpoints-subscription
                 Effect: Allow
                 Action:
                   - lambda:InvokeFunction
@@ -64,7 +64,7 @@ Resources:
                   - logs:DescribeLogGroups
                   - logs:DescribeLogStreams
                   - logs:PutLogEvents
-              - Resource: !Sub arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/sdlf-crossaccount-role-*
+              - Resource: !Sub arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/sdlf-crossaccount-role-*
                 Effect: Allow
                 Action:
                   - cloudformation:CreateChangeSet
@@ -76,15 +76,15 @@ Resources:
                   - cloudformation:ExecuteChangeSet
                   - cloudformation:SetStackPolicy
                   - cloudformation:UpdateStack
-              - Resource: !Sub arn:aws:iam::${AWS::AccountId}:role/*
+              - Resource: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/*
                 Effect: Allow
                 Action:
                   - iam:ListRoles
-              - Resource: !Sub arn:aws:iam::${AWS::AccountId}:role/sdlf-cicd-foundations-eventbus-*
+              - Resource: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/sdlf-cicd-foundations-eventbus-*
                 Effect: Allow
                 Action:
                   - iam:PassRole
-              - Resource: !Sub arn:aws:iam::${AWS::AccountId}:role/sdlf-cicd-team-codecommit-*
+              - Resource: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/sdlf-cicd-team-codecommit-*
                 Effect: Allow
                 Action:
                   - iam:AttachRolePolicy
@@ -100,7 +100,7 @@ Resources:
                   - iam:UntagRole
                   - iam:UpdateRole
                   - iam:UpdateRoleDescription
-              - Resource: !Sub "arn:aws:events:${AWS::Region}:${AWS::AccountId}:rule/sdlf-cicd-team-codecommit-*"
+              - Resource: !Sub "arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:rule/sdlf-cicd-team-codecommit-*"
                 Effect: "Allow"
                 Action:
                   - events:DescribeRule
@@ -108,7 +108,7 @@ Resources:
                   - events:PutRule
                   - events:PutTargets
                   - events:RemoveTargets
-              - Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/Misc/*
+              - Resource: !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/Misc/*
                 Effect: Allow
                 Action:
                   - ssm:GetParameter
@@ -161,7 +161,7 @@ Resources:
         detail-type:
           - CodeCommit Repository State Change
         resources:
-          - !Sub arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:${pTeamFoundationsRepository}
+          - !Sub arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:${pTeamFoundationsRepository}
         detail:
           event:
             - referenceCreated
@@ -202,7 +202,7 @@ Resources:
                   - logs:PutLogEvents
                 Effect: Allow
                 Resource:
-                  - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:*
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:*
                 Sid: LogAccessPolicy
               - Action:
                   - codecommit:BatchGetCommits
@@ -215,7 +215,7 @@ Resources:
                   - codecommit:GetTree
                 Effect: Allow
                 Resource:
-                  - !Sub arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:${pTeamFoundationsRepository}
+                  - !Sub arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:${pTeamFoundationsRepository}
                 Sid: CodeCommitRead
               - Action:
                   - codebuild:StartBuild

--- a/sdlf-cicd/template-codecommit-pr-check.yaml
+++ b/sdlf-cicd/template-codecommit-pr-check.yaml
@@ -67,7 +67,7 @@ Resources:
                   - logs:AssociateKmsKey
                   - logs:CreateLogStream
                   - logs:PutLogEvents
-                Resource: !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/${pTargetRepositoryName}-pr-function*
+                Resource: !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/${pTargetRepositoryName}-pr-function*
               - Effect: Allow
                 Action:
                   - codecommit:BatchGet*
@@ -75,7 +75,7 @@ Resources:
                   - codecommit:Describe*
                   - codecommit:PostCommentForPullRequest
                 Resource:
-                  - !Sub arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:${pTargetRepositoryName}
+                  - !Sub arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:${pTargetRepositoryName}
               - Effect: Allow
                 Action:
                   - kms:CreateGrant
@@ -169,7 +169,7 @@ Resources:
                   - logs:DescribeLogStreams
                   - logs:PutLogEvents
                 Resource:
-                  - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:*
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:*
               - Effect: "Allow"
                 Action:
                   - codecommit:BatchGet*
@@ -179,7 +179,7 @@ Resources:
                   - codecommit:List*
                   - codecommit:GitPull
                 Resource:
-                  - !Sub arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:${pTargetRepositoryName}
+                  - !Sub arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:${pTargetRepositoryName}
 
   rPRCodeBuildProject:
     Type: AWS::CodeBuild::Project
@@ -242,7 +242,7 @@ Resources:
         detail-type:
           - "CodeCommit Pull Request State Change"
         resources:
-          - !Sub arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:${pTargetRepositoryName}
+          - !Sub arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:${pTargetRepositoryName}
         detail:
           event:
             - "pullRequestSourceBranchUpdated"
@@ -316,7 +316,7 @@ Resources:
                   - logs:CreateLogStream
                   - logs:PutLogEvents
                   - logs:AssociateKmsKey
-                Resource: !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/${pTargetRepositoryName}-cb-result-function*
+                Resource: !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/${pTargetRepositoryName}-cb-result-function*
               - Effect: Allow
                 Action:
                   - codecommit:BatchGet*
@@ -324,7 +324,7 @@ Resources:
                   - codecommit:Describe*
                   - codecommit:PostCommentForPullRequest
                 Resource:
-                  - !Sub arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:${pTargetRepositoryName}
+                  - !Sub arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:${pTargetRepositoryName}
               - Effect: Allow
                 Action:
                   - kms:CreateGrant

--- a/sdlf-datalakeLibrary/python/datalake_library/octagon/metric.py
+++ b/sdlf-datalakeLibrary/python/datalake_library/octagon/metric.py
@@ -291,7 +291,8 @@ class MetricAPI:
             raise ValueError(f"Wrong evaluation operation: {evaluation}")
 
     def _get_topic_arn(self, name):
-        if "arn:aws:sns:" in name:
+        partition = self.client.get_partition_for_region(self.client.region)
+        if name.startswith(f"arn:{partition}:"):
             return name
         else:
-            return ":".join(["arn", "aws", "sns", self.client.region, self.client.account_id, name])
+            return ":".join(["arn", partition, "sns", self.client.region, self.client.account_id, name])

--- a/sdlf-dataset/template.yaml
+++ b/sdlf-dataset/template.yaml
@@ -75,7 +75,7 @@ Resources:
       ScheduleExpression: "cron(*/5 * * * ? *)"
       Targets:
         - Id: !Sub sdlf-${pTeamName}-${pDatasetName}-rule-b
-          Arn: !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:sdlf-${pTeamName}-${pPipelineName}-routing-b
+          Arn: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:sdlf-${pTeamName}-${pPipelineName}-routing-b
           Input: !Sub |
             {
               "team": "${pTeamName}",

--- a/sdlf-foundations/nested-stacks/template-cloudtrail.yaml
+++ b/sdlf-foundations/nested-stacks/template-cloudtrail.yaml
@@ -93,7 +93,7 @@ Resources:
             Principal:
               Service: cloudtrail.amazonaws.com
             Action: s3:GetBucketAcl
-            Resource: !Sub arn:aws:s3:::${rTrailBucket}
+            Resource: !Sub arn:${AWS::Partition}:s3:::${rTrailBucket}
           - Sid: AWSCloudTrailWrite
             Effect: Allow
             Principal:
@@ -102,8 +102,8 @@ Resources:
             Resource:
               !If [
                 HasLogFilePrefix,
-                !Sub "arn:aws:s3:::${rTrailBucket}/${pLogFilePrefix}/AWSLogs/${AWS::AccountId}/*",
-                !Sub "arn:aws:s3:::${rTrailBucket}/AWSLogs/${AWS::AccountId}/*",
+                !Sub "arn:${AWS::Partition}:s3:::${rTrailBucket}/${pLogFilePrefix}/AWSLogs/${AWS::AccountId}/*",
+                !Sub "arn:${AWS::Partition}:s3:::${rTrailBucket}/AWSLogs/${AWS::AccountId}/*",
               ]
             Condition:
               StringEquals:
@@ -113,8 +113,8 @@ Resources:
             Principal: "*"
             Action: s3:*
             Resource:
-              - !Sub arn:aws:s3:::${rTrailBucket}/*
-              - !Sub arn:aws:s3:::${rTrailBucket}
+              - !Sub arn:${AWS::Partition}:s3:::${rTrailBucket}/*
+              - !Sub arn:${AWS::Partition}:s3:::${rTrailBucket}
             Condition:
               Bool:
                 aws:SecureTransport: False
@@ -156,18 +156,16 @@ Resources:
       IsLogging: true
       IsMultiRegionTrail: false
       EventSelectors:
-        !If [
-          IsS3DataEvents,
-          [
-            {
-              DataResources:
-                [{ Type: "AWS::S3::Object", Values: ["arn:aws:s3:::"] }],
-              IncludeManagementEvents: true,
-              ReadWriteType: All,
-            },
-          ],
-          !Ref "AWS::NoValue",
-        ]
+      EventSelectors: !If
+        - IsS3DataEvents
+        -
+          - DataResources:
+            - Type: AWS::S3::Object
+              Values:
+                - !Sub "arn:${AWS::Partition}:s3"
+            IncludeManagementEvents: true
+            ReadWriteType: All
+        - !Ref "AWS::NoValue"
       KMSKeyId: !Ref pKMSKeyId
       S3BucketName: !Ref rTrailBucket
       S3KeyPrefix: !Ref pLogFilePrefix
@@ -182,19 +180,16 @@ Resources:
       IncludeGlobalServiceEvents: true
       IsLogging: true
       IsMultiRegionTrail: true
-      EventSelectors:
-        !If [
-          IsS3DataEvents,
-          [
-            {
-              DataResources:
-                [{ Type: "AWS::S3::Object", Values: ["arn:aws:s3:::"] }],
-              IncludeManagementEvents: true,
-              ReadWriteType: All,
-            },
-          ],
-          !Ref "AWS::NoValue",
-        ]
+      EventSelectors: !If
+        - IsS3DataEvents
+        -
+          - DataResources:
+            - Type: AWS::S3::Object
+              Values:
+                - !Sub "arn:${AWS::Partition}:s3"
+            IncludeManagementEvents: true
+            ReadWriteType: All
+        - !Ref "AWS::NoValue"
       KMSKeyId: !Ref pKMSKeyId
       S3BucketName: !Ref pExternalTrailBucket
       S3KeyPrefix: !Ref pLogFilePrefix

--- a/sdlf-foundations/nested-stacks/template-glue.yaml
+++ b/sdlf-foundations/nested-stacks/template-glue.yaml
@@ -39,18 +39,18 @@ Resources:
           - Effect: Allow
             Action:
               - logs:CreateLogGroup
-            Resource: !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*
+            Resource: !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:*
           - Effect: Allow
             Action:
               - logs:CreateLogStream
               - logs:PutLogEvents
             Resource:
-              - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/sdlf-*
+              - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/sdlf-*
           - Effect: Allow
             Action:
               - ssm:GetParameter
               - ssm:GetParameters
-            Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/*
+            Resource: !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/*
           - Effect: Allow
             Action:
               - dynamodb:BatchGetItem
@@ -64,7 +64,7 @@ Resources:
               - dynamodb:Scan
               - dynamodb:UpdateItem
             Resource:
-              - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/octagon-*
+              - !Sub arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/octagon-*
           - Effect: Allow
             Action:
               - kms:CreateGrant

--- a/sdlf-foundations/nested-stacks/template-kibana.yaml
+++ b/sdlf-foundations/nested-stacks/template-kibana.yaml
@@ -191,7 +191,7 @@ Resources:
                   - logs:DescribeLogStreams
                   - logs:DescribeSubscriptionFilters
                   - logs:PutSubscriptionFilter
-                Resource: arn:aws:logs:*:*:log-group:*:log-stream*
+                Resource: !Sub arn:${AWS::Partition}:logs:*:*:log-group:*:log-stream*
               - Effect: Allow
                 Action:
                   - lambda:InvokeFunction
@@ -208,7 +208,7 @@ Resources:
                   - kms:ReEncrypt*
                 Resource: !Ref KMSKeyId
       ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
 
   rUpdateCloudWatchSubscriptionFilterFunction:
     Type: AWS::Serverless::Function
@@ -244,7 +244,7 @@ Resources:
                   - logs:CreateLogGroup
                   - logs:CreateLogStream
                   - logs:PutLogEvents
-                Resource: !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/*
+                Resource: !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/*
               - Effect: Allow
                 Action:
                   - es:DescribeElasticsearchDomain
@@ -253,7 +253,7 @@ Resources:
                   - es:ESHttpPost
                   - es:ESHttpGet
                   - es:ESHttpPut
-                Resource: !Sub arn:aws:es:${AWS::Region}:${AWS::AccountId}:domain/*
+                Resource: !Sub arn:${AWS::Partition}:es:${AWS::Region}:${AWS::AccountId}:domain/*
               - Effect: "Allow"
                 Action:
                   - dynamodb:DescribeStream
@@ -501,7 +501,7 @@ Resources:
                   - "cognito-sync:ListIdentityPoolUsage"
                   - "cognito-sync:SetCognitoEvents"
                   - "cognito-sync:SetIdentityPoolConfiguration"
-                Resource: !Sub "arn:aws:cognito-identity:${AWS::Region}:${AWS::AccountId}:identitypool/${IdentityPool}"
+                Resource: !Sub "arn:${AWS::Partition}:cognito-identity:${AWS::Region}:${AWS::AccountId}:identitypool/${IdentityPool}"
 
   # Create a role for authorized access to AWS resources.
   # Only allows users in the previously created Identity Pool
@@ -547,14 +547,14 @@ Resources:
                   - "cognito-identity:MergeDeveloperIdentities"
                   - "cognito-identity:UnlikeDeveloperIdentity"
                   - "cognito-identity:UpdateIdentityPool"
-                Resource: !Sub "arn:aws:cognito-identity:${AWS::Region}:${AWS::AccountId}:identitypool/${IdentityPool}"
+                Resource: !Sub "arn:${AWS::Partition}:cognito-identity:${AWS::Region}:${AWS::AccountId}:identitypool/${IdentityPool}"
 
   CognitoESAccessRole:
     Type: "AWS::IAM::Role"
     # DeletionPolicy: Retain
     Properties:
       ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/AmazonESCognitoAccess
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/AmazonESCognitoAccess
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -652,11 +652,11 @@ Resources:
                   - logs:CreateLogGroup
                   - logs:CreateLogStream
                   - logs:PutLogEvents
-                Resource: arn:aws:logs:*:*:*
+                Resource: !Sub arn:${AWS::Partition}:logs:*:*:*
               - Effect: Allow
                 Action:
                   - es:UpdateElasticsearchDomainConfig
-                Resource: !Sub "arn:aws:es:${AWS::Region}:${AWS::AccountId}:domain/${DOMAINNAME}"
+                Resource: !Sub "arn:${AWS::Partition}:es:${AWS::Region}:${AWS::AccountId}:domain/${DOMAINNAME}"
               - Effect: Allow
                 Action:
                   - cognito-idp:CreateUserPoolDomain
@@ -708,7 +708,7 @@ Resources:
           - Effect: Allow
             Action:
               - es:ESHttpPost
-            Resource: !Sub arn:aws:es:${AWS::Region}:${AWS::AccountId}:domain/*
+            Resource: !Sub arn:${AWS::Partition}:es:${AWS::Region}:${AWS::AccountId}:domain/*
       Roles:
         - !Ref LoggingMasterRole
 
@@ -743,16 +743,16 @@ Resources:
               AWS:
                 - !Sub ${LoggingMasterRole.Arn}
             Effect: Allow
-            Resource: !Sub arn:aws:es:${AWS::Region}:${AWS::AccountId}:domain/* #removing domain name due to cyclic dependency
+            Resource: !Sub arn:${AWS::Partition}:es:${AWS::Region}:${AWS::AccountId}:domain/* #removing domain name due to cyclic dependency
           - Action: "es:*"
             Principal:
               AWS:
                 - !Sub
-                  - arn:aws:sts::${AWS::AccountId}:assumed-role/${AuthRole}/CognitoIdentityCredentials
+                  - arn:${AWS::Partition}:sts::${AWS::AccountId}:assumed-role/${AuthRole}/CognitoIdentityCredentials
                   - { AuthRole: !Ref CognitoAuthorizedRole }
                 - !Sub ${rLogStreamerRole.Arn}
             Effect: Allow
-            Resource: !Sub "arn:aws:es:${AWS::Region}:${AWS::AccountId}:domain/${DOMAINNAME}/*"
+            Resource: !Sub "arn:${AWS::Partition}:es:${AWS::Region}:${AWS::AccountId}:domain/${DOMAINNAME}/*"
       # V57095985 - 10/08/2018 - ES Domain needed configurations
       # https://github.com/awslabs/aws-centralized-logging/issues/2
       AdvancedOptions:

--- a/sdlf-foundations/nested-stacks/template-kms.yaml
+++ b/sdlf-foundations/nested-stacks/template-kms.yaml
@@ -22,7 +22,7 @@ Resources:
           - Sid: Allow administration of the key
             Effect: Allow
             Principal:
-              AWS: [!Sub "arn:aws:iam::${AWS::AccountId}:root"]
+              AWS: [!Sub "arn:${AWS::Partition}:iam::${AWS::AccountId}:root"]
             Action: kms:*
             Resource: "*"
           - Sid: Allow CloudTrail/CloudWatch alarms access

--- a/sdlf-foundations/nested-stacks/template-s3.yaml
+++ b/sdlf-foundations/nested-stacks/template-s3.yaml
@@ -61,8 +61,8 @@ Resources:
             Action: s3:*
             Effect: Deny
             Resource:
-              - !Sub arn:aws:s3:::${rPipelineBucket}/*
-              - !Sub arn:aws:s3:::${rPipelineBucket}
+              - !Sub arn:${AWS::Partition}:s3:::${rPipelineBucket}/*
+              - !Sub arn:${AWS::Partition}:s3:::${rPipelineBucket}
             Condition:
               Bool:
                 aws:SecureTransport: False
@@ -110,8 +110,8 @@ Resources:
             Action: s3:*
             Effect: Deny
             Resource:
-              - !Sub arn:aws:s3:::${rCentralBucket}/*
-              - !Sub arn:aws:s3:::${rCentralBucket}
+              - !Sub arn:${AWS::Partition}:s3:::${rCentralBucket}/*
+              - !Sub arn:${AWS::Partition}:s3:::${rCentralBucket}
             Condition:
               Bool:
                 aws:SecureTransport: False
@@ -121,7 +121,7 @@ Resources:
     Type: AWS::LakeFormation::Resource
     Condition: CreateSingleBucket
     Properties:
-      ResourceArn: !Sub arn:aws:s3:::${rCentralBucket}/
+      ResourceArn: !Sub arn:${AWS::Partition}:s3:::${rCentralBucket}/
       UseServiceLinkedRole: True
 
   rRawBucket:
@@ -165,8 +165,8 @@ Resources:
             Action: s3:*
             Effect: Deny
             Resource:
-              - !Sub arn:aws:s3:::${rRawBucket}/*
-              - !Sub arn:aws:s3:::${rRawBucket}
+              - !Sub arn:${AWS::Partition}:s3:::${rRawBucket}/*
+              - !Sub arn:${AWS::Partition}:s3:::${rRawBucket}
             Condition:
               Bool:
                 aws:SecureTransport: False
@@ -176,7 +176,7 @@ Resources:
     Type: AWS::LakeFormation::Resource
     Condition: CreateMultipleBuckets
     Properties:
-      ResourceArn: !Sub arn:aws:s3:::${rRawBucket}/
+      ResourceArn: !Sub arn:${AWS::Partition}:s3:::${rRawBucket}/
       UseServiceLinkedRole: True
 
   rStageBucket:
@@ -220,8 +220,8 @@ Resources:
             Action: s3:*
             Effect: Deny
             Resource:
-              - !Sub arn:aws:s3:::${rStageBucket}/*
-              - !Sub arn:aws:s3:::${rStageBucket}
+              - !Sub arn:${AWS::Partition}:s3:::${rStageBucket}/*
+              - !Sub arn:${AWS::Partition}:s3:::${rStageBucket}
             Condition:
               Bool:
                 aws:SecureTransport: False
@@ -231,7 +231,7 @@ Resources:
     Type: AWS::LakeFormation::Resource
     Condition: CreateMultipleBuckets
     Properties:
-      ResourceArn: !Sub arn:aws:s3:::${rStageBucket}/
+      ResourceArn: !Sub arn:${AWS::Partition}:s3:::${rStageBucket}/
       UseServiceLinkedRole: True
 
   rAnalyticsBucket:
@@ -275,8 +275,8 @@ Resources:
             Action: s3:*
             Effect: Deny
             Resource:
-              - !Sub arn:aws:s3:::${rAnalyticsBucket}/*
-              - !Sub arn:aws:s3:::${rAnalyticsBucket}
+              - !Sub arn:${AWS::Partition}:s3:::${rAnalyticsBucket}/*
+              - !Sub arn:${AWS::Partition}:s3:::${rAnalyticsBucket}
             Condition:
               Bool:
                 aws:SecureTransport: False
@@ -286,7 +286,7 @@ Resources:
     Type: AWS::LakeFormation::Resource
     Condition: CreateMultipleBuckets
     Properties:
-      ResourceArn: !Sub arn:aws:s3:::${rAnalyticsBucket}/
+      ResourceArn: !Sub arn:${AWS::Partition}:s3:::${rAnalyticsBucket}/
       UseServiceLinkedRole: True
 
   rDataQualityBucket:
@@ -319,8 +319,8 @@ Resources:
             Action: s3:*
             Effect: Deny
             Resource:
-              - !Sub arn:aws:s3:::${rDataQualityBucket}/*
-              - !Sub arn:aws:s3:::${rDataQualityBucket}
+              - !Sub arn:${AWS::Partition}:s3:::${rDataQualityBucket}/*
+              - !Sub arn:${AWS::Partition}:s3:::${rDataQualityBucket}
             Condition:
               Bool:
                 aws:SecureTransport: False
@@ -329,7 +329,7 @@ Resources:
   rDataQualityBucketLakeFormationS3Registration:
     Type: AWS::LakeFormation::Resource
     Properties:
-      ResourceArn: !Sub arn:aws:s3:::${rDataQualityBucket}/
+      ResourceArn: !Sub arn:${AWS::Partition}:s3:::${rDataQualityBucket}/
       UseServiceLinkedRole: True
 
   rAthenaBucket:
@@ -362,8 +362,8 @@ Resources:
             Action: s3:*
             Effect: Deny
             Resource:
-              - !Sub arn:aws:s3:::${rAthenaBucket}/*
-              - !Sub arn:aws:s3:::${rAthenaBucket}
+              - !Sub arn:${AWS::Partition}:s3:::${rAthenaBucket}/*
+              - !Sub arn:${AWS::Partition}:s3:::${rAthenaBucket}
             Condition:
               Bool:
                 aws:SecureTransport: False
@@ -522,20 +522,20 @@ Resources:
                     !If [
                       CreateMultipleBuckets,
                       [
-                        !Sub "arn:aws:s3:::${pCustomBucketPrefix}-raw",
-                        !Sub "arn:aws:s3:::${pCustomBucketPrefix}-stage",
-                        !Sub "arn:aws:s3:::${pCustomBucketPrefix}-analytics",
+                        !Sub "arn:${AWS::Partition}:s3:::${pCustomBucketPrefix}-raw",
+                        !Sub "arn:${AWS::Partition}:s3:::${pCustomBucketPrefix}-stage",
+                        !Sub "arn:${AWS::Partition}:s3:::${pCustomBucketPrefix}-analytics",
                       ],
-                      !Sub "arn:aws:s3:::${pCustomBucketPrefix}",
+                      !Sub "arn:${AWS::Partition}:s3:::${pCustomBucketPrefix}",
                     ],
                     !If [
                       CreateMultipleBuckets,
                       [
-                        !Sub "arn:aws:s3:::${pOrganizationName}-${pApplicationName}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}-raw",
-                        !Sub "arn:aws:s3:::${pOrganizationName}-${pApplicationName}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}-stage",
-                        !Sub "arn:aws:s3:::${pOrganizationName}-${pApplicationName}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}-analytics",
+                        !Sub "arn:${AWS::Partition}:s3:::${pOrganizationName}-${pApplicationName}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}-raw",
+                        !Sub "arn:${AWS::Partition}:s3:::${pOrganizationName}-${pApplicationName}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}-stage",
+                        !Sub "arn:${AWS::Partition}:s3:::${pOrganizationName}-${pApplicationName}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}-analytics",
                       ],
-                      !Sub "arn:aws:s3:::${pOrganizationName}-${pApplicationName}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}",
+                      !Sub "arn:${AWS::Partition}:s3:::${pOrganizationName}-${pApplicationName}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}",
                     ],
                   ]
               StringEquals:
@@ -578,12 +578,12 @@ Resources:
               - Effect: Allow
                 Action:
                   - logs:CreateLogGroup
-                Resource: !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*
+                Resource: !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:*
               - Effect: Allow
                 Action:
                   - logs:CreateLogStream
                   - logs:PutLogEvents
-                Resource: !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/sdlf-*
+                Resource: !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/sdlf-*
               - Effect: Allow
                 Action:
                   - sqs:DeleteMessage
@@ -597,7 +597,7 @@ Resources:
                   - sqs:SendMessage
                   - sqs:SendMessageBatch
                 Resource:
-                  - !Sub arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:sdlf-*
+                  - !Sub arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:sdlf-*
               - Effect: Allow
                 Action:
                   - dynamodb:BatchGetItem
@@ -611,7 +611,7 @@ Resources:
                   - dynamodb:Scan
                   - dynamodb:UpdateItem
                 Resource:
-                  - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/octagon-*
+                  - !Sub arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/octagon-*
               - Effect: Allow
                 Action:
                   - kms:CreateGrant

--- a/sdlf-foundations/nested-stacks/template-sns.yaml
+++ b/sdlf-foundations/nested-stacks/template-sns.yaml
@@ -60,27 +60,27 @@ Resources:
                   - logs:PutLogEvents
                 Effect: Allow
                 Resource:
-                  - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:*
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:*
                 Sid: LogAccessPolicy
               - Action:
                   - sns:Unsubscribe
                   - sns:Subscribe
                 Effect: Allow
                 Resource:
-                  - !Sub arn:aws:sns:${AWS::Region}:${AWS::AccountId}:sdlf-*
+                  - !Sub arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:sdlf-*
                 Sid: SNSSubscription
               - Action:
                   - ssm:GetParameter
                 Effect: Allow
                 Resource:
-                  - !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/*
+                  - !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/*
                 Sid: SSMGetParameter
               - Action:
                   - dynamodb:GetItem
                   - dynamodb:PutItem
                 Effect: Allow
                 Resource:
-                  - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/octagon-Teams-${pEnvironment}
+                  - !Sub arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/octagon-Teams-${pEnvironment}
                 Sid: DynamoDBControl
             Version: 2012-10-17
 
@@ -170,7 +170,7 @@ Resources:
           state:
             - FAILED
           pipeline:
-            - !Sub arn:aws:codepipeline:${AWS::Region}:${AWS::AccountId}:sdlf-cicd-foundations
+            - !Sub arn:${AWS::Partition}:codepipeline:${AWS::Region}:${AWS::AccountId}:sdlf-cicd-foundations
       State: ENABLED
       Targets:
         - Arn: !Ref rSNSTopic
@@ -194,7 +194,7 @@ Resources:
           state:
             - FAILED
           pipeline:
-            - !Sub arn:aws:codepipeline:${AWS::Region}:${AWS::AccountId}:sdlf-cicd-team
+            - !Sub arn:${AWS::Partition}:codepipeline:${AWS::Region}:${AWS::AccountId}:sdlf-cicd-team
       State: ENABLED
       Targets:
         - Arn: !Ref rSNSTopic

--- a/sdlf-pipeline/nested-stacks/template-statemachine.yaml
+++ b/sdlf-pipeline/nested-stacks/template-statemachine.yaml
@@ -55,7 +55,7 @@ Resources:
           Actions:
             -
               Name: Source
-              RoleArn: !Sub arn:aws:iam::${pSharedDevOpsAccountId}:role/sdlf-cicd-team-codecommit-${pEnv}-${pTeamName}
+              RoleArn: !Sub arn:${AWS::Partition}:iam::${pSharedDevOpsAccountId}:role/sdlf-cicd-team-codecommit-${pEnv}-${pTeamName}
               ActionTypeId:
                 Category: Source
                 Owner: AWS
@@ -156,7 +156,7 @@ Resources:
         detail-type:
           - CodeCommit Repository State Change
         resources:
-          - !Sub arn:aws:codecommit:${AWS::Region}:${pSharedDevOpsAccountId}:${pRepositoryName}
+          - !Sub arn:${AWS::Partition}:codecommit:${AWS::Region}:${pSharedDevOpsAccountId}:${pRepositoryName}
         detail:
           event:
             - referenceCreated
@@ -166,7 +166,7 @@ Resources:
           referenceName:
             - !Ref pBranchName
       Targets:
-        - Arn: !Sub arn:aws:codepipeline:${AWS::Region}:${AWS::AccountId}:${rStateMachinePipeline}
+        - Arn: !Sub arn:${AWS::Partition}:codepipeline:${AWS::Region}:${AWS::AccountId}:${rStateMachinePipeline}
           Id: !Sub sdlf-${pTeamName}-${pPipeline}-${pRepositoryName}-trigger
           RoleArn: !Ref pCloudWatchRepositoryTriggerRoleArn
 
@@ -185,7 +185,7 @@ Resources:
           project-name:
             - !Ref pBuildDatalakeLibrary
       Targets:
-        - Arn: !Sub arn:aws:codepipeline:${AWS::Region}:${AWS::AccountId}:${rStateMachinePipeline}
+        - Arn: !Sub arn:${AWS::Partition}:codepipeline:${AWS::Region}:${AWS::AccountId}:${rStateMachinePipeline}
           Id: !Sub sdlf-${pTeamName}-${pPipeline}-${pRepositoryName}-update
           RoleArn: !Ref pCloudWatchRepositoryTriggerRoleArn
 

--- a/sdlf-stageA/lambda/stage-a-process-object/test/test_template.yaml
+++ b/sdlf-stageA/lambda/stage-a-process-object/test/test_template.yaml
@@ -68,8 +68,7 @@ Resources:
           TEST: True
       Handler: lambda_function.lambda_handler
       MemorySize: 512
-      Role: >-
-        arn:aws:iam::509480599834:role/service-role/qs-transform-object-phase-a-role
+      Role: !Sub "arn:${AWS::Partition}:iam::509480599834:role/service-role/qs-transform-object-phase-a-role"
       Runtime: python3.9
       Timeout: 120
       Layers: 

--- a/sdlf-stageA/template.yaml
+++ b/sdlf-stageA/template.yaml
@@ -148,17 +148,17 @@ Resources:
           - Effect: Allow
             Action:
               - logs:CreateLogGroup
-            Resource: !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*
+            Resource: !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:*
           - Effect: Allow
             Action:
               - logs:CreateLogStream
               - logs:PutLogEvents
-            Resource: !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/sdlf-${pTeamName}-*
+            Resource: !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/sdlf-${pTeamName}-*
           - Effect: Allow
             Action:
               - ssm:GetParameter
               - ssm:GetParameters
-            Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/*
+            Resource: !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/*
           - Effect: Allow
             Action:
               - dynamodb:BatchGetItem
@@ -172,7 +172,7 @@ Resources:
               - dynamodb:Scan
               - dynamodb:UpdateItem
             Resource:
-              - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/octagon-*
+              - !Sub arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/octagon-*
           - Effect: Allow
             Action:
               - kms:CreateGrant
@@ -251,15 +251,15 @@ Resources:
                 Action:
                   - s3:ListBucket
                 Resource:
-                  - !Sub arn:aws:s3:::${pStageBucket}
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}
               - Effect: Allow
                 Action:
                   - s3:GetObject
                 Resource:
-                  - !Sub arn:aws:s3:::${pStageBucket}/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pStageBucket}/stage/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pStageBucket}/pre-stage/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pStageBucket}/post-stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/pre-stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/post-stage/${pTeamName}/*
 
   # Step2 Role
   rRoleLambdaExecutionStep2:
@@ -287,20 +287,20 @@ Resources:
                   - s3:GetBucketVersioning
                   - s3:ListBucket
                 Resource:
-                  - !Sub arn:aws:s3:::${pDatasetBucket}
-                  - !Sub arn:aws:s3:::${pStageBucket}
-                  - !Sub arn:aws:s3:::${pArtifactsBucket}
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}
+                  - !Sub arn:${AWS::Partition}:s3:::${pArtifactsBucket}
               - Effect: Allow
                 Action:
                   - s3:GetObject
                   - s3:PutObject
                 Resource:
-                  - !Sub arn:aws:s3:::${pDatasetBucket}/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pDatasetBucket}/raw/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pStageBucket}/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pStageBucket}/stage/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pStageBucket}/pre-stage/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pStageBucket}/post-stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}/raw/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/pre-stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/post-stage/${pTeamName}/*
               - Effect: Allow
                 Action:
                   - kms:DescribeKey
@@ -343,20 +343,20 @@ Resources:
                   - sqs:SendMessage
                   - sqs:SendMessageBatch
                 Resource:
-                  - !Sub arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - s3:ListBucket
                 Resource:
-                  - !Sub arn:aws:s3:::${pStageBucket}
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}
               - Effect: Allow
                 Action:
                   - s3:GetObject
                 Resource:
-                  - !Sub arn:aws:s3:::${pStageBucket}/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pStageBucket}/stage/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pStageBucket}/pre-stage/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pStageBucket}/post-stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/pre-stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/post-stage/${pTeamName}/*
 
   # Error Handling Lambda Role
   rRoleLambdaExecutionErrorStep:

--- a/sdlf-stageB/lambda/stage-b-process-data/test/test_template.yaml
+++ b/sdlf-stageB/lambda/stage-b-process-data/test/test_template.yaml
@@ -63,8 +63,7 @@ Resources:
           TEST: True
       Handler: lambda_function.lambda_handler
       MemorySize: 512
-      Role: >-
-        arn:aws:iam::509480599834:role/service-role/qs-transform-object-phase-a-role
+      Role: !Sub arn:${AWS::Partition}:iam::509480599834:role/service-role/qs-transform-object-phase-a-role
       Runtime: python3.9
       Timeout: 120
       Layers: 

--- a/sdlf-stageB/state-machine/stage-b.asl.json
+++ b/sdlf-stageB/state-machine/stage-b.asl.json
@@ -60,7 +60,7 @@
             },
             "Data Quality": {
               "Type":"Task",
-              "Resource":"arn:aws:states:::states:startExecution",
+              "Resource":"arn:${awsPartition}:states:::states:startExecution",
               "Parameters":{
                   "StateMachineArn":"${smDataQuality}",
                   "Input": {"body.$": "$.body"}

--- a/sdlf-stageB/template.yaml
+++ b/sdlf-stageB/template.yaml
@@ -120,17 +120,17 @@ Resources:
           - Effect: Allow
             Action:
               - logs:CreateLogGroup
-            Resource: !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*
+            Resource: !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:*
           - Effect: Allow
             Action:
               - logs:CreateLogStream
               - logs:PutLogEvents
-            Resource: !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/sdlf-${pTeamName}-*
+            Resource: !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/sdlf-${pTeamName}-*
           - Effect: Allow
             Action:
               - ssm:GetParameter
               - ssm:GetParameters
-            Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/*
+            Resource: !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/*
           - Effect: Allow
             Action:
               - dynamodb:BatchGetItem
@@ -144,7 +144,7 @@ Resources:
               - dynamodb:Scan
               - dynamodb:UpdateItem
             Resource:
-              - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/octagon-*
+              - !Sub arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/octagon-*
           - Effect: Allow
             Action:
               - kms:CreateGrant
@@ -195,7 +195,7 @@ Resources:
                   - sqs:SendMessage
                   - sqs:SendMessageBatch
                 Resource:
-                  - !Sub arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
 
   # Step1 Role
   rRoleLambdaExecutionStep1:
@@ -222,23 +222,23 @@ Resources:
                 Action:
                   - s3:ListBucket
                 Resource:
-                  - !Sub arn:aws:s3:::${pDatasetBucket}
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}
               - Effect: Allow
                 Action:
                   - s3:GetObject
                   - s3:PutObject
                 Resource:
-                  - !Sub arn:aws:s3:::${pDatasetBucket}/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pDatasetBucket}/stage/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pDatasetBucket}/pre-stage/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pDatasetBucket}/post-stage/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pDatasetBucket}/analytics/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}/stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}/pre-stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}/post-stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}/analytics/${pTeamName}/*
               - Effect: Allow
                 Action:
                   - glue:GetJobRun
                   - glue:StartJobRun
                 Resource:
-                  - !Sub arn:aws:glue:${AWS::Region}:${AWS::AccountId}:job/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:job/sdlf-${pTeamName}-*
 
   # Step2 Role
   rRoleLambdaExecutionStep2:
@@ -265,7 +265,7 @@ Resources:
                 Action:
                   - glue:StartCrawler
                 Resource:
-                  - !Sub arn:aws:glue:${AWS::Region}:${AWS::AccountId}:crawler/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:crawler/sdlf-${pTeamName}-*
 
   # Step3 Role
   rRoleLambdaExecutionStep3:
@@ -292,16 +292,16 @@ Resources:
                 Action:
                   - s3:ListBucket
                 Resource:
-                  - !Sub arn:aws:s3:::${pDatasetBucket}
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}
               - Effect: Allow
                 Action:
                   - s3:GetObject
                 Resource:
-                  - !Sub arn:aws:s3:::${pDatasetBucket}/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pDatasetBucket}/stage/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pDatasetBucket}/pre-stage/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pDatasetBucket}/post-stage/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pDatasetBucket}/analytics/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}/stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}/pre-stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}/post-stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}/analytics/${pTeamName}/*
 
   # Error Handling Lambda Role
   rRoleLambdaExecutionErrorStep:
@@ -337,7 +337,7 @@ Resources:
                   - sqs:SendMessage
                   - sqs:SendMessageBatch
                 Resource:
-                  - !Sub arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
 
   ######## LAMBDA FUNCTIONS #########
   rLambdaRoutingStep:
@@ -586,6 +586,7 @@ Resources:
         lCheckJob: !GetAtt rLambdaJobCheckStep.Arn
         lError: !GetAtt rLambdaErrorStep.Arn
         smDataQuality: "{{resolve:ssm:/SDLF/SM/DataQualityStateMachine:1}}"
+        awsPartition: !Sub "${AWS::Partition}"
       Role: !Ref pStatesExecutionRole
       Tracing:
         Enabled: !If [EnableTracing, true, false]

--- a/sdlf-team/deploy.sh
+++ b/sdlf-team/deploy.sh
@@ -30,6 +30,7 @@ then
     echo "-p not specified, using default..." >&2
     PROFILE="default"
 fi
+AWS_PARTITION=$(aws sts get-caller-identity --query 'Arn' --output text --profile "PROFILE" | cut -d':' -f2)
 ENV=$(sed -e 's/^"//' -e 's/"$//' <<<"$(aws ssm get-parameter --name /SDLF/Misc/pEnv --profile "$PROFILE" --query "Parameter.Value")")
 TEAM_NAME=$(sed -e 's/^"//' -e 's/"$//' <<<"$(jq '.[] | select(.ParameterKey=="pTeamName") | .ParameterValue' "$DIRNAME/parameters-$ENV".json)")
 if ! "$sflag"
@@ -146,13 +147,13 @@ function add_lf_permissions()
       --resource "$LOCATION_JSON"
 }
 if [ "$CENTRAL_BUCKET" == "$STAGE_BUCKET" ];then
-  add_lf_permissions "$CRAWLER_ARN" "arn:aws:s3:::${CENTRAL_BUCKET}/raw/${TEAM_NAME}/"
-  add_lf_permissions "$CRAWLER_ARN" "arn:aws:s3:::${CENTRAL_BUCKET}/pre-stage/${TEAM_NAME}/"
-  add_lf_permissions "$CRAWLER_ARN" "arn:aws:s3:::${CENTRAL_BUCKET}/post-stage/${TEAM_NAME}/"
-  add_lf_permissions "$CRAWLER_ARN" "arn:aws:s3:::${CENTRAL_BUCKET}/analytics/${TEAM_NAME}/"
+  add_lf_permissions "$CRAWLER_ARN" "arn:"$AWS_PARTITION":s3:::${CENTRAL_BUCKET}/raw/${TEAM_NAME}/"
+  add_lf_permissions "$CRAWLER_ARN" "arn:"$AWS_PARTITION":s3:::${CENTRAL_BUCKET}/pre-stage/${TEAM_NAME}/"
+  add_lf_permissions "$CRAWLER_ARN" "arn:"$AWS_PARTITION":s3:::${CENTRAL_BUCKET}/post-stage/${TEAM_NAME}/"
+  add_lf_permissions "$CRAWLER_ARN" "arn:"$AWS_PARTITION":s3:::${CENTRAL_BUCKET}/analytics/${TEAM_NAME}/"
 else
-  add_lf_permissions "$CRAWLER_ARN" "arn:aws:s3:::${CENTRAL_BUCKET}/${TEAM_NAME}/"
-  add_lf_permissions "$CRAWLER_ARN" "arn:aws:s3:::${STAGE_BUCKET}/pre-stage/${TEAM_NAME}/"
-  add_lf_permissions "$CRAWLER_ARN" "arn:aws:s3:::${STAGE_BUCKET}/post-stage/${TEAM_NAME}/"
-  add_lf_permissions "$CRAWLER_ARN" "arn:aws:s3:::${ANALYTICS_BUCKET}/${TEAM_NAME}/"
+  add_lf_permissions "$CRAWLER_ARN" "arn:"$AWS_PARTITION":s3:::${CENTRAL_BUCKET}/${TEAM_NAME}/"
+  add_lf_permissions "$CRAWLER_ARN" "arn:"$AWS_PARTITION":s3:::${STAGE_BUCKET}/pre-stage/${TEAM_NAME}/"
+  add_lf_permissions "$CRAWLER_ARN" "arn:"$AWS_PARTITION":s3:::${STAGE_BUCKET}/post-stage/${TEAM_NAME}/"
+  add_lf_permissions "$CRAWLER_ARN" "arn:"$AWS_PARTITION":s3:::${ANALYTICS_BUCKET}/${TEAM_NAME}/"
 fi

--- a/sdlf-team/nested-stacks/template-cicd.yaml
+++ b/sdlf-team/nested-stacks/template-cicd.yaml
@@ -441,7 +441,7 @@ Resources:
         - Name: Source
           Actions:
             - Name: Source
-              RoleArn: !Sub arn:aws:iam::${pSharedDevOpsAccountId}:role/sdlf-cicd-team-codecommit-${pEnvironment}-${pTeamName}
+              RoleArn: !Sub arn:${AWS::Partition}:iam::${pSharedDevOpsAccountId}:role/sdlf-cicd-team-codecommit-${pEnvironment}-${pTeamName}
               ActionTypeId:
                 Category: Source
                 Owner: AWS
@@ -499,7 +499,7 @@ Resources:
         - Name: Source
           Actions:
             - Name: Source
-              RoleArn: !Sub arn:aws:iam::${pSharedDevOpsAccountId}:role/sdlf-cicd-team-codecommit-${pEnvironment}-${pTeamName}
+              RoleArn: !Sub arn:${AWS::Partition}:iam::${pSharedDevOpsAccountId}:role/sdlf-cicd-team-codecommit-${pEnvironment}-${pTeamName}
               ActionTypeId:
                 Category: Source
                 Owner: AWS
@@ -570,7 +570,7 @@ Resources:
         - Name: Source
           Actions:
             - Name: Source
-              RoleArn: !Sub arn:aws:iam::${pSharedDevOpsAccountId}:role/sdlf-cicd-team-codecommit-${pEnvironment}-${pTeamName}
+              RoleArn: !Sub arn:${AWS::Partition}:iam::${pSharedDevOpsAccountId}:role/sdlf-cicd-team-codecommit-${pEnvironment}-${pTeamName}
               ActionTypeId:
                 Category: Source
                 Owner: AWS
@@ -613,7 +613,7 @@ Resources:
         - Name: Source
           Actions:
             - Name: Source
-              RoleArn: !Sub arn:aws:iam::${pSharedDevOpsAccountId}:role/sdlf-cicd-team-codecommit-${pEnvironment}-${pTeamName}
+              RoleArn: !Sub arn:${AWS::Partition}:iam::${pSharedDevOpsAccountId}:role/sdlf-cicd-team-codecommit-${pEnvironment}-${pTeamName}
               ActionTypeId:
                 Category: Source
                 Owner: AWS
@@ -657,7 +657,7 @@ Resources:
         - Name: Source
           Actions:
             - Name: Source
-              RoleArn: !Sub arn:aws:iam::${pSharedDevOpsAccountId}:role/sdlf-cicd-team-codecommit-${pEnvironment}-${pTeamName}
+              RoleArn: !Sub arn:${AWS::Partition}:iam::${pSharedDevOpsAccountId}:role/sdlf-cicd-team-codecommit-${pEnvironment}-${pTeamName}
               ActionTypeId:
                 Category: Source
                 Owner: AWS
@@ -702,7 +702,7 @@ Resources:
         detail-type:
           - CodeCommit Repository State Change
         resources:
-          - !Sub arn:aws:codecommit:${AWS::Region}:${pSharedDevOpsAccountId}:${pDatalakeLibraryRepositoryName}
+          - !Sub arn:${AWS::Partition}:codecommit:${AWS::Region}:${pSharedDevOpsAccountId}:${pDatalakeLibraryRepositoryName}
         detail:
           event:
             - referenceCreated
@@ -715,8 +715,8 @@ Resources:
         - Arn:
             !If [
               NotRunUnitTestingStage,
-              !Sub "arn:aws:codepipeline:${AWS::Region}:${AWS::AccountId}:${rCommonDatalakeLibs}",
-              !Sub "arn:aws:codepipeline:${AWS::Region}:${AWS::AccountId}:${rCommonDatalakeTestLibs}",
+              !Sub "arn:${AWS::Partition}:codepipeline:${AWS::Region}:${AWS::AccountId}:${rCommonDatalakeLibs}",
+              !Sub "arn:${AWS::Partition}:codepipeline:${AWS::Region}:${AWS::AccountId}:${rCommonDatalakeTestLibs}",
             ]
           Id: !Sub sdlf-${pTeamName}-${pDatalakeLibsLambdaLayerName}-trigger
           RoleArn: !Ref pCloudWatchRepositoryTriggerRoleArn
@@ -765,7 +765,7 @@ Resources:
         detail-type:
           - CodeCommit Repository State Change
         resources:
-          - !Sub arn:aws:codecommit:${AWS::Region}:${pSharedDevOpsAccountId}:${pPipLibrariesRepositoryName}
+          - !Sub arn:${AWS::Partition}:codecommit:${AWS::Region}:${pSharedDevOpsAccountId}:${pPipLibrariesRepositoryName}
         detail:
           event:
             - referenceCreated
@@ -775,7 +775,7 @@ Resources:
           referenceName:
             - !Ref pLibrariesBranchName
       Targets:
-        - Arn: !Sub arn:aws:codepipeline:${AWS::Region}:${AWS::AccountId}:${rCommonPipLibs}
+        - Arn: !Sub arn:${AWS::Partition}:codepipeline:${AWS::Region}:${AWS::AccountId}:${rCommonPipLibs}
           Id: !Sub sdlf-${pTeamName}-${pDefaultPipLibrariesLambdaLayerName}-trigger
           RoleArn: !Ref pCloudWatchRepositoryTriggerRoleArn
 
@@ -812,7 +812,7 @@ Resources:
         detail-type:
           - CodeCommit Repository State Change
         resources:
-          - !Sub arn:aws:codecommit:${AWS::Region}:${pSharedDevOpsAccountId}:sdlf-${pTeamName}-pipeline
+          - !Sub arn:${AWS::Partition}:codecommit:${AWS::Region}:${pSharedDevOpsAccountId}:sdlf-${pTeamName}-pipeline
         detail:
           event:
             - referenceCreated
@@ -822,7 +822,7 @@ Resources:
           referenceName:
             - !FindInMap [pCodeCommitBranch, !Ref pEnvironment, branch]
       Targets:
-        - Arn: !Sub arn:aws:codepipeline:${AWS::Region}:${AWS::AccountId}:${rPipelineCodePipeline}
+        - Arn: !Sub arn:${AWS::Partition}:codepipeline:${AWS::Region}:${AWS::AccountId}:${rPipelineCodePipeline}
           Id: !Sub sdlf-${pTeamName}-cicd-team-pipeline
           RoleArn: !Ref pCloudWatchRepositoryTriggerRoleArn
 
@@ -859,7 +859,7 @@ Resources:
         detail-type:
           - CodeCommit Repository State Change
         resources:
-          - !Sub arn:aws:codecommit:${AWS::Region}:${pSharedDevOpsAccountId}:sdlf-${pTeamName}-dataset
+          - !Sub arn:${AWS::Partition}:codecommit:${AWS::Region}:${pSharedDevOpsAccountId}:sdlf-${pTeamName}-dataset
         detail:
           event:
             - referenceCreated
@@ -869,7 +869,7 @@ Resources:
           referenceName:
             - !FindInMap [pCodeCommitBranch, !Ref pEnvironment, branch]
       Targets:
-        - Arn: !Sub arn:aws:codepipeline:${AWS::Region}:${AWS::AccountId}:${rDatasetCodePipeline}
+        - Arn: !Sub arn:${AWS::Partition}:codepipeline:${AWS::Region}:${AWS::AccountId}:${rDatasetCodePipeline}
           Id: !Sub sdlf-${pTeamName}-cicd-team-dataset
           RoleArn: !Ref pCloudWatchRepositoryTriggerRoleArn
 
@@ -910,13 +910,13 @@ Resources:
               "CodeCommit Pull Request State Change"
             ],
             "resources": [
-              "arn:aws:codecommit:${AWS::Region}:${pSharedDevOpsAccountId}:sdlf-${pTeamName}-pipeline",
-              "arn:aws:codecommit:${AWS::Region}:${pSharedDevOpsAccountId}:sdlf-${pTeamName}-dataset",
-              "arn:aws:codecommit:${AWS::Region}:${pSharedDevOpsAccountId}:sdlf-${pTeamName}-datalakeLibrary",
-              "arn:aws:codecommit:${AWS::Region}:${pSharedDevOpsAccountId}:sdlf-${pTeamName}-pipLibrary",
-              "arn:aws:codecommit:${AWS::Region}:${pSharedDevOpsAccountId}:sdlf-${pTeamName}-stageA",
-              "arn:aws:codecommit:${AWS::Region}:${pSharedDevOpsAccountId}:sdlf-${pTeamName}-stageB",
-              "arn:aws:codecommit:${AWS::Region}:${pSharedDevOpsAccountId}:sdlf-${pTeamName}-stageC"
+              "arn:${AWS::Partition}:codecommit:${AWS::Region}:${pSharedDevOpsAccountId}:sdlf-${pTeamName}-pipeline",
+              "arn:${AWS::Partition}:codecommit:${AWS::Region}:${pSharedDevOpsAccountId}:sdlf-${pTeamName}-dataset",
+              "arn:${AWS::Partition}:codecommit:${AWS::Region}:${pSharedDevOpsAccountId}:sdlf-${pTeamName}-datalakeLibrary",
+              "arn:${AWS::Partition}:codecommit:${AWS::Region}:${pSharedDevOpsAccountId}:sdlf-${pTeamName}-pipLibrary",
+              "arn:${AWS::Partition}:codecommit:${AWS::Region}:${pSharedDevOpsAccountId}:sdlf-${pTeamName}-stageA",
+              "arn:${AWS::Partition}:codecommit:${AWS::Region}:${pSharedDevOpsAccountId}:sdlf-${pTeamName}-stageB",
+              "arn:${AWS::Partition}:codecommit:${AWS::Region}:${pSharedDevOpsAccountId}:sdlf-${pTeamName}-stageC"
             ],
             "source": [
               "aws.codecommit"
@@ -954,14 +954,14 @@ Resources:
     Properties:
       Name: !Sub /SDLF/Lambda/${pTeamName}/LatestDatalakeLibraryLayer
       Type: String
-      Value: !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:layer:${pTeamName}-${pDatalakeLibsLambdaLayerName}:1
+      Value: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:layer:${pTeamName}-${pDatalakeLibsLambdaLayerName}:1
       Description: The ARN of the latest version of the Datalake Library layer
   rPipLibrariesLayerSsm:
     Type: AWS::SSM::Parameter
     Properties:
       Name: !Sub /SDLF/Lambda/${pTeamName}/LatestDefaultPipLibraryLayer
       Type: String
-      Value: !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:layer:${pTeamName}-${pDefaultPipLibrariesLambdaLayerName}:1
+      Value: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:layer:${pTeamName}-${pDefaultPipLibrariesLambdaLayerName}:1
       Description: The ARN of the latest version of the Lambda Layer containing the Pip libraries
   rTransformValidateServerlessTemplateSsm:
     Type: AWS::SSM::Parameter

--- a/sdlf-team/nested-stacks/template-iam.yaml
+++ b/sdlf-team/nested-stacks/template-iam.yaml
@@ -52,17 +52,17 @@ Resources:
             Action:
               - s3:GetBucketLocation
               - s3:ListAllMyBuckets
-            Resource: arn:aws:s3:::*
+            Resource: !Sub arn:${AWS::Partition}:s3:::*
           - Sid: AllowTeamBucketList
             Effect: Allow
             Action:
               - s3:ListBucket
             Resource:
               [
-                !Sub "arn:aws:s3:::${pPipelineBucket}",
-                !Sub "arn:aws:s3:::${pCentralBucket}",
-                !Sub "arn:aws:s3:::${pStageBucket}",
-                !Sub "arn:aws:s3:::${pAnalyticsBucket}",
+                !Sub "arn:${AWS::Partition}:s3:::${pPipelineBucket}",
+                !Sub "arn:${AWS::Partition}:s3:::${pCentralBucket}",
+                !Sub "arn:${AWS::Partition}:s3:::${pStageBucket}",
+                !Sub "arn:${AWS::Partition}:s3:::${pAnalyticsBucket}",
               ]
           - Sid: AllowTeamPrefixActions
             Effect: Allow
@@ -71,27 +71,27 @@ Resources:
               - s3:GetObject
               - s3:PutObject
             Resource:
-              - !Sub arn:aws:s3:::${pPipelineBucket}/${pTeamName}/*
+              - !Sub arn:${AWS::Partition}:s3:::${pPipelineBucket}/${pTeamName}/*
               - !If [
                   CreateMultipleBuckets,
-                  !Sub "arn:aws:s3:::${pCentralBucket}/${pTeamName}/*",
-                  !Sub "arn:aws:s3:::${pCentralBucket}/raw/${pTeamName}/*",
+                  !Sub "arn:${AWS::Partition}:s3:::${pCentralBucket}/${pTeamName}/*",
+                  !Sub "arn:${AWS::Partition}:s3:::${pCentralBucket}/raw/${pTeamName}/*",
                 ]
-              - !Sub arn:aws:s3:::${pStageBucket}/${pTeamName}/*
-              - !Sub arn:aws:s3:::${pStageBucket}/pre-stage/${pTeamName}/*
-              - !Sub arn:aws:s3:::${pStageBucket}/stage/${pTeamName}/*
-              - !Sub arn:aws:s3:::${pStageBucket}/post-stage/${pTeamName}/*
+              - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/${pTeamName}/*
+              - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/pre-stage/${pTeamName}/*
+              - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/stage/${pTeamName}/*
+              - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/post-stage/${pTeamName}/*
               - !If [
                   CreateMultipleBuckets,
-                  !Sub "arn:aws:s3:::${pAnalyticsBucket}/${pTeamName}/*",
-                  !Sub "arn:aws:s3:::${pAnalyticsBucket}/analytics/${pTeamName}/*",
+                  !Sub "arn:${AWS::Partition}:s3:::${pAnalyticsBucket}/${pTeamName}/*",
+                  !Sub "arn:${AWS::Partition}:s3:::${pAnalyticsBucket}/analytics/${pTeamName}/*",
                 ]
           - Sid: AllowFullCodeCommitOnTeamRepositories
             Effect: Allow
             Action:
               - codecommit:*
             Resource:
-              - !Sub arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
+              - !Sub arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
           - Sid: AllowTeamKMSDataKeyUsage
             Effect: Allow
             Action:
@@ -109,7 +109,7 @@ Resources:
             Action:
               - ssm:GetParameter
               - ssm:GetParameters
-            Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/*
+            Resource: !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/*
           - Sid: AllowOctagonDynamoAccess
             Effect: Allow
             Action:
@@ -124,7 +124,7 @@ Resources:
               - dynamodb:Scan
               - dynamodb:UpdateItem
             Resource:
-              - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/octagon-*
+              - !Sub arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/octagon-*
           - Sid: AllowSQSManagement
             Effect: Allow
             Action:
@@ -139,29 +139,29 @@ Resources:
               - sqs:SendMessage
               - sqs:SendMessageBatch
             Resource:
-              - !Sub arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
+              - !Sub arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
           - Effect: Allow
             Action:
               - states:StartExecution
             Resource:
-              - !Sub arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:sdlf-${pTeamName}-*
+              - !Sub arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:stateMachine:sdlf-${pTeamName}-*
           - Effect: Allow
             Action:
               - glue:StartCrawler
             Resource:
-              - !Sub arn:aws:glue:${AWS::Region}:${AWS::AccountId}:crawler/sdlf-${pTeamName}-*
+              - !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:crawler/sdlf-${pTeamName}-*
           - Effect: Allow
             Action:
               - glue:GetJobRun
               - glue:GetJobRuns
               - glue:StartJobRun
             Resource:
-              - !Sub arn:aws:glue:${AWS::Region}:${AWS::AccountId}:job/sdlf-${pTeamName}-*
-              - !Sub arn:aws:glue:${AWS::Region}:${AWS::AccountId}:job/${pOrganizationName}-${pApplicationName}-${pEnvironment}-${pTeamName}-*
+              - !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:job/sdlf-${pTeamName}-*
+              - !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:job/${pOrganizationName}-${pApplicationName}-${pEnvironment}-${pTeamName}-*
           - Effect: Allow
             Action:
               - logs:CreateLogGroup
-            Resource: !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*
+            Resource: !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:*
           - Sid: AllowCloudWatchLogsReadOnlyAccess
             Effect: Allow
             Action:
@@ -170,9 +170,9 @@ Resources:
               - logs:GetLogEvents
               - logs:PutLogEvents
             Resource:
-              - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/sdlf-${pTeamName}-*
-              - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/sdlf-${pTeamName}-*
-              - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws-glue/jobs/sdlf-${pTeamName}-*
+              - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/sdlf-${pTeamName}-*
+              - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/sdlf-${pTeamName}-*
+              - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws-glue/jobs/sdlf-${pTeamName}-*
           - Sid: AllowCloudFormationReadOnlyAccess
             Effect: Allow
             Action:
@@ -181,7 +181,7 @@ Resources:
               - cloudformation:DescribeStackResource
               - cloudformation:DescribeStackResources
             Resource:
-              - !Sub arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack:sdlf-${pTeamName}:*
+              - !Sub arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stack:sdlf-${pTeamName}:*
 
   rCodePipelineRole:
     Type: AWS::IAM::Role
@@ -219,25 +219,25 @@ Resources:
                 Action:
                   - iam:PassRole
                 Resource:
-                  - !Sub arn:aws:iam::${AWS::AccountId}:role/sdlf-${pTeamName}-states-execution
-                  - !Sub arn:aws:iam::${AWS::AccountId}:role/state-machine/sdlf-${pTeamName}-*
-                  - !Sub arn:aws:iam::${AWS::AccountId}:role/glue/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/sdlf-${pTeamName}-states-execution
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/state-machine/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/glue/sdlf-${pTeamName}-*
                   - !GetAtt rRoleCloudWatchEventRole.Arn
-                  - !Sub arn:aws:iam::${AWS::AccountId}:role/service-role/*
-                  - !Sub arn:aws:iam::${AWS::AccountId}:role/EMR*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/service-role/*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/EMR*
               - Effect: Allow
                 Action:
                   - iam:ListRoles
                 Resource:
-                  - !Sub arn:aws:iam::${AWS::AccountId}:role/*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/*
               - Effect: Allow
                 Action:
                   - iam:CreateRole
                 Resource:
-                  - !Sub arn:aws:iam::${AWS::AccountId}:role/sdlf-${pTeamName}-*
-                  - !Sub arn:aws:iam::${AWS::AccountId}:role/state-machine/sdlf-${pTeamName}-*
-                  - !Sub arn:aws:iam::${AWS::AccountId}:role/service-role/sdlf-${pTeamName}-*
-                  - !Sub arn:aws:iam::${AWS::AccountId}:role/glue/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/state-machine/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/service-role/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/glue/sdlf-${pTeamName}-*
                 Condition:
                   StringEquals:
                     iam:PermissionsBoundary: !Ref rTeamIAMManagedPolicy
@@ -246,14 +246,14 @@ Resources:
                   - iam:AttachRolePolicy
                   - iam:DetachRolePolicy
                 Resource:
-                  - !Sub arn:aws:iam::${AWS::AccountId}:role/sdlf-${pTeamName}-*
-                  - !Sub arn:aws:iam::${AWS::AccountId}:role/state-machine/sdlf-${pTeamName}-*
-                  - !Sub arn:aws:iam::${AWS::AccountId}:role/service-role/sdlf-${pTeamName}-*
-                  - !Sub arn:aws:iam::${AWS::AccountId}:role/glue/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/state-machine/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/service-role/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/glue/sdlf-${pTeamName}-*
                 Condition:
                   ArnEquals:
                     iam:PolicyARN:
-                      - !Sub arn:aws:iam::${AWS::AccountId}:policy/sdlf-${pTeamName}-*
+                      - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:policy/sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - iam:DeleteRole
@@ -267,16 +267,16 @@ Resources:
                   - iam:UpdateRoleDescription
                   - iam:TagRole
                 Resource:
-                  - !Sub arn:aws:iam::${AWS::AccountId}:role/sdlf-${pTeamName}-*
-                  - !Sub arn:aws:iam::${AWS::AccountId}:role/state-machine/sdlf-${pTeamName}-*
-                  - !Sub arn:aws:iam::${AWS::AccountId}:role/service-role/sdlf-${pTeamName}-*
-                  - !Sub arn:aws:iam::${AWS::AccountId}:role/glue/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/state-machine/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/service-role/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/glue/sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - iam:ListPolicies
                   - iam:ListPolicyVersions
                 Resource:
-                  - !Sub arn:aws:iam::${AWS::AccountId}:policy/*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:policy/*
               - Effect: Allow
                 Action:
                   - iam:CreatePolicy
@@ -286,8 +286,8 @@ Resources:
                   - iam:GetPolicy
                   - iam:GetPolicyVersion
                 Resource:
-                  - !Sub arn:aws:iam::${AWS::AccountId}:policy/sdlf-${pTeamName}-*
-                  - !Sub arn:aws:iam::${AWS::AccountId}:policy/state-machine/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:policy/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:policy/state-machine/sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - codecommit:CancelUploadArchive
@@ -296,7 +296,7 @@ Resources:
                   - codecommit:GetUploadArchiveStatus
                   - codecommit:UploadArchive
                 Resource:
-                  - !Sub arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - events:DeleteRule
@@ -304,7 +304,7 @@ Resources:
                   - events:PutRule
                   - events:PutTargets
                   - events:RemoveTargets
-                Resource: !Sub arn:aws:events:${AWS::Region}:${AWS::AccountId}:rule/sdlf-${pTeamName}-*
+                Resource: !Sub arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:rule/sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - lambda:GetLayerVersion
@@ -330,11 +330,11 @@ Resources:
                   - lambda:UpdateFunctionCode
                   - lambda:UpdateFunctionConfiguration
                   - lambda:UpdateFunctionConfiguration
-                Resource: !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:sdlf-${pTeamName}-*
+                Resource: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - lambda:InvokeFunction
-                Resource: !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:sdlf-foundations-rKibana*
+                Resource: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:sdlf-foundations-rKibana*
               - Effect: Allow
                 Action:
                   - lambda:CreateEventSourceMapping
@@ -353,14 +353,14 @@ Resources:
                   - cloudformation:ExecuteChangeSet
                   - cloudformation:SetStackPolicy
                   - cloudformation:UpdateStack
-                Resource: !Sub arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/sdlf-${pTeamName}-*
+                Resource: !Sub arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - cloudformation:CreateChangeSet
                   - cloudformation:DeleteChangeSet
                   - cloudformation:DescribeChangeSet
                   - cloudformation:ExecuteChangeSet
-                Resource: !Sub arn:aws:cloudformation:${AWS::Region}:aws:transform/*
+                Resource: !Sub arn:${AWS::Partition}:cloudformation:${AWS::Region}:aws:transform/*
               - Effect: Allow
                 Action:
                   - cloudformation:ValidateTemplate
@@ -371,7 +371,7 @@ Resources:
                   - codebuild:CreateProject
                   - codebuild:StartBuild
                   - codebuild:UpdateProject
-                Resource: !Sub arn:aws:codebuild:${AWS::Region}:${AWS::AccountId}:project/sdlf-${pTeamName}-*
+                Resource: !Sub arn:${AWS::Partition}:codebuild:${AWS::Region}:${AWS::AccountId}:project/sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - states:CreateActivity
@@ -379,25 +379,25 @@ Resources:
                   - states:ListActivities
                   - states:ListStateMachines
                   - states:TagResource
-                Resource: !Sub arn:aws:states:${AWS::Region}:${AWS::AccountId}:*
+                Resource: !Sub arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:*
               - Effect: Allow
                 Action:
                   - states:DeleteStateMachine
                   - states:DescribeStateMachine
                   - states:DescribeStateMachineForExecution
                   - states:UpdateStateMachine
-                Resource: !Sub arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:sdlf-${pTeamName}-*
+                Resource: !Sub arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:stateMachine:sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - states:DescribeActivity
                   - states:DeleteActivity
                   - states:GetActivityTask
-                Resource: !Sub arn:aws:states:${AWS::Region}:${AWS::AccountId}:activity:sdlf-${pTeamName}-*
+                Resource: !Sub arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:activity:sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - logs:CreateLogGroup
                   - logs:DescribeLogGroups
-                Resource: !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*
+                Resource: !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:*
               - Effect: Allow
                 Action:
                   - logs:CreateLogStream
@@ -408,8 +408,8 @@ Resources:
                   - logs:PutRetentionPolicy
                   - logs:TagLogGroup
                 Resource:
-                  - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/sdlf-${pTeamName}-*:log-stream:*
-                  - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/sdlf-${pTeamName}-*:log-stream:*
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/sdlf-${pTeamName}-*:log-stream:*
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/sdlf-${pTeamName}-*:log-stream:*
               - Effect: Allow
                 Action:
                   - cloudwatch:DeleteAlarms
@@ -418,11 +418,11 @@ Resources:
                   - cloudwatch:PutMetricData
                   - cloudwatch:SetAlarmState
                 Resource:
-                  - !Sub arn:aws:cloudwatch:${AWS::Region}:${AWS::AccountId}:alarm:sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:cloudwatch:${AWS::Region}:${AWS::AccountId}:alarm:sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - sqs:ListQueues
-                Resource: !Sub arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:*
+                Resource: !Sub arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:*
               - Effect: Allow
                 Action:
                   - sqs:AddPermission
@@ -433,7 +433,7 @@ Resources:
                   - sqs:GetQueueAttributes
                   - sqs:SetQueueAttributes
                   - sqs:TagQueue
-                Resource: !Sub arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
+                Resource: !Sub arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - s3:CreateBucket
@@ -452,10 +452,10 @@ Resources:
                   - s3:PutObject
                   - s3:SetBucketEncryption
                 Resource:
-                  - !Sub arn:aws:s3:::${pCFNBucket}
-                  - !Sub arn:aws:s3:::${pCFNBucket}/*
-                  - !Sub arn:aws:s3:::${pPipelineBucket}
-                  - !Sub arn:aws:s3:::${pPipelineBucket}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pCFNBucket}
+                  - !Sub arn:${AWS::Partition}:s3:::${pCFNBucket}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pPipelineBucket}
+                  - !Sub arn:${AWS::Partition}:s3:::${pPipelineBucket}/*
               - Effect: Allow
                 Action:
                   - ssm:AddTagsToResource
@@ -467,12 +467,12 @@ Resources:
                   - ssm:GetParametersByPath
                   - ssm:ListTagsForResource
                   - ssm:RemoveTagsFromResource
-                Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/*
+                Resource: !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/*
               - Effect: Allow
                 Action:
                   - ssm:DeleteParameter
                   - ssm:PutParameter
-                Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/*/${pTeamName}/*
+                Resource: !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/*/${pTeamName}/*
               - Effect: Allow
                 Action:
                   - kms:CreateGrant
@@ -485,7 +485,7 @@ Resources:
                   - !Ref pKMSInfraKeyId
               - Effect: Allow
                 Action: sts:AssumeRole
-                Resource: !Sub arn:aws:iam::${pSharedDevOpsAccountId}:role/sdlf-cicd-team-codecommit-${pEnvironment}-${pTeamName}
+                Resource: !Sub arn:${AWS::Partition}:iam::${pSharedDevOpsAccountId}:role/sdlf-cicd-team-codecommit-${pEnvironment}-${pTeamName}
 
   rCloudWatchRepositoryTriggerRole:
     Type: AWS::IAM::Role
@@ -509,10 +509,10 @@ Resources:
                 Action:
                   - codebuild:BatchGetBuilds
                   - codebuild:StartBuild
-                Resource: !Sub arn:aws:codebuild:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
+                Resource: !Sub arn:${AWS::Partition}:codebuild:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
               - Effect: Allow
                 Action: codepipeline:StartPipelineExecution
-                Resource: !Sub arn:aws:codepipeline:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
+                Resource: !Sub arn:${AWS::Partition}:codepipeline:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
 
   rTransformValidateRole:
     Type: AWS::IAM::Role
@@ -548,13 +548,13 @@ Resources:
                   - codecommit:List*
                   - codecommit:UploadArchive
                 Resource:
-                  - !Sub arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - logs:CreateLogGroup
                   - logs:CreateLogStream
                   - logs:PutLogEvents
-                Resource: !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/sdlf-${pTeamName}*
+                Resource: !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/sdlf-${pTeamName}*
               - Effect: Allow
                 Action:
                   - s3:GetBucketAcl
@@ -563,8 +563,8 @@ Resources:
                   - s3:GetObjectVersion
                   - s3:PutObject
                 Resource:
-                  - !Sub arn:aws:s3:::${pPipelineBucket}/*
-                  - !Sub arn:aws:s3:::${pCFNBucket}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pPipelineBucket}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pCFNBucket}/*
               - Effect: Allow
                 Action:
                   - lambda:List*
@@ -572,7 +572,7 @@ Resources:
               - Effect: Allow
                 Action:
                   - lambda:GetLayer*
-                Resource: !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:layer:sdlf-${pTeamName}-*
+                Resource: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:layer:sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - kms:CreateGrant
@@ -603,14 +603,14 @@ Resources:
             Statement:
               - Effect: Allow
                 Action: sts:AssumeRole
-                Resource: !Sub arn:aws:iam::${pSharedDevOpsAccountId}:role/sdlf-cicd-team-codecommit-${pEnvironment}-${pTeamName}
+                Resource: !Sub arn:${AWS::Partition}:iam::${pSharedDevOpsAccountId}:role/sdlf-cicd-team-codecommit-${pEnvironment}-${pTeamName}
               - Effect: Allow
                 Action:
                   - iam:PassRole
                 Resource:
-                  - !Sub arn:aws:iam::${AWS::AccountId}:role/sdlf-${pTeamName}-*
-                  - !Sub arn:aws:iam::${AWS::AccountId}:role/service-role/sdlf-${pTeamName}-*
-                  - !Sub arn:aws:iam::${pSharedDevOpsAccountId}:role/sdlf-cicd-team-codecommit-${pEnvironment}-${pTeamName}
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/service-role/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:iam::${pSharedDevOpsAccountId}:role/sdlf-cicd-team-codecommit-${pEnvironment}-${pTeamName}
               - Effect: Allow
                 Action:
                   - cloudformation:CreateChangeSet
@@ -622,14 +622,14 @@ Resources:
                   - cloudformation:ExecuteChangeSet
                   - cloudformation:SetStackPolicy
                   - cloudformation:UpdateStack
-                Resource: !Sub arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/sdlf-${pTeamName}-*
+                Resource: !Sub arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - cloudformation:CreateChangeSet
                   - cloudformation:DeleteChangeSet
                   - cloudformation:DescribeChangeSet
                   - cloudformation:ExecuteChangeSet
-                Resource: !Sub arn:aws:cloudformation:${AWS::Region}:aws:transform/*
+                Resource: !Sub arn:${AWS::Partition}:cloudformation:${AWS::Region}:aws:transform/*
               - Effect: Allow
                 Action:
                   - ssm:AddTagsToResource
@@ -641,13 +641,13 @@ Resources:
                   - ssm:GetParametersByPath
                   - ssm:ListTagsForResource
                   - ssm:RemoveTagsFromResource
-                Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/*
+                Resource: !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/*
               - Effect: Allow
                 Action:
                   - ssm:DeleteParameter
                   - ssm:DeleteParameters
                   - ssm:PutParameter
-                Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/*/${pTeamName}/*
+                Resource: !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/*/${pTeamName}/*
               - Effect: Allow
                 Action:
                   - dynamodb:DeleteItem
@@ -657,8 +657,8 @@ Resources:
                   - dynamodb:Scan
                   - dynamodb:UpdateItem
                 Resource:
-                  - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/octagon-Pipelines-${pEnvironment}
-                  - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/octagon-Datasets-${pEnvironment}
+                  - !Sub arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/octagon-Pipelines-${pEnvironment}
+                  - !Sub arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/octagon-Datasets-${pEnvironment}
               - Effect: Allow
                 Action:
                   - events:DeleteRule
@@ -668,7 +668,7 @@ Resources:
                   - events:PutRule
                   - events:PutTargets
                   - events:RemoveTargets
-                Resource: !Sub arn:aws:events:${AWS::Region}:${AWS::AccountId}:rule/sdlf-${pTeamName}-*
+                Resource: !Sub arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:rule/sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - codepipeline:CreatePipeline
@@ -676,7 +676,7 @@ Resources:
                   - codepipeline:GetPipelineState
                   - codepipeline:GetPipeline
                   - codepipeline:UpdatePipeline
-                Resource: !Sub arn:aws:codepipeline:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
+                Resource: !Sub arn:${AWS::Partition}:codepipeline:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - codebuild:BatchGetProjects
@@ -684,16 +684,16 @@ Resources:
                   - codebuild:CreateProject
                   - codebuild:DeleteProject
                   - codebuild:UpdateProject
-                Resource: !Sub arn:aws:codebuild:${AWS::Region}:${AWS::AccountId}:project/sdlf-${pTeamName}-*
+                Resource: !Sub arn:${AWS::Partition}:codebuild:${AWS::Region}:${AWS::AccountId}:project/sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - s3:ListBucket
-                Resource: !Sub arn:aws:s3:::${pCFNBucket}
+                Resource: !Sub arn:${AWS::Partition}:s3:::${pCFNBucket}
               - Effect: Allow
                 Action:
                   - s3:GetObject
                   - s3:PutObject
-                Resource: !Sub arn:aws:s3:::${pCFNBucket}/*
+                Resource: !Sub arn:${AWS::Partition}:s3:::${pCFNBucket}/*
               - Effect: Allow
                 Action:
                   - kms:CreateGrant
@@ -710,7 +710,7 @@ Resources:
                   - logs:CreateLogStream
                   - logs:PutLogEvents
                 Resource:
-                  - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - lakeformation:GetDataAccess
@@ -734,7 +734,7 @@ Resources:
                   - sqs:SetQueueAttributes
                   - sqs:TagQueue
                   - sqs:UntagQueue
-                Resource: !Sub arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
+                Resource: !Sub arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - glue:TagResource
@@ -747,7 +747,7 @@ Resources:
                   - glue:GetCrawler
                   - glue:GetCrawlers
                   - glue:UpdateCrawler
-                Resource: !Sub arn:aws:glue:${AWS::Region}:${AWS::AccountId}:crawler/sdlf-${pTeamName}-*
+                Resource: !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:crawler/sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - glue:CreateDatabase
@@ -756,13 +756,13 @@ Resources:
                   - glue:GetDatabases
                   - glue:UpdateDatabase
                 Resource:
-                  - !Sub arn:aws:glue:${AWS::Region}:${AWS::AccountId}:catalog
-                  - !Sub arn:aws:glue:${AWS::Region}:${AWS::AccountId}:database/${pOrganizationName}_${pApplicationName}_${pEnvironment}_${pTeamName}_*
+                  - !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:catalog
+                  - !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:database/${pOrganizationName}_${pApplicationName}_${pEnvironment}_${pTeamName}_*
               - Effect: Allow
                 Action:
                   - lambda:AddPermission
                   - lambda:RemovePermission
-                Resource: !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:sdlf-${pTeamName}*
+                Resource: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:sdlf-${pTeamName}*
 
   rCodeBuildServiceRole:
     Type: AWS::IAM::Role
@@ -787,7 +787,7 @@ Resources:
                   - logs:CreateLogStream
                   - logs:PutLogEvents
                 Resource:
-                  - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - s3:GetBucketAcl
@@ -796,12 +796,12 @@ Resources:
                   - s3:GetObjectVersion
                   - s3:PutObject
                 Resource:
-                  - !Sub arn:aws:s3:::${pPipelineBucket}/*
-                  - !Sub arn:aws:s3:::${pCFNBucket}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pPipelineBucket}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pCFNBucket}/*
               - Effect: Allow
                 Action: codecommit:GitPull
                 Resource:
-                  - !Sub arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - kms:CreateGrant
@@ -839,7 +839,7 @@ Resources:
               - Effect: Allow
                 Action:
                   - lambda:InvokeFunction
-                Resource: !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:sdlf-${pTeamName}-*
+                Resource: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - states:DescribeStateMachine
@@ -856,7 +856,7 @@ Resources:
                   - events:DescribeRule
                   - events:PutRule
                   - events:PutTargets
-                Resource: !Sub arn:aws:events:${AWS::Region}:${AWS::AccountId}:rule/StepFunctionsGetEventsForStepFunctionsExecutionRule
+                Resource: !Sub arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:rule/StepFunctionsGetEventsForStepFunctionsExecutionRule
               - Effect: Allow
                 Action:
                   - elasticmapreduce:DescribeCluster
@@ -873,17 +873,17 @@ Resources:
                   - elasticmapreduce:ModifyInstanceFleet
                   - elasticmapreduce:ModifyInstanceGroups
                   - elasticmapreduce:SetTerminationProtection
-                Resource: !Sub arn:aws:elasticmapreduce:${AWS::Region}:${AWS::AccountId}:cluster/*
+                Resource: !Sub arn:${AWS::Partition}:elasticmapreduce:${AWS::Region}:${AWS::AccountId}:cluster/*
               - Effect: Allow
                 Action:
                   - iam:PassRole
-                Resource: !Sub arn:aws:iam::${AWS::AccountId}:role/EMR*
+                Resource: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/EMR*
               - Effect: Allow
                 Action:
                   - iam:CreateServiceLinkedRole
                   - iam:PutRolePolicy
                   - iam:UpdateRoleDescription
-                Resource: !Sub arn:aws:iam::${AWS::AccountId}:role/aws-service-role/elasticmapreduce.amazonaws.com/AWSServiceRoleForEMRCleanup*
+                Resource: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/aws-service-role/elasticmapreduce.amazonaws.com/AWSServiceRoleForEMRCleanup*
                 Condition:
                   StringLike:
                     iam:AWSServiceName: elasticmapreduce.amazonaws.com
@@ -920,7 +920,7 @@ Resources:
               - Effect: Allow
                 Action:
                   - lambda:InvokeFunction
-                Resource: !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:sdlf-${pTeamName}-*
+                Resource: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:sdlf-${pTeamName}-*
         - PolicyName: !Sub sdlf-${pTeamName}-describe-state-machines
           PolicyDocument:
             Version: 2012-10-17
@@ -928,7 +928,7 @@ Resources:
               - Effect: Allow
                 Action:
                   - states:ListStateMachines
-                Resource: !Sub arn:aws:states:${AWS::Region}:${AWS::AccountId}:*
+                Resource: !Sub arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:*
         - PolicyName: !Sub sdlf-${pTeamName}-dataset-state-machine
           PolicyDocument:
             Version: 2012-10-17
@@ -938,7 +938,7 @@ Resources:
                   - states:DescribeStateMachineForExecution
                   - states:DescribeStateMachine
                   - states:StartExecution
-                Resource: !Sub arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:sdlf-${pTeamName}-*
+                Resource: !Sub arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:stateMachine:sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - s3:ListBucket
@@ -946,10 +946,10 @@ Resources:
                   - s3:GetObjectVersion
                   - s3:GetBucketVersioning
                 Resource:
-                  - !Sub arn:aws:s3:::${pPipelineBucket}
-                  - !Sub arn:aws:s3:::${pCentralBucket}
-                  - !Sub arn:aws:s3:::${pStageBucket}
-                  - !Sub arn:aws:s3:::${pAnalyticsBucket}
+                  - !Sub arn:${AWS::Partition}:s3:::${pPipelineBucket}
+                  - !Sub arn:${AWS::Partition}:s3:::${pCentralBucket}
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}
+                  - !Sub arn:${AWS::Partition}:s3:::${pAnalyticsBucket}
 
   rCodeBuildPublishLayerRole:
     Type: AWS::IAM::Role
@@ -970,14 +970,14 @@ Resources:
             Statement:
               - Effect: Allow
                 Action: lambda:PublishLayerVersion
-                Resource: !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:layer:sdlf-${pTeamName}-*
+                Resource: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:layer:sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - dynamodb:Get*
                   - dynamodb:Update*
                   - dynamodb:Put*
                 Resource:
-                  - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/octagon-*
+                  - !Sub arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/octagon-*
               - Effect: Allow
                 Action:
                   - ssm:AddTagsToResource
@@ -989,12 +989,12 @@ Resources:
                   - ssm:GetParametersByPath
                   - ssm:ListTagsForResource
                   - ssm:RemoveTagsFromResource
-                Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/*
+                Resource: !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/*
               - Effect: Allow
                 Action:
                   - ssm:PutParameter
                   - ssm:DeleteParameter
-                Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/*/${pTeamName}/*
+                Resource: !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/*/${pTeamName}/*
               - Effect: Allow
                 Action:
                   - s3:GetBucketAcl
@@ -1005,10 +1005,10 @@ Resources:
                   - s3:ListBucket
                   - s3:PutObject
                 Resource:
-                  - !Sub arn:aws:s3:::${pPipelineBucket}
-                  - !Sub arn:aws:s3:::${pPipelineBucket}/*
-                  - !Sub arn:aws:s3:::${pCFNBucket}
-                  - !Sub arn:aws:s3:::${pCFNBucket}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pPipelineBucket}
+                  - !Sub arn:${AWS::Partition}:s3:::${pPipelineBucket}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pCFNBucket}
+                  - !Sub arn:${AWS::Partition}:s3:::${pCFNBucket}/*
 
   rDatalakeCrawlerRole:
     Type: AWS::IAM::Role
@@ -1025,7 +1025,7 @@ Resources:
             Action:
               - sts:AssumeRole
       ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/service-role/AWSGlueServiceRole
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSGlueServiceRole
       Policies:
         - PolicyName: !Sub sdlf-${pTeamName}-glue-crawler
           PolicyDocument:
@@ -1040,21 +1040,21 @@ Resources:
               - Effect: Allow
                 Action:
                   - s3:CreateBucket
-                Resource: arn:aws:s3:::aws-glue-*
+                Resource: !Sub arn:${AWS::Partition}:s3:::aws-glue-*
               - Effect: Allow
                 Action:
                   - s3:DeleteObject
                   - s3:GetObject
                   - s3:PutObject
                 Resource:
-                  - arn:aws:s3:::aws-glue-*/*
-                  - arn:aws:s3:::*/*aws-glue-*/*
+                  - !Sub arn:${AWS::Partition}:s3:::aws-glue-*/*
+                  - !Sub arn:${AWS::Partition}:s3:::*/*aws-glue-*/*
               - Effect: Allow
                 Action:
                   - s3:GetObject
                 Resource:
-                  - arn:aws:s3:::crawler-public*
-                  - arn:aws:s3:::aws-glue-*
+                  - !Sub arn:${AWS::Partition}:s3:::crawler-public*
+                  - !Sub arn:${AWS::Partition}:s3:::aws-glue-*
               - Effect: Allow
                 Action:
                   - s3:ListObjectsV2
@@ -1066,14 +1066,14 @@ Resources:
                   - s3:PutObject
                   - s3:PutObjectVersion
                 Resource:
-                  - !Sub arn:aws:s3:::${pCentralBucket}/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pCentralBucket}/raw/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pStageBucket}/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pStageBucket}/stage/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pStageBucket}/pre-stage/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pStageBucket}/post-stage/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pAnalyticsBucket}/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pAnalyticsBucket}/analytics/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pCentralBucket}/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pCentralBucket}/raw/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/pre-stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/post-stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pAnalyticsBucket}/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pAnalyticsBucket}/analytics/${pTeamName}/*
               - Effect: Allow
                 Action:
                   - kms:DescribeKey

--- a/sdlf-team/nested-stacks/template-kms.yaml
+++ b/sdlf-team/nested-stacks/template-kms.yaml
@@ -30,7 +30,7 @@ Resources:
           - Sid: Allow administration of the key
             Effect: Allow
             Principal:
-              AWS: [!Sub "arn:aws:iam::${AWS::AccountId}:root"]
+              AWS: [!Sub "arn:${AWS::Partition}:iam::${AWS::AccountId}:root"]
             Action: kms:*
             Resource: "*"
           - Sid: Allow CloudWatch alarms access
@@ -72,8 +72,8 @@ Resources:
             Effect: Allow
             Principal:
               AWS:
-                - !Sub arn:aws:iam::${AWS::AccountId}:role/sdlf-routing
-                - !Sub arn:aws:iam::${pSharedDevOpsAccountId}:role/sdlf-cicd-team-codecommit-${pEnvironment}-${pTeamName}
+                - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/sdlf-routing
+                - !Sub arn:${AWS::Partition}:iam::${pSharedDevOpsAccountId}:role/sdlf-cicd-team-codecommit-${pEnvironment}-${pTeamName}
             Action:
               - kms:Decrypt
               - kms:Describe*
@@ -87,8 +87,8 @@ Resources:
             Effect: Allow
             Principal:
               AWS:
-                - !Sub arn:aws:iam::${AWS::AccountId}:role/sdlf-routing
-                - !Sub arn:aws:iam::${pSharedDevOpsAccountId}:role/sdlf-cicd-team-codecommit-${pEnvironment}-${pTeamName}
+                - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/sdlf-routing
+                - !Sub arn:${AWS::Partition}:iam::${pSharedDevOpsAccountId}:role/sdlf-cicd-team-codecommit-${pEnvironment}-${pTeamName}
             Action:
               - kms:CreateGrant
               - kms:ListGrants
@@ -119,7 +119,7 @@ Resources:
             Action: kms:*
             Effect: Allow
             Principal:
-              AWS: [!Sub "arn:aws:iam::${AWS::AccountId}:root"]
+              AWS: [!Sub "arn:${AWS::Partition}:iam::${AWS::AccountId}:root"]
             Resource: "*"
           - Sid: Allow Lake Formation permissions
             Action:
@@ -132,7 +132,7 @@ Resources:
             Principal:
               AWS:
                 [
-                  !Sub "arn:aws:iam::${AWS::AccountId}:role/aws-service-role/lakeformation.amazonaws.com/AWSServiceRoleForLakeFormationDataAccess",
+                  !Sub "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/aws-service-role/lakeformation.amazonaws.com/AWSServiceRoleForLakeFormationDataAccess",
                 ]
             Resource: "*"
 

--- a/sdlf-team/scripts/template-team-repos.yaml
+++ b/sdlf-team/scripts/template-team-repos.yaml
@@ -44,7 +44,7 @@ Resources:
           - Effect: Allow
             Principal:
               AWS:
-                - !Sub arn:aws:iam::${pChildAccountId}:root
+                - !Sub arn:${AWS::Partition}:iam::${pChildAccountId}:root
             Action:
               - sts:AssumeRole
       Policies:
@@ -76,15 +76,15 @@ Resources:
                   - codecommit:GetUploadArchiveStatus
                   - codecommit:UploadArchive
                 Resource:
-                  - !Sub arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-*
+                  - !Sub arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-*
               - Effect: Allow
                 Action:
                   - s3:Get*
                   - s3:ListBucket*
                   - s3:Put*
                 Resource:
-                  - !Sub arn:aws:s3:::sdlf-cfn-artifacts-${AWS::Region}-${pChildAccountId}
-                  - !Sub arn:aws:s3:::sdlf-cfn-artifacts-${AWS::Region}-${pChildAccountId}/*
+                  - !Sub arn:${AWS::Partition}:s3:::sdlf-cfn-artifacts-${AWS::Region}-${pChildAccountId}
+                  - !Sub arn:${AWS::Partition}:s3:::sdlf-cfn-artifacts-${AWS::Region}-${pChildAccountId}/*
               - Effect: Allow
                 Action:
                   - kms:Encrypt
@@ -94,7 +94,7 @@ Resources:
                   - kms:DescribeKey
                   - kms:List*
                   - kms:Describe*
-                Resource: !Sub arn:aws:kms:${AWS::Region}:${pChildAccountId}:key/*
+                Resource: !Sub arn:${AWS::Partition}:kms:${AWS::Region}:${pChildAccountId}:key/*
                 Condition:
                   ForAllValues:StringLike:
                     aws:PrincipalArn: !Sub "*${pTeamName}*"
@@ -111,13 +111,13 @@ Resources:
               "CodeCommit Repository State Change"
             ],
             "resources": [
-              "arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-pipeline",
-              "arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-dataset",
-              "arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-datalakeLibrary",
-              "arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-pipLibrary",
-              "arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-stageA",
-              "arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-stageB",
-              "arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-stageC"
+              "arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-pipeline",
+              "arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-dataset",
+              "arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-datalakeLibrary",
+              "arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-pipLibrary",
+              "arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-stageA",
+              "arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-stageB",
+              "arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-stageC"
             ],
             "source": [
               "aws.codecommit"
@@ -138,9 +138,9 @@ Resources:
         - { cBranch: !FindInMap [pCodeCommitBranch, !Ref pEnvironment, branch] }
       State: ENABLED
       Targets:
-        - Arn: !Sub arn:aws:events:${AWS::Region}:${pChildAccountId}:event-bus/default
+        - Arn: !Sub arn:${AWS::Partition}:events:${AWS::Region}:${pChildAccountId}:event-bus/default
           Id: !Sub sdlf-cicd-team-codecommit-${pEnvironment}-${pTeamName}
-          RoleArn: !Sub arn:aws:iam::${AWS::AccountId}:role/sdlf-cicd-foundations-eventbus-${pEnvironment}
+          RoleArn: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/sdlf-cicd-foundations-eventbus-${pEnvironment}
 
   rPullRequestCreated:
     Condition: IsProduction
@@ -155,13 +155,13 @@ Resources:
               "CodeCommit Pull Request State Change"
             ],
             "resources": [
-              "arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-pipeline",
-              "arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-dataset",
-              "arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-datalakeLibrary",
-              "arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-pipLibrary",
-              "arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-stageA",
-              "arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-stageB",
-              "arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-stageC"
+              "arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-pipeline",
+              "arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-dataset",
+              "arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-datalakeLibrary",
+              "arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-pipLibrary",
+              "arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-stageA",
+              "arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-stageB",
+              "arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-stageC"
             ],
             "source": [
               "aws.codecommit"
@@ -179,6 +179,6 @@ Resources:
         - { cBranch: !FindInMap [pCodeCommitBranch, !Ref pEnvironment, branch] }
       State: ENABLED
       Targets:
-        - Arn: !Sub arn:aws:events:${AWS::Region}:${pChildAccountId}:event-bus/default
+        - Arn: !Sub arn:${AWS::Partition}:events:${AWS::Region}:${pChildAccountId}:event-bus/default
           Id: !Sub sdlf-cicd-team-codecommit-pr-${pEnvironment}-${pTeamName}
-          RoleArn: !Sub arn:aws:iam::${AWS::AccountId}:role/sdlf-cicd-foundations-eventbus-${pEnvironment}
+          RoleArn: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/sdlf-cicd-foundations-eventbus-${pEnvironment}

--- a/sdlf-utils/ingestion-examples/cdc/dms-replication/template.yaml
+++ b/sdlf-utils/ingestion-examples/cdc/dms-replication/template.yaml
@@ -36,7 +36,7 @@ Resources:
               - sts:AssumeRole
       Path: /
       ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/service-role/AmazonDMSCloudWatchLogsRole
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AmazonDMSCloudWatchLogsRole
 
   rDMSVPCRole:
     Type: AWS::IAM::Role
@@ -53,7 +53,7 @@ Resources:
               - sts:AssumeRole
       Path: /
       ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/service-role/AmazonDMSVPCManagementRole
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AmazonDMSVPCManagementRole
 
   rExecutionRole:
     Type: AWS::IAM::Role
@@ -72,9 +72,9 @@ Resources:
               - sts:AssumeRole
       Path: /
       ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/service-role/AWSGlueServiceRole
-        - arn:aws:iam::aws:policy/AmazonS3FullAccess
-        - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSGlueServiceRole
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/AmazonS3FullAccess
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
       Policies:
         - PolicyName: DMSCDCExecutionPolicy
           PolicyDocument:
@@ -96,14 +96,14 @@ Resources:
                   - iam:PassRole
                   - lambda:InvokeFunction
                 Resource:
-                  - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/DMSCDC_Controller
-                  - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/octagon-ObjectMetadata-${pEnvironment}
-                  - !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${pOrg}-${pApp}-${pEnvironment}-${pTeamName}-dms-cdc-init-controller
-                  - !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${pOrg}-${pApp}-${pEnvironment}-${pTeamName}-dms-cdc-init-dms
-                  - !Sub arn:aws:iam::${AWS::AccountId}:role/${pOrg}-${pApp}-${pEnvironment}-${pTeamName}-dms-cdc-execution-role
-                  - !Sub arn:aws:dms:${AWS::Region}:${AWS::AccountId}:endpoint:*
-                  - !Sub arn:aws:dms:${AWS::Region}:${AWS::AccountId}:task:*
-                  - !Sub arn:aws:dms:${AWS::Region}:${AWS::AccountId}:rep:*
+                  - !Sub arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/DMSCDC_Controller
+                  - !Sub arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/octagon-ObjectMetadata-${pEnvironment}
+                  - !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:${pOrg}-${pApp}-${pEnvironment}-${pTeamName}-dms-cdc-init-controller
+                  - !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:${pOrg}-${pApp}-${pEnvironment}-${pTeamName}-dms-cdc-init-dms
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/${pOrg}-${pApp}-${pEnvironment}-${pTeamName}-dms-cdc-execution-role
+                  - !Sub arn:${AWS::Partition}:dms:${AWS::Region}:${AWS::AccountId}:endpoint:*
+                  - !Sub arn:${AWS::Partition}:dms:${AWS::Region}:${AWS::AccountId}:task:*
+                  - !Sub arn:${AWS::Partition}:dms:${AWS::Region}:${AWS::AccountId}:rep:*
               - Effect: Allow
                 Action:
                   - dms:DescribeConnections

--- a/sdlf-utils/ingestion-examples/cdc/dms-task/template.yaml
+++ b/sdlf-utils/ingestion-examples/cdc/dms-task/template.yaml
@@ -123,7 +123,7 @@ Resources:
           ]
         BucketName:
           Ref: pCentralBucket
-        ServiceAccessRoleArn: !Sub arn:aws:iam::${AWS::AccountId}:role/${pOrg}-${pApp}-${pEnvironment}-${pTeamName}-dms-cdc-execution-role
+        ServiceAccessRoleArn: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/${pOrg}-${pApp}-${pEnvironment}-${pTeamName}-dms-cdc-execution-role
 
   DMSReplicationTask:
     Type: AWS::DMS::ReplicationTask
@@ -143,7 +143,7 @@ Resources:
   InitDMS:
     Type: Custom::InitDMS
     Properties:
-      ServiceToken: !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${pOrg}-${pApp}-${pEnvironment}-${pTeamName}-dms-cdc-init-dms
+      ServiceToken: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:${pOrg}-${pApp}-${pEnvironment}-${pTeamName}-dms-cdc-init-dms
       taskArn: !Ref DMSReplicationTask
       sourceArn: !Ref DMSSourceEndpoint
       targetArn: !Ref DMSTargetEndpoint
@@ -155,7 +155,7 @@ Resources:
     DependsOn:
       - InitDMS
     Properties:
-      ServiceToken: !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:${pOrg}-${pApp}-${pEnvironment}-${pTeamName}-dms-cdc-init-controller
+      ServiceToken: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:${pOrg}-${pApp}-${pEnvironment}-${pTeamName}-dms-cdc-init-controller
       dmsBucket: !Ref pCentralBucket
       dmsPath: !Sub
         - "${prefix}/${schema}/"

--- a/sdlf-utils/ingestion-examples/preprocessing/fargate-unzip/template.yaml
+++ b/sdlf-utils/ingestion-examples/preprocessing/fargate-unzip/template.yaml
@@ -130,8 +130,8 @@ Resources:
             Action: s3:*
             Effect: Deny
             Resource:
-              - !Sub arn:aws:s3:::${pS3LandingBucketName}/*
-              - !Sub arn:aws:s3:::${pS3LandingBucketName}
+              - !Sub arn:${AWS::Partition}:s3:::${pS3LandingBucketName}/*
+              - !Sub arn:${AWS::Partition}:s3:::${pS3LandingBucketName}
             Condition:
               Bool:
                 aws:SecureTransport: False
@@ -174,7 +174,7 @@ Resources:
             Resource: !GetAtt "rLandingSQSQueue.Arn"
             Condition:
               ArnLike:
-                aws:SourceArn: !Sub "arn:aws:s3:::${pS3LandingBucketName}"
+                aws:SourceArn: !Sub "arn:${AWS::Partition}:s3:::${pS3LandingBucketName}"
       Queues:
         - !Ref "rLandingSQSQueue"
 
@@ -331,14 +331,14 @@ Resources:
               - Effect: "Allow"
                 Action: "s3:GetObject"
                 Resource:
-                  - !Sub "arn:aws:s3:::${rS3LandingBucket}/*"
-                  - !Sub "arn:aws:s3:::${rS3LandingBucket}/"
-                  - !Sub "arn:aws:s3:::${pS3RawBucketName}/*"
-                  - !Sub "arn:aws:s3:::${pS3RawBucketName}/"
+                  - !Sub "arn:${AWS::Partition}:s3:::${rS3LandingBucket}/*"
+                  - !Sub "arn:${AWS::Partition}:s3:::${rS3LandingBucket}/"
+                  - !Sub "arn:${AWS::Partition}:s3:::${pS3RawBucketName}/*"
+                  - !Sub "arn:${AWS::Partition}:s3:::${pS3RawBucketName}/"
               - Effect: "Allow"
                 Action: "s3:PutObject"
                 Resource:
-                  - !Sub "arn:aws:s3:::${pS3RawBucketName}/*"
-                  - !Sub "arn:aws:s3:::${pS3RawBucketName}/"
-                  - !Sub "arn:aws:s3:::${pAthenaBucketName}/*"
-                  - !Sub "arn:aws:s3:::${pAthenaBucketName}/"
+                  - !Sub "arn:${AWS::Partition}:s3:::${pS3RawBucketName}/*"
+                  - !Sub "arn:${AWS::Partition}:s3:::${pS3RawBucketName}/"
+                  - !Sub "arn:${AWS::Partition}:s3:::${pAthenaBucketName}/*"
+                  - !Sub "arn:${AWS::Partition}:s3:::${pAthenaBucketName}/"

--- a/sdlf-utils/ingestion-examples/sqoop/sdlf-pipeline/nested-stacks/template-statemachine.yaml
+++ b/sdlf-utils/ingestion-examples/sqoop/sdlf-pipeline/nested-stacks/template-statemachine.yaml
@@ -58,7 +58,7 @@ Resources:
           Actions:
             -
               Name: Source
-              RoleArn: !Sub arn:aws:iam::${pSharedDevOpsAccountId}:role/sdlf-cicd-team-codecommit-${pEnv}-${pTeamName}
+              RoleArn: !Sub arn:${AWS::Partition}:iam::${pSharedDevOpsAccountId}:role/sdlf-cicd-team-codecommit-${pEnv}-${pTeamName}
               ActionTypeId:
                 Category: Source
                 Owner: AWS
@@ -161,7 +161,7 @@ Resources:
         detail-type:
           - CodeCommit Repository State Change
         resources:
-          - !Sub arn:aws:codecommit:${AWS::Region}:${pSharedDevOpsAccountId}:${pRepositoryName}
+          - !Sub arn:${AWS::Partition}:codecommit:${AWS::Region}:${pSharedDevOpsAccountId}:${pRepositoryName}
         detail:
           event:
             - referenceCreated
@@ -171,7 +171,7 @@ Resources:
           referenceName:
             - !Ref pBranchName
       Targets:
-        - Arn: !Sub arn:aws:codepipeline:${AWS::Region}:${AWS::AccountId}:${rStateMachinePipeline}
+        - Arn: !Sub arn:${AWS::Partition}:codepipeline:${AWS::Region}:${AWS::AccountId}:${rStateMachinePipeline}
           Id: !Sub sdlf-${pTeamName}-${pPipeline}-${pRepositoryName}-trigger
           RoleArn: !Ref pCloudWatchRepositoryTriggerRoleArn
 
@@ -190,7 +190,7 @@ Resources:
           project-name:
             - !Ref pBuildDatalakeLibrary
       Targets:
-        - Arn: !Sub arn:aws:codepipeline:${AWS::Region}:${AWS::AccountId}:${rStateMachinePipeline}
+        - Arn: !Sub arn:${AWS::Partition}:codepipeline:${AWS::Region}:${AWS::AccountId}:${rStateMachinePipeline}
           Id: !Sub sdlf-${pTeamName}-${pPipeline}-${pRepositoryName}-update
           RoleArn: !Ref pCloudWatchRepositoryTriggerRoleArn
 

--- a/sdlf-utils/ingestion-examples/sqoop/sdlf-stageX/template.yaml
+++ b/sdlf-utils/ingestion-examples/sqoop/sdlf-stageX/template.yaml
@@ -198,8 +198,8 @@ Resources:
       RoleName: !Sub sdlf-${pTeamName}-${pPipeline}-sqoop-emr-Role
       ManagedPolicyArns:
         - !Ref rLambdaCommonPolicy
-        - arn:aws:iam::aws:policy/service-role/AmazonElasticMapReduceRole
-        #- arn:aws:iam::aws:policy/service-role/AmazonElasticMapReduceforAutoScalingRole
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AmazonElasticMapReduceRole
+        #- arn:${AWS::Partition}:iam::aws:policy/service-role/AmazonElasticMapReduceforAutoScalingRole
       AssumeRolePolicyDocument:
         Version: 2012-10-17
         Statement:
@@ -231,7 +231,7 @@ Resources:
             - athena:StopQueryExecution
             - athena:DeleteNamedQuery
             - athena:DeletePreparedStatement
-            Resource: !Sub arn:aws:athena:*:${AWS::AccountId}:*
+            Resource: !Sub arn:${AWS::Partition}:athena:*:${AWS::AccountId}:*
           - Effect: Allow
             Action:
             - kms:Decrypt
@@ -240,7 +240,7 @@ Resources:
             - kms:GenerateDataKey
             - kms:DescribeKey
             - kms:CreateGrant
-            Resource: !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/*
+            Resource: !Sub arn:${AWS::Partition}:kms:${AWS::Region}:${AWS::AccountId}:key/*
 
   rRoleSqoopEMREC2:
     Type: AWS::IAM::Role
@@ -248,9 +248,9 @@ Resources:
       RoleName: !Sub sdlf-${pTeamName}-${pPipeline}-emr-ec2
       ManagedPolicyArns:
         - !Ref rLambdaCommonPolicy
-        - arn:aws:iam::aws:policy/service-role/AmazonElasticMapReduceforEC2Role
-        - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
-        - arn:aws:iam::aws:policy/AmazonS3FullAccess
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AmazonElasticMapReduceforEC2Role
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/AmazonSSMManagedInstanceCore
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/AmazonS3FullAccess
       AssumeRolePolicyDocument:
         Version: 2012-10-17
         Statement:
@@ -270,11 +270,11 @@ Resources:
             Action:
             - elasticmapreduce:TerminateJobFlows
             - elasticmapreduce:ModifyCluster
-            Resource: !Sub arn:aws:elasticmapreduce:${AWS::Region}:${AWS::AccountId}:cluster/*
+            Resource: !Sub arn:${AWS::Partition}:elasticmapreduce:${AWS::Region}:${AWS::AccountId}:cluster/*
           - Effect: Allow
             Action:
             - ssm:GetParameter
-            Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/*
+            Resource: !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/*
           - Effect: Allow
             Action:
             - athena:List*
@@ -290,14 +290,14 @@ Resources:
             - athena:StopQueryExecution
             - athena:DeleteNamedQuery
             - athena:DeletePreparedStatement
-            Resource: !Sub arn:aws:athena:*:${AWS::AccountId}:*
+            Resource: !Sub arn:${AWS::Partition}:athena:*:${AWS::AccountId}:*
           - Effect: Allow
             Action:
             - secretsmanager:GetSecretValue
             Resource:
-            - !Sub arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:/SDLF/credentials/*
-            - !Sub arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:sdlf/sqoop/*
-            - !Sub arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:SDLF/SQOOP/*
+            - !Sub arn:${AWS::Partition}:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:/SDLF/credentials/*
+            - !Sub arn:${AWS::Partition}:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:sdlf/sqoop/*
+            - !Sub arn:${AWS::Partition}:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:SDLF/SQOOP/*
           - Effect: Allow
             Action:
             - secretsmanager:ListSecrets
@@ -308,7 +308,7 @@ Resources:
             - kms:Encrypt
             - kms:ReEncrypt*
             - kms:GenerateDataKey
-            Resource: !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/*
+            Resource: !Sub arn:${AWS::Partition}:kms:${AWS::Region}:${AWS::AccountId}:key/*
 
   rEmrInstanceProfile:
     Type: AWS::IAM::InstanceProfile
@@ -327,17 +327,17 @@ Resources:
           - Effect: Allow
             Action:
               - logs:CreateLogGroup
-            Resource: !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*
+            Resource: !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:*
           - Effect: Allow
             Action:
               - logs:CreateLogStream
               - logs:PutLogEvents
-            Resource: !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/sdlf-${pTeamName}-*
+            Resource: !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/sdlf-${pTeamName}-*
           - Effect: Allow
             Action:
               - ssm:GetParameter
               - ssm:GetParameters
-            Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/*
+            Resource: !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/*
           - Effect: Allow
             Action:
               - dynamodb:BatchGetItem
@@ -351,7 +351,7 @@ Resources:
               - dynamodb:Scan
               - dynamodb:UpdateItem
             Resource:
-              - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/octagon-*
+              - !Sub arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/octagon-*
           - Effect: Allow
             Action:
               - kms:CreateGrant
@@ -524,7 +524,7 @@ Resources:
                   - events:DeleteRule
                   - events:RemoveTargets
                 Resource:
-                  - !Sub arn:aws:events:${AWS::Region}:${AWS::AccountId}:rule/*
+                  - !Sub arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:rule/*
               - Effect: Allow
                 Action:
                   - dynamodb:GetRecords
@@ -564,11 +564,11 @@ Resources:
           - Effect: Allow
             Action:
               - lambda:InvokeFunction
-            Resource: !Sub arn:aws:events:${AWS::Region}:${AWS::AccountId}:rule/*
+            Resource: !Sub arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:rule/*
           - Effect: Allow
             Action:
               - states:StartExecution
-            Resource: !Sub arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:sdlf-${pTeamName}-${pPipeline}*
+            Resource: !Sub arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:stateMachine:sdlf-${pTeamName}-${pPipeline}*
           - Effect: Allow
             Action:
             - elasticmapreduce:*
@@ -577,11 +577,11 @@ Resources:
             Action:
             - s3:GetObject*
             - s3:PutObject*
-            Resource: arn:aws:s3:::*/*
+            Resource: !Sub arn:${AWS::Partition}:s3:::*/*
           - Effect: Allow
             Action:
             - s3:ListBucket
-            Resource: arn:aws:s3:::*
+            Resource: !Sub arn:${AWS::Partition}:s3:::*
           - Effect: Allow
             Action:
               - events:PutTargets
@@ -605,8 +605,8 @@ Resources:
             Action:
             - secretsmanager:GetSecretValue
             Resource:
-            - !Sub arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:SDLF/SQOOP/*
-            - !Sub arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:sdlf/sqoop/*
+            - !Sub arn:${AWS::Partition}:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:SDLF/SQOOP/*
+            - !Sub arn:${AWS::Partition}:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:sdlf/sqoop/*
           - Effect: Allow
             Action:
             - kms:CreateGrant

--- a/sdlf-utils/ingestion-examples/sqoop/sdlf-team/nested-stacks/template-iam.yaml
+++ b/sdlf-utils/ingestion-examples/sqoop/sdlf-team/nested-stacks/template-iam.yaml
@@ -62,7 +62,7 @@ Resources:
             Action:
               - s3:GetBucketLocation
               - s3:ListAllMyBuckets
-            Resource: arn:aws:s3:::*
+            Resource: !Sub arn:${AWS::Partition}:s3:::*
           - Sid: AllowTeamBucketList
             Effect: Allow
             Action:
@@ -71,11 +71,11 @@ Resources:
               - s3:ListBucketMultipartUploads
             Resource:
               [
-                !Sub "arn:aws:s3:::${pPipelineBucket}",
-                !Sub "arn:aws:s3:::${pCentralBucket}",
-                !Sub "arn:aws:s3:::${pStageBucket}",
-                !Sub "arn:aws:s3:::${pAnalyticsBucket}",
-                !Sub "arn:aws:s3:::${pAthenaBucket}",
+                !Sub "arn:${AWS::Partition}:s3:::${pPipelineBucket}",
+                !Sub "arn:${AWS::Partition}:s3:::${pCentralBucket}",
+                !Sub "arn:${AWS::Partition}:s3:::${pStageBucket}",
+                !Sub "arn:${AWS::Partition}:s3:::${pAnalyticsBucket}",
+                !Sub "arn:${AWS::Partition}:s3:::${pAthenaBucket}",
               ]
           - Sid: AllowTeamPrefixActions
             Effect: Allow
@@ -87,22 +87,22 @@ Resources:
               - s3:AbortMultipartUpload
               - s3:PutObjectTagging
             Resource:
-              - !Sub arn:aws:s3:::${pPipelineBucket}/${pTeamName}/*
-              - !Sub arn:aws:s3:::${pPipelineBucket}/*/${pTeamName}/*
+              - !Sub arn:${AWS::Partition}:s3:::${pPipelineBucket}/${pTeamName}/*
+              - !Sub arn:${AWS::Partition}:s3:::${pPipelineBucket}/*/${pTeamName}/*
               - !If [
                   CreateMultipleBuckets,
-                  !Sub "arn:aws:s3:::${pCentralBucket}/${pTeamName}/*",
-                  !Sub "arn:aws:s3:::${pCentralBucket}/raw/${pTeamName}/*",
+                  !Sub "arn:${AWS::Partition}:s3:::${pCentralBucket}/${pTeamName}/*",
+                  !Sub "arn:${AWS::Partition}:s3:::${pCentralBucket}/raw/${pTeamName}/*",
                 ]
-              - !Sub arn:aws:s3:::${pStageBucket}/${pTeamName}/*
-              - !Sub arn:aws:s3:::${pStageBucket}/pre-stage/${pTeamName}/*
-              - !Sub arn:aws:s3:::${pStageBucket}/stage/${pTeamName}/*
-              - !Sub arn:aws:s3:::${pStageBucket}/post-stage/${pTeamName}/*
-              - !Sub arn:aws:s3:::${pAthenaBucket}/${pTeamName}/*
+              - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/${pTeamName}/*
+              - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/pre-stage/${pTeamName}/*
+              - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/stage/${pTeamName}/*
+              - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/post-stage/${pTeamName}/*
+              - !Sub arn:${AWS::Partition}:s3:::${pAthenaBucket}/${pTeamName}/*
               - !If [
                   CreateMultipleBuckets,
-                  !Sub "arn:aws:s3:::${pAnalyticsBucket}/${pTeamName}/*",
-                  !Sub "arn:aws:s3:::${pAnalyticsBucket}/analytics/*",
+                  !Sub "arn:${AWS::Partition}:s3:::${pAnalyticsBucket}/${pTeamName}/*",
+                  !Sub "arn:${AWS::Partition}:s3:::${pAnalyticsBucket}/analytics/*",
                 ]
           - Sid: Allows3Read
             Effect: Allow
@@ -112,14 +112,14 @@ Resources:
               - s3:ListMultipartUploadParts
               - s3:AbortMultipartUpload
             Resource:
-              - !Sub arn:aws:s3:::${pArtifactBucket}/*
-              - !Sub arn:aws:s3:::${pCloudtraailBucket}/*
+              - !Sub arn:${AWS::Partition}:s3:::${pArtifactBucket}/*
+              - !Sub arn:${AWS::Partition}:s3:::${pCloudtraailBucket}/*
           - Sid: AllowFullCodeCommitOnTeamRepositories
             Effect: Allow
             Action:
               - codecommit:*
             Resource:
-              - !Sub arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
+              - !Sub arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
           - Sid: AllowTeamKMSDataKeyUsage
             Effect: Allow
             Action:
@@ -137,7 +137,7 @@ Resources:
             Action:
               - ssm:GetParameter
               - ssm:GetParameters
-            Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/*
+            Resource: !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/*
           - Sid: AllowOctagonDynamoAccess
             Effect: Allow
             Action:
@@ -156,7 +156,7 @@ Resources:
               - dynamodb:ListStreams
               - dynamodb:ListShards
             Resource:
-              - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/octagon-*
+              - !Sub arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/octagon-*
           - Sid: AllowSQSManagement
             Effect: Allow
             Action:
@@ -171,29 +171,29 @@ Resources:
               - sqs:SendMessage
               - sqs:SendMessageBatch
             Resource:
-              - !Sub arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
+              - !Sub arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
           - Effect: Allow
             Action:
               - states:StartExecution
             Resource:
-              - !Sub arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:sdlf-${pTeamName}-*
+              - !Sub arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:stateMachine:sdlf-${pTeamName}-*
           - Effect: Allow
             Action:
               - glue:StartCrawler
             Resource:
-              - !Sub arn:aws:glue:${AWS::Region}:${AWS::AccountId}:crawler/sdlf-${pTeamName}-*
+              - !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:crawler/sdlf-${pTeamName}-*
           - Effect: Allow
             Action:
               - glue:GetJobRun
               - glue:GetJobRuns
               - glue:StartJobRun
             Resource:
-              - !Sub arn:aws:glue:${AWS::Region}:${AWS::AccountId}:job/sdlf-${pTeamName}-*
-              - !Sub arn:aws:glue:${AWS::Region}:${AWS::AccountId}:job/${pOrganizationName}-${pApplicationName}-${pEnvironment}-${pTeamName}-*
+              - !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:job/sdlf-${pTeamName}-*
+              - !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:job/${pOrganizationName}-${pApplicationName}-${pEnvironment}-${pTeamName}-*
           - Effect: Allow
             Action:
               - logs:CreateLogGroup
-            Resource: !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*
+            Resource: !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:*
           - Sid: AllowCloudWatchLogsReadOnlyAccess
             Effect: Allow
             Action:
@@ -202,9 +202,9 @@ Resources:
               - logs:GetLogEvents
               - logs:PutLogEvents
             Resource:
-              - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/sdlf-${pTeamName}-*
-              - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/sdlf-${pTeamName}-*
-              - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws-glue/jobs/sdlf-${pTeamName}-*
+              - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/sdlf-${pTeamName}-*
+              - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/sdlf-${pTeamName}-*
+              - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws-glue/jobs/sdlf-${pTeamName}-*
           - Sid: AllowCloudFormationReadOnlyAccess
             Effect: Allow
             Action:
@@ -213,7 +213,7 @@ Resources:
               - cloudformation:DescribeStackResource
               - cloudformation:DescribeStackResources
             Resource:
-              - !Sub arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack:sdlf-${pTeamName}:*
+              - !Sub arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stack:sdlf-${pTeamName}:*
           - Sid: AllowAthenaProcessing
             Effect: Allow
             Action:
@@ -229,9 +229,9 @@ Resources:
               - athena:GetQueryExecution
               - athena:GetQueryResults
             Resource:
-              - !Sub arn:aws:glue:${AWS::Region}:${AWS::AccountId}:*
-              - !Sub arn:aws:athena:${AWS::Region}:${AWS::AccountId}:*
-              - !Sub arn:aws:lakeformation:${AWS::Region}:${AWS::AccountId}:*
+              - !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:*
+              - !Sub arn:${AWS::Partition}:athena:${AWS::Region}:${AWS::AccountId}:*
+              - !Sub arn:${AWS::Partition}:lakeformation:${AWS::Region}:${AWS::AccountId}:*
           - Sid: AllowEMR
             Effect: Allow
             Action:
@@ -247,20 +247,20 @@ Resources:
               - events:DeleteRule
               - events:RemoveTargets
             Resource:
-              - !Sub arn:aws:events:${AWS::Region}:${AWS::AccountId}:rule/*
+              - !Sub arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:rule/*
           - Sid: GetSecrets
             Effect: Allow
             Action:
               - secretsmanager:GetSecretValue
             Resource:
-              - !Sub arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:SDLF/SQOOP/*
-              - !Sub arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:sdlf/sqoop/*
+              - !Sub arn:${AWS::Partition}:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:SDLF/SQOOP/*
+              - !Sub arn:${AWS::Partition}:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:sdlf/sqoop/*
           - Sid: CallLambda
             Effect: Allow
             Action:
               - lambda:AddPermission
               - lambda:InvokeFunction
-            Resource: !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:sdlf-${pTeamName}*
+            Resource: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:sdlf-${pTeamName}*
 
   rCodePipelineRole:
     Type: AWS::IAM::Role
@@ -298,25 +298,25 @@ Resources:
                 Action:
                   - iam:PassRole
                 Resource:
-                  - !Sub arn:aws:iam::${AWS::AccountId}:role/sdlf-${pTeamName}-*
-                  - !Sub arn:aws:iam::${AWS::AccountId}:role/state-machine/sdlf-${pTeamName}-*
-                  - !Sub arn:aws:iam::${AWS::AccountId}:role/glue/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/state-machine/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/glue/sdlf-${pTeamName}-*
                   - !GetAtt rRoleCloudWatchEventRole.Arn
-                  - !Sub arn:aws:iam::${AWS::AccountId}:role/service-role/*
-                  - !Sub arn:aws:iam::${AWS::AccountId}:role/EMR*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/service-role/*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/EMR*
               - Effect: Allow
                 Action:
                   - iam:ListRoles
                 Resource:
-                  - !Sub arn:aws:iam::${AWS::AccountId}:role/*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/*
               - Effect: Allow
                 Action:
                   - iam:CreateRole
                 Resource:
-                  - !Sub arn:aws:iam::${AWS::AccountId}:role/sdlf-${pTeamName}-*
-                  - !Sub arn:aws:iam::${AWS::AccountId}:role/state-machine/sdlf-${pTeamName}-*
-                  - !Sub arn:aws:iam::${AWS::AccountId}:role/service-role/sdlf-${pTeamName}-*
-                  - !Sub arn:aws:iam::${AWS::AccountId}:role/glue/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/state-machine/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/service-role/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/glue/sdlf-${pTeamName}-*
                 Condition:
                   StringEquals:
                     iam:PermissionsBoundary: !Ref rTeamIAMManagedPolicy
@@ -325,18 +325,18 @@ Resources:
                   - iam:AttachRolePolicy
                   - iam:DetachRolePolicy
                 Resource:
-                  - !Sub arn:aws:iam::${AWS::AccountId}:role/sdlf-${pTeamName}-*
-                  - !Sub arn:aws:iam::${AWS::AccountId}:role/state-machine/sdlf-${pTeamName}-*
-                  - !Sub arn:aws:iam::${AWS::AccountId}:role/service-role/sdlf-${pTeamName}-*
-                  - !Sub arn:aws:iam::${AWS::AccountId}:role/glue/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/state-machine/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/service-role/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/glue/sdlf-${pTeamName}-*
                 Condition:
                   ArnEquals:
                     iam:PolicyARN:
-                      - !Sub arn:aws:iam::${AWS::AccountId}:policy/sdlf-${pTeamName}-*
-                      - arn:aws:iam::aws:policy/service-role/AmazonElasticMapReduceRole
-                      - arn:aws:iam::aws:policy/service-role/AmazonElasticMapReduceforEC2Role
-                      - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
-                      - arn:aws:iam::aws:policy/AmazonS3FullAccess
+                      - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:policy/sdlf-${pTeamName}-*
+                      - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AmazonElasticMapReduceRole
+                      - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AmazonElasticMapReduceforEC2Role
+                      - !Sub arn:${AWS::Partition}:iam::aws:policy/AmazonSSMManagedInstanceCore
+                      - !Sub arn:${AWS::Partition}:iam::aws:policy/AmazonS3FullAccess
               - Effect: Allow
                 Action:
                   - iam:DeleteRole
@@ -350,16 +350,16 @@ Resources:
                   - iam:UpdateRoleDescription
                   - iam:TagRole
                 Resource:
-                  - !Sub arn:aws:iam::${AWS::AccountId}:role/sdlf-${pTeamName}-*
-                  - !Sub arn:aws:iam::${AWS::AccountId}:role/state-machine/sdlf-${pTeamName}-*
-                  - !Sub arn:aws:iam::${AWS::AccountId}:role/service-role/sdlf-${pTeamName}-*
-                  - !Sub arn:aws:iam::${AWS::AccountId}:role/glue/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/state-machine/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/service-role/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/glue/sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - iam:ListPolicies
                   - iam:ListPolicyVersions
                 Resource:
-                  - !Sub arn:aws:iam::${AWS::AccountId}:policy/*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:policy/*
               - Effect: Allow
                 Action:
                   - iam:CreatePolicy
@@ -369,13 +369,13 @@ Resources:
                   - iam:GetPolicy
                   - iam:GetPolicyVersion
                 Resource:
-                  - !Sub arn:aws:iam::${AWS::AccountId}:policy/sdlf-${pTeamName}-*
-                  - !Sub arn:aws:iam::${AWS::AccountId}:policy/state-machine/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:policy/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:policy/state-machine/sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - iam:*InstanceProfile
                 Resource:
-                  - !Sub arn:aws:iam::${AWS::AccountId}:instance-profile/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - codecommit:CancelUploadArchive
@@ -384,7 +384,7 @@ Resources:
                   - codecommit:GetUploadArchiveStatus
                   - codecommit:UploadArchive
                 Resource:
-                  - !Sub arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - events:DeleteRule
@@ -392,7 +392,7 @@ Resources:
                   - events:PutRule
                   - events:PutTargets
                   - events:RemoveTargets
-                Resource: !Sub arn:aws:events:${AWS::Region}:${AWS::AccountId}:rule/sdlf-${pTeamName}-*
+                Resource: !Sub arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:rule/sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - lambda:GetLayerVersion
@@ -418,11 +418,11 @@ Resources:
                   - lambda:UpdateFunctionCode
                   - lambda:UpdateFunctionConfiguration
                   - lambda:UpdateFunctionConfiguration
-                Resource: !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:sdlf-${pTeamName}-*
+                Resource: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - lambda:InvokeFunction
-                Resource: !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:sdlf-foundations-rKibana*
+                Resource: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:sdlf-foundations-rKibana*
               - Effect: Allow
                 Action:
                   - lambda:CreateEventSourceMapping
@@ -441,14 +441,14 @@ Resources:
                   - cloudformation:ExecuteChangeSet
                   - cloudformation:SetStackPolicy
                   - cloudformation:UpdateStack
-                Resource: !Sub arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/sdlf-${pTeamName}-*
+                Resource: !Sub arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - cloudformation:CreateChangeSet
                   - cloudformation:DeleteChangeSet
                   - cloudformation:DescribeChangeSet
                   - cloudformation:ExecuteChangeSet
-                Resource: !Sub arn:aws:cloudformation:${AWS::Region}:aws:transform/*
+                Resource: !Sub arn:${AWS::Partition}:cloudformation:${AWS::Region}:aws:transform/*
               - Effect: Allow
                 Action:
                   - cloudformation:ValidateTemplate
@@ -459,7 +459,7 @@ Resources:
                   - codebuild:CreateProject
                   - codebuild:StartBuild
                   - codebuild:UpdateProject
-                Resource: !Sub arn:aws:codebuild:${AWS::Region}:${AWS::AccountId}:project/sdlf-${pTeamName}-*
+                Resource: !Sub arn:${AWS::Partition}:codebuild:${AWS::Region}:${AWS::AccountId}:project/sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - states:CreateActivity
@@ -467,25 +467,25 @@ Resources:
                   - states:ListActivities
                   - states:ListStateMachines
                   - states:TagResource
-                Resource: !Sub arn:aws:states:${AWS::Region}:${AWS::AccountId}:*
+                Resource: !Sub arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:*
               - Effect: Allow
                 Action:
                   - states:DeleteStateMachine
                   - states:DescribeStateMachine
                   - states:DescribeStateMachineForExecution
                   - states:UpdateStateMachine
-                Resource: !Sub arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:sdlf-${pTeamName}-*
+                Resource: !Sub arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:stateMachine:sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - states:DescribeActivity
                   - states:DeleteActivity
                   - states:GetActivityTask
-                Resource: !Sub arn:aws:states:${AWS::Region}:${AWS::AccountId}:activity:sdlf-${pTeamName}-*
+                Resource: !Sub arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:activity:sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - logs:CreateLogGroup
                   - logs:DescribeLogGroups
-                Resource: !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*
+                Resource: !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:*
               - Effect: Allow
                 Action:
                   - logs:CreateLogStream
@@ -496,8 +496,8 @@ Resources:
                   - logs:PutRetentionPolicy
                   - logs:TagLogGroup
                 Resource:
-                  - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/sdlf-${pTeamName}-*:log-stream:*
-                  - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/sdlf-${pTeamName}-*:log-stream:*
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/sdlf-${pTeamName}-*:log-stream:*
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/sdlf-${pTeamName}-*:log-stream:*
               - Effect: Allow
                 Action:
                   - cloudwatch:DeleteAlarms
@@ -506,11 +506,11 @@ Resources:
                   - cloudwatch:PutMetricData
                   - cloudwatch:SetAlarmState
                 Resource:
-                  - !Sub arn:aws:cloudwatch:${AWS::Region}:${AWS::AccountId}:alarm:sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:cloudwatch:${AWS::Region}:${AWS::AccountId}:alarm:sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - sqs:ListQueues
-                Resource: !Sub arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:*
+                Resource: !Sub arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:*
               - Effect: Allow
                 Action:
                   - sqs:AddPermission
@@ -521,7 +521,7 @@ Resources:
                   - sqs:GetQueueAttributes
                   - sqs:SetQueueAttributes
                   - sqs:TagQueue
-                Resource: !Sub arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
+                Resource: !Sub arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - s3:CreateBucket
@@ -540,10 +540,10 @@ Resources:
                   - s3:PutObject
                   - s3:SetBucketEncryption
                 Resource:
-                  - !Sub arn:aws:s3:::${pCFNBucket}
-                  - !Sub arn:aws:s3:::${pCFNBucket}/*
-                  - !Sub arn:aws:s3:::${pPipelineBucket}
-                  - !Sub arn:aws:s3:::${pPipelineBucket}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pCFNBucket}
+                  - !Sub arn:${AWS::Partition}:s3:::${pCFNBucket}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pPipelineBucket}
+                  - !Sub arn:${AWS::Partition}:s3:::${pPipelineBucket}/*
               - Effect: Allow
                 Action:
                   - ssm:AddTagsToResource
@@ -555,12 +555,12 @@ Resources:
                   - ssm:GetParametersByPath
                   - ssm:ListTagsForResource
                   - ssm:RemoveTagsFromResource
-                Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/*
+                Resource: !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/*
               - Effect: Allow
                 Action:
                   - ssm:DeleteParameter
                   - ssm:PutParameter
-                Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/*/${pTeamName}/*
+                Resource: !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/*/${pTeamName}/*
               - Effect: Allow
                 Action:
                   - kms:CreateGrant
@@ -573,7 +573,7 @@ Resources:
                   - !Ref pKMSInfraKeyId
               - Effect: Allow
                 Action: sts:AssumeRole
-                Resource: !Sub arn:aws:iam::${pSharedDevOpsAccountId}:role/sdlf-cicd-team-codecommit-${pEnvironment}-${pTeamName}
+                Resource: !Sub arn:${AWS::Partition}:iam::${pSharedDevOpsAccountId}:role/sdlf-cicd-team-codecommit-${pEnvironment}-${pTeamName}
               - Effect: Allow
                 Action: ec2:DescribeSubnets
                 Resource: "*"
@@ -588,14 +588,14 @@ Resources:
                   - dynamodb:*Backup
                   - dynamodb:*Backups
                 Resource:
-                  - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/octagon-${pTeamName}-*
-                  - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/octagon-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - iam:CreateRole
                 Resource:
-                  - !Sub arn:aws:iam::${AWS::AccountId}:role/sdlf-${pTeamName}-*-emr-ec2
-                  - !Sub arn:aws:iam::${AWS::AccountId}:role/sdlf-${pTeamName}-*-emr-Role
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/sdlf-${pTeamName}-*-emr-ec2
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/sdlf-${pTeamName}-*-emr-Role
 
   rCloudWatchRepositoryTriggerRole:
     Type: AWS::IAM::Role
@@ -619,10 +619,10 @@ Resources:
                 Action:
                   - codebuild:BatchGetBuilds
                   - codebuild:StartBuild
-                Resource: !Sub arn:aws:codebuild:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
+                Resource: !Sub arn:${AWS::Partition}:codebuild:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
               - Effect: Allow
                 Action: codepipeline:StartPipelineExecution
-                Resource: !Sub arn:aws:codepipeline:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
+                Resource: !Sub arn:${AWS::Partition}:codepipeline:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
 
   rTransformValidateRole:
     Type: AWS::IAM::Role
@@ -658,13 +658,13 @@ Resources:
                   - codecommit:List*
                   - codecommit:UploadArchive
                 Resource:
-                  - !Sub arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - logs:CreateLogGroup
                   - logs:CreateLogStream
                   - logs:PutLogEvents
-                Resource: !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/sdlf-${pTeamName}*
+                Resource: !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/sdlf-${pTeamName}*
               - Effect: Allow
                 Action:
                   - s3:GetBucketAcl
@@ -673,8 +673,8 @@ Resources:
                   - s3:GetObjectVersion
                   - s3:PutObject
                 Resource:
-                  - !Sub arn:aws:s3:::${pPipelineBucket}/*
-                  - !Sub arn:aws:s3:::${pCFNBucket}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pPipelineBucket}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pCFNBucket}/*
               - Effect: Allow
                 Action:
                   - lambda:List*
@@ -682,7 +682,7 @@ Resources:
               - Effect: Allow
                 Action:
                   - lambda:GetLayer*
-                Resource: !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:layer:sdlf-${pTeamName}-*
+                Resource: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:layer:sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - kms:CreateGrant
@@ -713,7 +713,7 @@ Resources:
             Statement:
               - Effect: Allow
                 Action: sts:AssumeRole
-                Resource: !Sub arn:aws:iam::${pSharedDevOpsAccountId}:role/sdlf-cicd-team-codecommit-${pEnvironment}-${pTeamName}
+                Resource: !Sub arn:${AWS::Partition}:iam::${pSharedDevOpsAccountId}:role/sdlf-cicd-team-codecommit-${pEnvironment}-${pTeamName}
               - Effect: Allow
                 Action:
                   - iam:DeleteRole
@@ -729,9 +729,9 @@ Resources:
                   - iam:CreateRole
                   - iam:PassRole
                 Resource:
-                  - !Sub arn:aws:iam::${AWS::AccountId}:role/sdlf-${pTeamName}-*
-                  - !Sub arn:aws:iam::${AWS::AccountId}:role/service-role/sdlf-${pTeamName}-*
-                  - !Sub arn:aws:iam::${pSharedDevOpsAccountId}:role/sdlf-cicd-team-codecommit-${pEnvironment}-${pTeamName}
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/service-role/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:iam::${pSharedDevOpsAccountId}:role/sdlf-cicd-team-codecommit-${pEnvironment}-${pTeamName}
               - Effect: Allow
                 Action:
                   - cloudformation:CreateChangeSet
@@ -743,14 +743,14 @@ Resources:
                   - cloudformation:ExecuteChangeSet
                   - cloudformation:SetStackPolicy
                   - cloudformation:UpdateStack
-                Resource: !Sub arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/sdlf-${pTeamName}-*
+                Resource: !Sub arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - cloudformation:CreateChangeSet
                   - cloudformation:DeleteChangeSet
                   - cloudformation:DescribeChangeSet
                   - cloudformation:ExecuteChangeSet
-                Resource: !Sub arn:aws:cloudformation:${AWS::Region}:aws:transform/*
+                Resource: !Sub arn:${AWS::Partition}:cloudformation:${AWS::Region}:aws:transform/*
               - Effect: Allow
                 Action:
                   - ssm:AddTagsToResource
@@ -762,13 +762,13 @@ Resources:
                   - ssm:GetParametersByPath
                   - ssm:ListTagsForResource
                   - ssm:RemoveTagsFromResource
-                Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/*
+                Resource: !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/*
               - Effect: Allow
                 Action:
                   - ssm:DeleteParameter
                   - ssm:DeleteParameters
                   - ssm:PutParameter
-                Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/*/${pTeamName}/*
+                Resource: !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/*/${pTeamName}/*
               - Effect: Allow
                 Action:
                   - dynamodb:DeleteItem
@@ -778,8 +778,8 @@ Resources:
                   - dynamodb:Scan
                   - dynamodb:UpdateItem
                 Resource:
-                  - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/octagon-Pipelines-${pEnvironment}
-                  - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/octagon-Datasets-${pEnvironment}
+                  - !Sub arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/octagon-Pipelines-${pEnvironment}
+                  - !Sub arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/octagon-Datasets-${pEnvironment}
               - Effect: Allow
                 Action:
                   - dynamodb:CreateTable
@@ -791,15 +791,15 @@ Resources:
                   - dynamodb:*Backup
                   - dynamodb:*Backups
                 Resource:
-                  - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/octagon-${pTeamName}-*
-                  - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/octagon-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - athena:CreateWorkGroup
                   - athena:DeleteWorkGroup
                   - athena:UpdateWorkGroup
                 Resource:
-                  - !Sub arn:aws:athena:${AWS::Region}:${AWS::AccountId}:workgroup/${pTeamName}*
+                  - !Sub arn:${AWS::Partition}:athena:${AWS::Region}:${AWS::AccountId}:workgroup/${pTeamName}*
               - Effect: Allow
                 Action:
                   - events:DeleteRule
@@ -809,7 +809,7 @@ Resources:
                   - events:PutRule
                   - events:PutTargets
                   - events:RemoveTargets
-                Resource: !Sub arn:aws:events:${AWS::Region}:${AWS::AccountId}:rule/sdlf-${pTeamName}-*
+                Resource: !Sub arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:rule/sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - codepipeline:CreatePipeline
@@ -817,7 +817,7 @@ Resources:
                   - codepipeline:GetPipelineState
                   - codepipeline:GetPipeline
                   - codepipeline:UpdatePipeline
-                Resource: !Sub arn:aws:codepipeline:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
+                Resource: !Sub arn:${AWS::Partition}:codepipeline:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - codebuild:BatchGetProjects
@@ -825,16 +825,16 @@ Resources:
                   - codebuild:CreateProject
                   - codebuild:DeleteProject
                   - codebuild:UpdateProject
-                Resource: !Sub arn:aws:codebuild:${AWS::Region}:${AWS::AccountId}:project/sdlf-${pTeamName}-*
+                Resource: !Sub arn:${AWS::Partition}:codebuild:${AWS::Region}:${AWS::AccountId}:project/sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - s3:ListBucket
-                Resource: !Sub arn:aws:s3:::${pCFNBucket}
+                Resource: !Sub arn:${AWS::Partition}:s3:::${pCFNBucket}
               - Effect: Allow
                 Action:
                   - s3:GetObject
                   - s3:PutObject
-                Resource: !Sub arn:aws:s3:::${pCFNBucket}/*
+                Resource: !Sub arn:${AWS::Partition}:s3:::${pCFNBucket}/*
               - Effect: Allow
                 Action:
                   - kms:CreateGrant
@@ -851,7 +851,7 @@ Resources:
                   - logs:CreateLogStream
                   - logs:PutLogEvents
                 Resource:
-                  - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - lakeformation:GetDataAccess
@@ -875,7 +875,7 @@ Resources:
                   - sqs:SetQueueAttributes
                   - sqs:TagQueue
                   - sqs:UntagQueue
-                Resource: !Sub arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
+                Resource: !Sub arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - glue:TagResource
@@ -888,7 +888,7 @@ Resources:
                   - glue:GetCrawler
                   - glue:GetCrawlers
                   - glue:UpdateCrawler
-                Resource: !Sub arn:aws:glue:${AWS::Region}:${AWS::AccountId}:crawler/sdlf-${pTeamName}-*
+                Resource: !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:crawler/sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - glue:CreateDatabase
@@ -898,12 +898,12 @@ Resources:
                   - glue:UpdateDatabase
                   - glue:*Table
                 Resource:
-                  - !Sub arn:aws:glue:${AWS::Region}:${AWS::AccountId}:catalog
-                  - !Sub arn:aws:glue:${AWS::Region}:${AWS::AccountId}:database/${pOrganizationName}_${pApplicationName}_${pEnvironment}_${pTeamName}_*
-                  - !Sub arn:aws:glue:${AWS::Region}:${AWS::AccountId}:database/*${pTeamName}*
-                  - !Sub arn:aws:glue:${AWS::Region}:${AWS::AccountId}:table/*
-                  - !Sub arn:aws:glue:${AWS::Region}:${AWS::AccountId}:userDefinedFunction/*${pTeamName}*
-                  - !Sub arn:aws:glue:${AWS::Region}:${AWS::AccountId}:userDefinedFunction/${pTeamName}*
+                  - !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:catalog
+                  - !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:database/${pOrganizationName}_${pApplicationName}_${pEnvironment}_${pTeamName}_*
+                  - !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:database/*${pTeamName}*
+                  - !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:table/*
+                  - !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:userDefinedFunction/*${pTeamName}*
+                  - !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:userDefinedFunction/${pTeamName}*
               - Effect: Allow
                 Action:
                   - lambda:AddPermission
@@ -924,7 +924,7 @@ Resources:
                   - lambda:UpdateFunctionCode
                   - lambda:UpdateFunctionConfiguration
                   - lambda:UpdateFunctionConfiguration
-                Resource: !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:sdlf-${pTeamName}*
+                Resource: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:sdlf-${pTeamName}*
               - Effect: Allow
                 Action:
                   - lambda:CreateEventSourceMapping
@@ -956,7 +956,7 @@ Resources:
                   - logs:CreateLogStream
                   - logs:PutLogEvents
                 Resource:
-                  - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - s3:GetBucketAcl
@@ -965,12 +965,12 @@ Resources:
                   - s3:GetObjectVersion
                   - s3:PutObject
                 Resource:
-                  - !Sub arn:aws:s3:::${pPipelineBucket}/*
-                  - !Sub arn:aws:s3:::${pCFNBucket}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pPipelineBucket}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pCFNBucket}/*
               - Effect: Allow
                 Action: codecommit:GitPull
                 Resource:
-                  - !Sub arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - kms:CreateGrant
@@ -1008,7 +1008,7 @@ Resources:
               - Effect: Allow
                 Action:
                   - lambda:InvokeFunction
-                Resource: !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:sdlf-${pTeamName}-*
+                Resource: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - states:DescribeStateMachine
@@ -1025,7 +1025,7 @@ Resources:
                   - events:DescribeRule
                   - events:PutRule
                   - events:PutTargets
-                Resource: !Sub arn:aws:events:${AWS::Region}:${AWS::AccountId}:rule/StepFunctionsGetEventsForStepFunctionsExecutionRule
+                Resource: !Sub arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:rule/StepFunctionsGetEventsForStepFunctionsExecutionRule
               - Effect: Allow
                 Action:
                   - elasticmapreduce:DescribeCluster
@@ -1042,17 +1042,17 @@ Resources:
                   - elasticmapreduce:ModifyInstanceFleet
                   - elasticmapreduce:ModifyInstanceGroups
                   - elasticmapreduce:SetTerminationProtection
-                Resource: !Sub arn:aws:elasticmapreduce:${AWS::Region}:${AWS::AccountId}:cluster/*
+                Resource: !Sub arn:${AWS::Partition}:elasticmapreduce:${AWS::Region}:${AWS::AccountId}:cluster/*
               - Effect: Allow
                 Action:
                   - iam:PassRole
-                Resource: !Sub arn:aws:iam::${AWS::AccountId}:role/EMR*
+                Resource: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/EMR*
               - Effect: Allow
                 Action:
                   - iam:CreateServiceLinkedRole
                   - iam:PutRolePolicy
                   - iam:UpdateRoleDescription
-                Resource: !Sub arn:aws:iam::${AWS::AccountId}:role/aws-service-role/elasticmapreduce.amazonaws.com/AWSServiceRoleForEMRCleanup*
+                Resource: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/aws-service-role/elasticmapreduce.amazonaws.com/AWSServiceRoleForEMRCleanup*
                 Condition:
                   StringLike:
                     iam:AWSServiceName: elasticmapreduce.amazonaws.com
@@ -1089,7 +1089,7 @@ Resources:
               - Effect: Allow
                 Action:
                   - lambda:InvokeFunction
-                Resource: !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:sdlf-${pTeamName}-*
+                Resource: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:sdlf-${pTeamName}-*
         - PolicyName: !Sub sdlf-${pTeamName}-describe-state-machines
           PolicyDocument:
             Version: 2012-10-17
@@ -1097,7 +1097,7 @@ Resources:
               - Effect: Allow
                 Action:
                   - states:ListStateMachines
-                Resource: !Sub arn:aws:states:${AWS::Region}:${AWS::AccountId}:*
+                Resource: !Sub arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:*
         - PolicyName: !Sub sdlf-${pTeamName}-dataset-state-machine
           PolicyDocument:
             Version: 2012-10-17
@@ -1107,7 +1107,7 @@ Resources:
                   - states:DescribeStateMachineForExecution
                   - states:DescribeStateMachine
                   - states:StartExecution
-                Resource: !Sub arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:sdlf-${pTeamName}-*
+                Resource: !Sub arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:stateMachine:sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - s3:ListBucket
@@ -1115,10 +1115,10 @@ Resources:
                   - s3:GetObjectVersion
                   - s3:GetBucketVersioning
                 Resource:
-                  - !Sub arn:aws:s3:::${pPipelineBucket}
-                  - !Sub arn:aws:s3:::${pCentralBucket}
-                  - !Sub arn:aws:s3:::${pStageBucket}
-                  - !Sub arn:aws:s3:::${pAnalyticsBucket}
+                  - !Sub arn:${AWS::Partition}:s3:::${pPipelineBucket}
+                  - !Sub arn:${AWS::Partition}:s3:::${pCentralBucket}
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}
+                  - !Sub arn:${AWS::Partition}:s3:::${pAnalyticsBucket}
 
   rCodeBuildPublishLayerRole:
     Type: AWS::IAM::Role
@@ -1139,14 +1139,14 @@ Resources:
             Statement:
               - Effect: Allow
                 Action: lambda:PublishLayerVersion
-                Resource: !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:layer:sdlf-${pTeamName}-*
+                Resource: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:layer:sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - dynamodb:Get*
                   - dynamodb:Update*
                   - dynamodb:Put*
                 Resource:
-                  - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/octagon-*
+                  - !Sub arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/octagon-*
               - Effect: Allow
                 Action:
                   - ssm:AddTagsToResource
@@ -1158,12 +1158,12 @@ Resources:
                   - ssm:GetParametersByPath
                   - ssm:ListTagsForResource
                   - ssm:RemoveTagsFromResource
-                Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/*
+                Resource: !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/*
               - Effect: Allow
                 Action:
                   - ssm:PutParameter
                   - ssm:DeleteParameter
-                Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/*/${pTeamName}/*
+                Resource: !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/*/${pTeamName}/*
               - Effect: Allow
                 Action:
                   - s3:GetBucketAcl
@@ -1174,10 +1174,10 @@ Resources:
                   - s3:ListBucket
                   - s3:PutObject
                 Resource:
-                  - !Sub arn:aws:s3:::${pPipelineBucket}
-                  - !Sub arn:aws:s3:::${pPipelineBucket}/*
-                  - !Sub arn:aws:s3:::${pCFNBucket}
-                  - !Sub arn:aws:s3:::${pCFNBucket}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pPipelineBucket}
+                  - !Sub arn:${AWS::Partition}:s3:::${pPipelineBucket}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pCFNBucket}
+                  - !Sub arn:${AWS::Partition}:s3:::${pCFNBucket}/*
 
   rDatalakeCrawlerRole:
     Type: AWS::IAM::Role
@@ -1194,7 +1194,7 @@ Resources:
             Action:
               - sts:AssumeRole
       ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/service-role/AWSGlueServiceRole
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSGlueServiceRole
       Policies:
         - PolicyName: !Sub sdlf-${pTeamName}-glue-crawler
           PolicyDocument:
@@ -1209,21 +1209,21 @@ Resources:
               - Effect: Allow
                 Action:
                   - s3:CreateBucket
-                Resource: arn:aws:s3:::aws-glue-*
+                Resource: !Sub arn:${AWS::Partition}:s3:::aws-glue-*
               - Effect: Allow
                 Action:
                   - s3:DeleteObject
                   - s3:GetObject
                   - s3:PutObject
                 Resource:
-                  - arn:aws:s3:::aws-glue-*/*
-                  - arn:aws:s3:::*/*aws-glue-*/*
+                  - !Sub arn:${AWS::Partition}:s3:::aws-glue-*/*
+                  - !Sub arn:${AWS::Partition}:s3:::*/*aws-glue-*/*
               - Effect: Allow
                 Action:
                   - s3:GetObject
                 Resource:
-                  - arn:aws:s3:::crawler-public*
-                  - arn:aws:s3:::aws-glue-*
+                  - !Sub arn:${AWS::Partition}:s3:::crawler-public*
+                  - !Sub arn:${AWS::Partition}:s3:::aws-glue-*
               - Effect: Allow
                 Action:
                   - s3:ListObjectsV2
@@ -1235,14 +1235,14 @@ Resources:
                   - s3:PutObject
                   - s3:PutObjectVersion
                 Resource:
-                  - !Sub arn:aws:s3:::${pCentralBucket}/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pCentralBucket}/raw/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pStageBucket}/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pStageBucket}/stage/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pStageBucket}/pre-stage/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pStageBucket}/post-stage/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pAnalyticsBucket}/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pAnalyticsBucket}/analytics/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pCentralBucket}/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pCentralBucket}/raw/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/pre-stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/post-stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pAnalyticsBucket}/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pAnalyticsBucket}/analytics/${pTeamName}/*
               - Effect: Allow
                 Action:
                   - kms:DescribeKey

--- a/sdlf-utils/ingestion-examples/sqoop/sdlf-team/scripts/template-team-repos.yaml
+++ b/sdlf-utils/ingestion-examples/sqoop/sdlf-team/scripts/template-team-repos.yaml
@@ -44,7 +44,7 @@ Resources:
           - Effect: Allow
             Principal:
               AWS:
-                - !Sub arn:aws:iam::${pChildAccountId}:root
+                - !Sub arn:${AWS::Partition}:iam::${pChildAccountId}:root
             Action:
               - sts:AssumeRole
       Policies:
@@ -76,15 +76,15 @@ Resources:
                   - codecommit:GetUploadArchiveStatus
                   - codecommit:UploadArchive
                 Resource:
-                  - !Sub arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-*
+                  - !Sub arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-*
               - Effect: Allow
                 Action:
                   - s3:Get*
                   - s3:ListBucket*
                   - s3:Put*
                 Resource:
-                  - !Sub arn:aws:s3:::sdlf-cfn-artifacts-${AWS::Region}-${pChildAccountId}
-                  - !Sub arn:aws:s3:::sdlf-cfn-artifacts-${AWS::Region}-${pChildAccountId}/*
+                  - !Sub arn:${AWS::Partition}:s3:::sdlf-cfn-artifacts-${AWS::Region}-${pChildAccountId}
+                  - !Sub arn:${AWS::Partition}:s3:::sdlf-cfn-artifacts-${AWS::Region}-${pChildAccountId}/*
               - Effect: Allow
                 Action:
                   - kms:Encrypt
@@ -94,7 +94,7 @@ Resources:
                   - kms:DescribeKey
                   - kms:List*
                   - kms:Describe*
-                Resource: !Sub arn:aws:kms:${AWS::Region}:${pChildAccountId}:key/*
+                Resource: !Sub arn:${AWS::Partition}:kms:${AWS::Region}:${pChildAccountId}:key/*
                 Condition:
                   ForAllValues:StringLike:
                     aws:PrincipalArn: !Sub "*${pTeamName}*"
@@ -111,14 +111,14 @@ Resources:
               "CodeCommit Repository State Change"
             ],
             "resources": [
-              "arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-pipeline",
-              "arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-dataset",
-              "arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-datalakeLibrary",
-              "arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-pipLibrary",
-              "arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-stageA",
-              "arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-stageB",
-              "arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-stageC",
-              "arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-stageX"
+              "arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-pipeline",
+              "arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-dataset",
+              "arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-datalakeLibrary",
+              "arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-pipLibrary",
+              "arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-stageA",
+              "arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-stageB",
+              "arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-stageC",
+              "arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-stageX"
             ],
             "source": [
               "aws.codecommit"
@@ -139,9 +139,9 @@ Resources:
         - { cBranch: !FindInMap [pCodeCommitBranch, !Ref pEnvironment, branch] }
       State: ENABLED
       Targets:
-        - Arn: !Sub arn:aws:events:${AWS::Region}:${pChildAccountId}:event-bus/default
+        - Arn: !Sub arn:${AWS::Partition}:events:${AWS::Region}:${pChildAccountId}:event-bus/default
           Id: !Sub sdlf-cicd-team-codecommit-${pEnvironment}-${pTeamName}
-          RoleArn: !Sub arn:aws:iam::${AWS::AccountId}:role/sdlf-cicd-foundations-eventbus-${pEnvironment}
+          RoleArn: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/sdlf-cicd-foundations-eventbus-${pEnvironment}
 
   rPullRequestCreated:
     Condition: IsProduction
@@ -156,14 +156,14 @@ Resources:
               "CodeCommit Pull Request State Change"
             ],
             "resources": [
-              "arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-pipeline",
-              "arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-dataset",
-              "arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-datalakeLibrary",
-              "arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-pipLibrary",
-              "arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-stageA",
-              "arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-stageB",
-              "arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-stageC",
-              "arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-stageX"
+              "arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-pipeline",
+              "arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-dataset",
+              "arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-datalakeLibrary",
+              "arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-pipLibrary",
+              "arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-stageA",
+              "arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-stageB",
+              "arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-stageC",
+              "arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-stageX"
             ],
             "source": [
               "aws.codecommit"
@@ -181,6 +181,6 @@ Resources:
         - { cBranch: !FindInMap [pCodeCommitBranch, !Ref pEnvironment, branch] }
       State: ENABLED
       Targets:
-        - Arn: !Sub arn:aws:events:${AWS::Region}:${pChildAccountId}:event-bus/default
+        - Arn: !Sub arn:${AWS::Partition}:events:${AWS::Region}:${pChildAccountId}:event-bus/default
           Id: !Sub sdlf-cicd-team-codecommit-pr-${pEnvironment}-${pTeamName}
-          RoleArn: !Sub arn:aws:iam::${AWS::AccountId}:role/sdlf-cicd-foundations-eventbus-${pEnvironment}
+          RoleArn: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/sdlf-cicd-foundations-eventbus-${pEnvironment}

--- a/sdlf-utils/pipeline-examples/alternative-sdlf-dataset/deploy.sh
+++ b/sdlf-utils/pipeline-examples/alternative-sdlf-dataset/deploy.sh
@@ -30,11 +30,12 @@ then
     echo "-p not specified, using default..." >&2
     PROFILE="default"
 fi
+AWS_PARTITION=$(aws sts get-caller-identity --query 'Arn' --output text --profile "PROFILE" | cut -d':' -f2)
 ACCOUNT_ID=$(sed -e 's/^"//' -e 's/"$//' <<<"$(aws ssm get-parameter --name /SDLF/Misc/DevOpsAccountId --profile $PROFILE --query "Parameter.Value")")
 ENV=$(sed -e 's/^"//' -e 's/"$//' <<<"$(aws ssm get-parameter --name /SDLF/Misc/pEnv --profile $PROFILE --query "Parameter.Value")")
 
 # Devops role for cicd
-aws sts assume-role --role-arn "arn:aws:iam::$ACCOUNT_ID:role/sdlf-cicd-team-codecommit-$ENV-engineering" \
+aws sts assume-role --role-arn "arn:"$AWS_PARTITION":iam::$ACCOUNT_ID:role/sdlf-cicd-team-codecommit-$ENV-engineering" \
   --role-session-name codecommit_access | jq -r .Credentials > tmp_credentials.json
 
 export AWS_ACCESS_KEY_ID="$(jq -r '.AccessKeyId' tmp_credentials.json)"

--- a/sdlf-utils/pipeline-examples/alternative-sdlf-dataset/template.yaml
+++ b/sdlf-utils/pipeline-examples/alternative-sdlf-dataset/template.yaml
@@ -93,7 +93,7 @@ Resources:
       ScheduleExpression: !Ref pScheduleExpression
       Targets:
         - Id: !Sub sdlf-${pTeamName}-${pDatasetName}-rule-b
-          Arn: !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:sdlf-${pTeamName}-${pPipelineName}-routing-b
+          Arn: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:sdlf-${pTeamName}-${pPipelineName}-routing-b
           Input: !Sub |
             {
               "team": "${pTeamName}",

--- a/sdlf-utils/pipeline-examples/cloudfront/scripts/clf-emr-roles.yaml
+++ b/sdlf-utils/pipeline-examples/cloudfront/scripts/clf-emr-roles.yaml
@@ -16,7 +16,7 @@ Resources:
             Action:
               - sts:AssumeRole
       ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/service-role/AmazonElasticMapReduceRole
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AmazonElasticMapReduceRole
 
   rEMREC2DefaultRole:
     Type: AWS::IAM::Role
@@ -33,7 +33,7 @@ Resources:
             Action:
               - sts:AssumeRole
       ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/service-role/AmazonElasticMapReduceforEC2Role
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AmazonElasticMapReduceforEC2Role
       Policies:
         - PolicyName: kms-emr-security-config
           PolicyDocument:

--- a/sdlf-utils/pipeline-examples/cloudfront/template.yaml
+++ b/sdlf-utils/pipeline-examples/cloudfront/template.yaml
@@ -121,17 +121,17 @@ Resources:
           - Effect: Allow
             Action:
               - logs:CreateLogGroup
-            Resource: !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*
+            Resource: !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:*
           - Effect: Allow
             Action:
               - logs:CreateLogStream
               - logs:PutLogEvents
-            Resource: !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/sdlf-${pTeamName}-*
+            Resource: !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/sdlf-${pTeamName}-*
           - Effect: Allow
             Action:
               - ssm:GetParameter
               - ssm:GetParameters
-            Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/*
+            Resource: !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/*
           - Effect: Allow
             Action:
               - dynamodb:BatchGetItem
@@ -145,7 +145,7 @@ Resources:
               - dynamodb:Scan
               - dynamodb:UpdateItem
             Resource:
-              - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/octagon-*
+              - !Sub arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/octagon-*
           - Effect: Allow
             Action:
               - kms:CreateGrant
@@ -196,7 +196,7 @@ Resources:
                   - sqs:SendMessage
                   - sqs:SendMessageBatch
                 Resource:
-                  - !Sub arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
 
   # Step1 Role
   rRoleLambdaExecutionStep1:
@@ -223,26 +223,26 @@ Resources:
                 Action:
                   - s3:ListBucket
                 Resource:
-                  - !Sub arn:aws:s3:::${pDatasetBucket}
-                  - !Sub arn:aws:s3:::${pArtifactBucket}
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}
+                  - !Sub arn:${AWS::Partition}:s3:::${pArtifactBucket}
               - Effect: Allow
                 Action:
                   - s3:GetObject
                   - s3:PutObject
                 Resource:
-                  - !Sub arn:aws:s3:::${pDatasetBucket}/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pDatasetBucket}/stage/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pDatasetBucket}/pre-stage/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pDatasetBucket}/post-stage/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pDatasetBucket}/analytics/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pArtifactBucket}/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}/stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}/pre-stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}/post-stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}/analytics/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pArtifactBucket}/${pTeamName}/*
               - Effect: Allow
                 Action:
                   - iam:PassRole
                   - iam:GetRole
                 Resource:
-                  - !Sub arn:aws:iam::${AWS::AccountId}:role/service-role/*
-                  - !Sub arn:aws:iam::${AWS::AccountId}:role/EMR*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/service-role/*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/EMR*
 
   # Step2 Role
   rRoleLambdaExecutionStep2:
@@ -269,7 +269,7 @@ Resources:
                 Action:
                   - glue:StartCrawler
                 Resource:
-                  - !Sub arn:aws:glue:${AWS::Region}:${AWS::AccountId}:crawler/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:crawler/sdlf-${pTeamName}-*
 
   # Step3 Role
   rRoleLambdaExecutionStep3:
@@ -296,16 +296,16 @@ Resources:
                 Action:
                   - s3:ListBucket
                 Resource:
-                  - !Sub arn:aws:s3:::${pDatasetBucket}
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}
               - Effect: Allow
                 Action:
                   - s3:GetObject
                 Resource:
-                  - !Sub arn:aws:s3:::${pDatasetBucket}/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pDatasetBucket}/stage/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pDatasetBucket}/pre-stage/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pDatasetBucket}/post-stage/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pDatasetBucket}/analytics/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}/stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}/pre-stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}/post-stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}/analytics/${pTeamName}/*
 
   # Error Handling Lambda Role
   rRoleLambdaExecutionErrorStep:
@@ -341,7 +341,7 @@ Resources:
                   - sqs:SendMessage
                   - sqs:SendMessageBatch
                 Resource:
-                  - !Sub arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
 
   ######## LAMBDA FUNCTIONS #########
   rLambdaRoutingStep:

--- a/sdlf-utils/pipeline-examples/datalake-workload-management/sdlf-wlm-integration/demo/scripts/legislators-glue-job.yaml
+++ b/sdlf-utils/pipeline-examples/datalake-workload-management/sdlf-wlm-integration/demo/scripts/legislators-glue-job.yaml
@@ -31,9 +31,9 @@ Resources:
             Action:
               - sts:AssumeRole
       ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/service-role/AWSGlueServiceRole
-        - arn:aws:iam::aws:policy/AmazonS3FullAccess
-        - arn:aws:iam::aws:policy/CloudWatchLogsFullAccess
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSGlueServiceRole
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/AmazonS3FullAccess
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/CloudWatchLogsFullAccess
       Policies:
         - PolicyName: !Sub sdlf-${pTeamName}-${pDatasetName}-glue-job
           PolicyDocument:

--- a/sdlf-utils/pipeline-examples/datalake-workload-management/sdlf-wlm-integration/sdlf-dataset/template.yaml
+++ b/sdlf-utils/pipeline-examples/datalake-workload-management/sdlf-wlm-integration/sdlf-dataset/template.yaml
@@ -89,7 +89,7 @@ Resources:
       ScheduleExpression: "cron(*/5 * * * ? *)"
       Targets:
         - Id: !Sub sdlf-${pTeamName}-${pDatasetName}-rule-b
-          Arn: !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:sdlf-${pTeamName}-${pPipelineName}-routing-b
+          Arn: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:sdlf-${pTeamName}-${pPipelineName}-routing-b
           Input: !Sub |
             {
               "team": "${pTeamName}",

--- a/sdlf-utils/pipeline-examples/datalake-workload-management/wlm-standalone/nested-stack/template-kms.yaml
+++ b/sdlf-utils/pipeline-examples/datalake-workload-management/wlm-standalone/nested-stack/template-kms.yaml
@@ -15,7 +15,7 @@ Resources:
           - Sid: Allow administration of the key
             Effect: Allow
             Principal:
-              AWS: [!Sub "arn:aws:iam::${AWS::AccountId}:root"]
+              AWS: [!Sub "arn:${AWS::Partition}:iam::${AWS::AccountId}:root"]
             Action: "kms:*"
             Resource: "*"
           - Sid: Allow CloudTrail/CloudWatch alarms access

--- a/sdlf-utils/pipeline-examples/datalake-workload-management/wlm-standalone/nested-stack/template-workload-management.yaml
+++ b/sdlf-utils/pipeline-examples/datalake-workload-management/wlm-standalone/nested-stack/template-workload-management.yaml
@@ -52,7 +52,7 @@ Resources:
             Resource: !GetAtt rQueueRouting.Arn
             Condition:
               StringEquals:
-                aws:SourceArn: !Sub "arn:aws:s3:::workload-management-${AWS::Region}-${AWS::AccountId}-landing-bucket"
+                aws:SourceArn: !Sub "arn:${AWS::Partition}:s3:::workload-management-${AWS::Region}-${AWS::AccountId}-landing-bucket"
   
       Queues:
         - !Ref rQueueRouting
@@ -128,18 +128,18 @@ Resources:
             - Effect: Allow
               Action:
               - logs:*
-              Resource: arn:aws:logs:*:*:*
+              Resource: !Sub arn:${AWS::Partition}:logs:*:*:*
             - Effect: Allow
               Action: 'sns:Publish'
               Resource:
-                - !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:wlm-*"
+                - !Sub "arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:wlm-*"
             - Effect: Allow
               Action:
                 - "dynamodb:Get*"
                 - "dynamodb:Query"
                 - "dynamodb:Scan"
               Resource:
-                - !Sub "arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/workload-management-ddb"
+                - !Sub "arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/workload-management-ddb"
             - Effect: Allow
               Action:
                 - "kms:DescribeKey"
@@ -157,7 +157,7 @@ Resources:
                 - "sqs:DeleteMessage*"
                 - "sqs:GetQueue*"
               Resource:
-                - !Sub "arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:wlm-*"
+                - !Sub "arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:wlm-*"
             -
               Effect: "Allow"
               Action:
@@ -175,7 +175,7 @@ Resources:
                 - "states:StartExecution"
                 - "states:ListStateMachines"
                 - "states:ListExecutions"
-              Resource: !Sub "arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:wlm-*"
+              Resource: !Sub "arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:stateMachine:wlm-*"
           
 
 
@@ -341,11 +341,11 @@ Resources:
               - Effect: Allow
                 Action:
                   - "lambda:InvokeFunction"
-                Resource: !Sub "arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:wlm-*"
+                Resource: !Sub "arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:wlm-*"
               - Effect: Allow
                 Action: 'sns:Publish'
                 Resource:
-                  - !Sub "arn:aws:sns:${AWS::Region}:${AWS::AccountId}:wlm-*"
+                  - !Sub "arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:wlm-*"
 
 
   ######## STATE MACHINE #########
@@ -391,7 +391,7 @@ Resources:
                     },
                     "SNS": {
                       "Type": "Task",
-                      "Resource": "arn:aws:states:::sns:publish",
+                      "Resource": "arn:${AWS::Partition}:states:::sns:publish",
                       "Parameters": {
                         "Message": {
                           "Input.$": "$"

--- a/sdlf-utils/pipeline-examples/dataset-dependency/dataset/template.yaml
+++ b/sdlf-utils/pipeline-examples/dataset-dependency/dataset/template.yaml
@@ -65,7 +65,7 @@ Resources:
                 Action:
                   - states:StartExecution
                 Resource:
-                  - !Sub arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:sdlf-${pTeamName}-${pPipelineName}-*
+                  - !Sub arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:stateMachine:sdlf-${pTeamName}-${pPipelineName}-*
       Path: /state-machine/
 
   rStateRule:
@@ -77,7 +77,7 @@ Resources:
       ScheduleExpression: cron(*/5 * * * ? *)
       Targets:
         - Id: !Sub sdlf-${pTeamName}-${pDatasetName}-rule-a
-          Arn: !Sub arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:sdlf-${pTeamName}-${pPipelineName}-sm-a
+          Arn: !Sub arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:stateMachine:sdlf-${pTeamName}-${pPipelineName}-sm-a
           Input: !Sub |
             {
               "body": {

--- a/sdlf-utils/pipeline-examples/dataset-dependency/stageA/template.yaml
+++ b/sdlf-utils/pipeline-examples/dataset-dependency/stageA/template.yaml
@@ -116,17 +116,17 @@ Resources:
           - Effect: Allow
             Action:
               - logs:CreateLogGroup
-            Resource: !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*
+            Resource: !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:*
           - Effect: Allow
             Action:
               - logs:CreateLogStream
               - logs:PutLogEvents
-            Resource: !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/sdlf-${pTeamName}-*
+            Resource: !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/sdlf-${pTeamName}-*
           - Effect: Allow
             Action:
               - ssm:GetParameter
               - ssm:GetParameters
-            Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/*
+            Resource: !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/*
           - Effect: Allow
             Action:
               - dynamodb:BatchGetItem
@@ -140,7 +140,7 @@ Resources:
               - dynamodb:Scan
               - dynamodb:UpdateItem
             Resource:
-              - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/octagon-*
+              - !Sub arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/octagon-*
           - Effect: Allow
             Action:
               - kms:CreateGrant
@@ -192,23 +192,23 @@ Resources:
                 Action:
                   - s3:ListBucket
                 Resource:
-                  - !Sub arn:aws:s3:::${pDatasetBucket}
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}
               - Effect: Allow
                 Action:
                   - s3:GetObject
                   - s3:PutObject
                 Resource:
-                  - !Sub arn:aws:s3:::${pDatasetBucket}/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pDatasetBucket}/stage/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pDatasetBucket}/pre-stage/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pDatasetBucket}/post-stage/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pDatasetBucket}/analytics/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}/stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}/pre-stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}/post-stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}/analytics/${pTeamName}/*
               - Effect: Allow
                 Action:
                   - glue:GetJobRun
                   - glue:StartJobRun
                 Resource:
-                  - !Sub arn:aws:glue:${AWS::Region}:${AWS::AccountId}:job/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:job/sdlf-${pTeamName}-*
 
   rLambdaStep1:
     Type: AWS::Serverless::Function

--- a/sdlf-utils/pipeline-examples/event-dataset-dependencies/sdlf-engineering-pipeline/nested-stacks/template-athena.yaml
+++ b/sdlf-utils/pipeline-examples/event-dataset-dependencies/sdlf-engineering-pipeline/nested-stacks/template-athena.yaml
@@ -137,7 +137,7 @@ Resources:
                   - events:DeleteRule
                   - events:RemoveTargets
                 Resource:
-                  - !Sub arn:aws:events:${AWS::Region}:${AWS::AccountId}:rule/*
+                  - !Sub arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:rule/*
               - Effect: Allow
                 Action:
                   - dynamodb:GetRecords
@@ -150,18 +150,18 @@ Resources:
                   - dynamodb:DeleteItem
                   - dynamodb:UpdateItem
                 Resource:
-                  - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/octagon-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/octagon-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - logs:*
                 Resource:
-                  - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:*
               - Effect: Allow
                 Action:
                   - kms:*
                 Resource:
-                  - !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:key/*
-                  - !Sub arn:aws:kms:${AWS::Region}:${AWS::AccountId}:alias/*
+                  - !Sub arn:${AWS::Partition}:kms:${AWS::Region}:${AWS::AccountId}:key/*
+                  - !Sub arn:${AWS::Partition}:kms:${AWS::Region}:${AWS::AccountId}:alias/*
 
   ####### SSM #######
   rAthenaWorkgroupSsm:

--- a/sdlf-utils/pipeline-examples/event-dataset-dependencies/sdlf-engineering-pipeline/nested-stacks/template-statemachine.yaml
+++ b/sdlf-utils/pipeline-examples/event-dataset-dependencies/sdlf-engineering-pipeline/nested-stacks/template-statemachine.yaml
@@ -58,7 +58,7 @@ Resources:
           Actions:
             -
               Name: Source
-              RoleArn: !Sub arn:aws:iam::${pSharedDevOpsAccountId}:role/sdlf-cicd-team-codecommit-${pEnv}-${pTeamName}
+              RoleArn: !Sub arn:${AWS::Partition}:iam::${pSharedDevOpsAccountId}:role/sdlf-cicd-team-codecommit-${pEnv}-${pTeamName}
               ActionTypeId:
                 Category: Source
                 Owner: AWS
@@ -161,7 +161,7 @@ Resources:
         detail-type:
           - CodeCommit Repository State Change
         resources:
-          - !Sub arn:aws:codecommit:${AWS::Region}:${pSharedDevOpsAccountId}:${pRepositoryName}
+          - !Sub arn:${AWS::Partition}:codecommit:${AWS::Region}:${pSharedDevOpsAccountId}:${pRepositoryName}
         detail:
           event:
             - referenceCreated
@@ -171,7 +171,7 @@ Resources:
           referenceName:
             - !Ref pBranchName
       Targets:
-        - Arn: !Sub arn:aws:codepipeline:${AWS::Region}:${AWS::AccountId}:${rStateMachinePipeline}
+        - Arn: !Sub arn:${AWS::Partition}:codepipeline:${AWS::Region}:${AWS::AccountId}:${rStateMachinePipeline}
           Id: !Sub sdlf-${pTeamName}-${pPipeline}-${pRepositoryName}-trigger
           RoleArn: !Ref pCloudWatchRepositoryTriggerRoleArn
 
@@ -190,7 +190,7 @@ Resources:
           project-name:
             - !Ref pBuildDatalakeLibrary
       Targets:
-        - Arn: !Sub arn:aws:codepipeline:${AWS::Region}:${AWS::AccountId}:${rStateMachinePipeline}
+        - Arn: !Sub arn:${AWS::Partition}:codepipeline:${AWS::Region}:${AWS::AccountId}:${rStateMachinePipeline}
           Id: !Sub sdlf-${pTeamName}-${pPipeline}-${pRepositoryName}-update
           RoleArn: !Ref pCloudWatchRepositoryTriggerRoleArn
 

--- a/sdlf-utils/pipeline-examples/event-dataset-dependencies/sdlf-engineering-stageA/template.yaml
+++ b/sdlf-utils/pipeline-examples/event-dataset-dependencies/sdlf-engineering-stageA/template.yaml
@@ -158,17 +158,17 @@ Resources:
           - Effect: Allow
             Action:
               - logs:CreateLogGroup
-            Resource: !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*
+            Resource: !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:*
           - Effect: Allow
             Action:
               - logs:CreateLogStream
               - logs:PutLogEvents
-            Resource: !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/sdlf-${pTeamName}-*
+            Resource: !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/sdlf-${pTeamName}-*
           - Effect: Allow
             Action:
               - ssm:GetParameter
               - ssm:GetParameters
-            Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/*
+            Resource: !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/*
           - Effect: Allow
             Action:
               - dynamodb:BatchGetItem
@@ -182,7 +182,7 @@ Resources:
               - dynamodb:Scan
               - dynamodb:UpdateItem
             Resource:
-              - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/octagon-*
+              - !Sub arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/octagon-*
           - Effect: Allow
             Action:
               - kms:CreateGrant
@@ -261,15 +261,15 @@ Resources:
                 Action:
                   - s3:ListBucket
                 Resource:
-                  - !Sub arn:aws:s3:::${pStageBucket}
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}
               - Effect: Allow
                 Action:
                   - s3:GetObject
                 Resource:
-                  - !Sub arn:aws:s3:::${pStageBucket}/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pStageBucket}/stage/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pStageBucket}/pre-stage/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pStageBucket}/post-stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/pre-stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/post-stage/${pTeamName}/*
 
   # Step2 Role
   rRoleLambdaExecutionStep2:
@@ -299,10 +299,10 @@ Resources:
                   - s3:GetBucketLocation
                   - s3:ListBucketMultipartUploads
                 Resource:
-                  - !Sub arn:aws:s3:::${pDatasetBucket}
-                  - !Sub arn:aws:s3:::${pStageBucket}
-                  - !Sub arn:aws:s3:::${pArtifactsBucket}
-                  - !Sub arn:aws:s3:::${pAthenaBucket}
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}
+                  - !Sub arn:${AWS::Partition}:s3:::${pArtifactsBucket}
+                  - !Sub arn:${AWS::Partition}:s3:::${pAthenaBucket}
               - Effect: Allow
                 Action:
                   - s3:GetObject
@@ -311,13 +311,13 @@ Resources:
                   - s3:AbortMultipartUpload
                   - s3:DeleteObject
                 Resource:
-                  - !Sub arn:aws:s3:::${pDatasetBucket}/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pDatasetBucket}/raw/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pStageBucket}/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pStageBucket}/stage/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pStageBucket}/pre-stage/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pStageBucket}/post-stage/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pAthenaBucket}/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}/raw/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/pre-stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/post-stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pAthenaBucket}/${pTeamName}/*
               - Effect: Allow
                 Action:
                   - kms:DescribeKey
@@ -380,7 +380,7 @@ Resources:
                   - sqs:SendMessage
                   - sqs:SendMessageBatch
                 Resource:
-                  - !Sub arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - s3:GetBucketVersioning
@@ -388,10 +388,10 @@ Resources:
                   - s3:GetBucketLocation
                   - s3:ListBucketMultipartUploads
                 Resource:
-                  - !Sub arn:aws:s3:::${pDatasetBucket}
-                  - !Sub arn:aws:s3:::${pStageBucket}
-                  - !Sub arn:aws:s3:::${pArtifactsBucket}
-                  - !Sub arn:aws:s3:::${pAthenaBucket}
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}
+                  - !Sub arn:${AWS::Partition}:s3:::${pArtifactsBucket}
+                  - !Sub arn:${AWS::Partition}:s3:::${pAthenaBucket}
               - Effect: Allow
                 Action:
                   - s3:GetObject
@@ -401,13 +401,13 @@ Resources:
                   - s3:DeleteObject
                   - s3:PutObjectTagging
                 Resource:
-                  - !Sub arn:aws:s3:::${pDatasetBucket}/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pDatasetBucket}/raw/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pStageBucket}/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pStageBucket}/stage/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pStageBucket}/pre-stage/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pStageBucket}/post-stage/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pAthenaBucket}/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}/raw/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/pre-stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/post-stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pAthenaBucket}/${pTeamName}/*
               - Effect: Allow
                 Action:
                   - kms:DescribeKey

--- a/sdlf-utils/pipeline-examples/event-dataset-dependencies/sdlf-engineering-stageB/template.yaml
+++ b/sdlf-utils/pipeline-examples/event-dataset-dependencies/sdlf-engineering-stageB/template.yaml
@@ -162,17 +162,17 @@ Resources:
           - Effect: Allow
             Action:
               - logs:CreateLogGroup
-            Resource: !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*
+            Resource: !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:*
           - Effect: Allow
             Action:
               - logs:CreateLogStream
               - logs:PutLogEvents
-            Resource: !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/sdlf-${pTeamName}-*
+            Resource: !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/sdlf-${pTeamName}-*
           - Effect: Allow
             Action:
               - ssm:GetParameter
               - ssm:GetParameters
-            Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/*
+            Resource: !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/*
           - Effect: Allow
             Action:
               - dynamodb:BatchGetItem
@@ -186,7 +186,7 @@ Resources:
               - dynamodb:Scan
               - dynamodb:UpdateItem
             Resource:
-              - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/octagon-*
+              - !Sub arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/octagon-*
           - Effect: Allow
             Action:
               - kms:CreateGrant
@@ -237,7 +237,7 @@ Resources:
                   - sqs:SendMessage
                   - sqs:SendMessageBatch
                 Resource:
-                  - !Sub arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
 
   # Step1 Role
   rRoleLambdaExecutionStep1:
@@ -264,9 +264,9 @@ Resources:
                 Action:
                   - s3:ListBucket
                 Resource:
-                  - !Sub arn:aws:s3:::${pDatasetBucket}
-                  - !Sub arn:aws:s3:::${pStageBucket}
-                  - !Sub arn:aws:s3:::${pAnalyticsBucket}
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}
+                  - !Sub arn:${AWS::Partition}:s3:::${pAnalyticsBucket}
               - Effect: Allow
                 Action:
                   - s3:GetObject
@@ -276,31 +276,31 @@ Resources:
                   - s3:DeleteObject
                   - s3:ListBucket
                 Resource:
-                  - !Sub arn:aws:s3:::${pDatasetBucket}/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pDatasetBucket}/raw/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pStageBucket}/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pStageBucket}/stage/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pStageBucket}/pre-stage/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pStageBucket}/post-stage/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pAthenaBucket}/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pAnalyticsBucket}/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pArtifactsBucket}/*${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}/raw/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/pre-stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/post-stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pAthenaBucket}/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pAnalyticsBucket}/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pArtifactsBucket}/*${pTeamName}/*
               - Effect: Allow
                 Action:
                   - s3:GetObject
                   - s3:PutObject
                 Resource:
-                  - !Sub arn:aws:s3:::${pDatasetBucket}/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pDatasetBucket}/stage/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pDatasetBucket}/pre-stage/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pDatasetBucket}/post-stage/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pDatasetBucket}/analytics/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}/stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}/pre-stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}/post-stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}/analytics/${pTeamName}/*
               - Effect: Allow
                 Action:
                   - glue:GetJobRun
                   - glue:StartJobRun
                 Resource:
-                  - !Sub arn:aws:glue:${AWS::Region}:${AWS::AccountId}:job/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:job/sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - kms:DescribeKey
@@ -357,7 +357,7 @@ Resources:
                 Action:
                   - glue:StartCrawler
                 Resource:
-                  - !Sub arn:aws:glue:${AWS::Region}:${AWS::AccountId}:crawler/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:crawler/sdlf-${pTeamName}-*
 
   # Step3 Role
   rRoleLambdaExecutionStep3:
@@ -390,7 +390,7 @@ Resources:
                   - sqs:SendMessage
                   - sqs:SendMessageBatch
                 Resource:
-                  - !Sub arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - s3:GetBucketVersioning
@@ -398,10 +398,10 @@ Resources:
                   - s3:GetBucketLocation
                   - s3:ListBucketMultipartUploads
                 Resource:
-                  - !Sub arn:aws:s3:::${pDatasetBucket}
-                  - !Sub arn:aws:s3:::${pStageBucket}
-                  - !Sub arn:aws:s3:::${pArtifactsBucket}
-                  - !Sub arn:aws:s3:::${pAthenaBucket}
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}
+                  - !Sub arn:${AWS::Partition}:s3:::${pArtifactsBucket}
+                  - !Sub arn:${AWS::Partition}:s3:::${pAthenaBucket}
               - Effect: Allow
                 Action:
                   - s3:GetObject
@@ -411,13 +411,13 @@ Resources:
                   - s3:DeleteObject
                   - s3:PutObjectTagging
                 Resource:
-                  - !Sub arn:aws:s3:::${pDatasetBucket}/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pDatasetBucket}/raw/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pStageBucket}/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pStageBucket}/stage/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pStageBucket}/pre-stage/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pStageBucket}/post-stage/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pAthenaBucket}/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}/raw/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/pre-stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/post-stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pAthenaBucket}/${pTeamName}/*
               - Effect: Allow
                 Action:
                   - kms:DescribeKey
@@ -478,7 +478,7 @@ Resources:
                   - sqs:SendMessage
                   - sqs:SendMessageBatch
                 Resource:
-                  - !Sub arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
 
   ######## LAMBDA FUNCTIONS #########
   rLambdaRoutingStep:

--- a/sdlf-utils/pipeline-examples/event-dataset-dependencies/sdlf-team/nested-stacks/template-iam.yaml
+++ b/sdlf-utils/pipeline-examples/event-dataset-dependencies/sdlf-team/nested-stacks/template-iam.yaml
@@ -62,7 +62,7 @@ Resources:
             Action:
               - s3:GetBucketLocation
               - s3:ListAllMyBuckets
-            Resource: arn:aws:s3:::*
+            Resource: !Sub arn:${AWS::Partition}:s3:::*
           - Sid: AllowTeamBucketList
             Effect: Allow
             Action:
@@ -71,11 +71,11 @@ Resources:
               - s3:ListBucketMultipartUploads
             Resource:
               [
-                !Sub "arn:aws:s3:::${pPipelineBucket}",
-                !Sub "arn:aws:s3:::${pCentralBucket}",
-                !Sub "arn:aws:s3:::${pStageBucket}",
-                !Sub "arn:aws:s3:::${pAnalyticsBucket}",
-                !Sub "arn:aws:s3:::${pAthenaBucket}",
+                !Sub "arn:${AWS::Partition}:s3:::${pPipelineBucket}",
+                !Sub "arn:${AWS::Partition}:s3:::${pCentralBucket}",
+                !Sub "arn:${AWS::Partition}:s3:::${pStageBucket}",
+                !Sub "arn:${AWS::Partition}:s3:::${pAnalyticsBucket}",
+                !Sub "arn:${AWS::Partition}:s3:::${pAthenaBucket}",
               ]
           - Sid: AllowTeamPrefixActions
             Effect: Allow
@@ -87,22 +87,22 @@ Resources:
               - s3:AbortMultipartUpload
               - s3:PutObjectTagging
             Resource:
-              - !Sub arn:aws:s3:::${pPipelineBucket}/${pTeamName}/*
-              - !Sub arn:aws:s3:::${pPipelineBucket}/*/${pTeamName}/*
+              - !Sub arn:${AWS::Partition}:s3:::${pPipelineBucket}/${pTeamName}/*
+              - !Sub arn:${AWS::Partition}:s3:::${pPipelineBucket}/*/${pTeamName}/*
               - !If [
                   CreateMultipleBuckets,
-                  !Sub "arn:aws:s3:::${pCentralBucket}/${pTeamName}/*",
-                  !Sub "arn:aws:s3:::${pCentralBucket}/raw/${pTeamName}/*",
+                  !Sub "arn:${AWS::Partition}:s3:::${pCentralBucket}/${pTeamName}/*",
+                  !Sub "arn:${AWS::Partition}:s3:::${pCentralBucket}/raw/${pTeamName}/*",
                 ]
-              - !Sub arn:aws:s3:::${pStageBucket}/${pTeamName}/*
-              - !Sub arn:aws:s3:::${pStageBucket}/pre-stage/${pTeamName}/*
-              - !Sub arn:aws:s3:::${pStageBucket}/stage/${pTeamName}/*
-              - !Sub arn:aws:s3:::${pStageBucket}/post-stage/${pTeamName}/*
-              - !Sub arn:aws:s3:::${pAthenaBucket}/${pTeamName}/*
+              - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/${pTeamName}/*
+              - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/pre-stage/${pTeamName}/*
+              - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/stage/${pTeamName}/*
+              - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/post-stage/${pTeamName}/*
+              - !Sub arn:${AWS::Partition}:s3:::${pAthenaBucket}/${pTeamName}/*
               - !If [
                   CreateMultipleBuckets,
-                  !Sub "arn:aws:s3:::${pAnalyticsBucket}/${pTeamName}/*",
-                  !Sub "arn:aws:s3:::${pAnalyticsBucket}/analytics/*",
+                  !Sub "arn:${AWS::Partition}:s3:::${pAnalyticsBucket}/${pTeamName}/*",
+                  !Sub "arn:${AWS::Partition}:s3:::${pAnalyticsBucket}/analytics/*",
                 ]
           - Sid: Allows3Read
             Effect: Allow
@@ -112,14 +112,14 @@ Resources:
               - s3:ListMultipartUploadParts
               - s3:AbortMultipartUpload
             Resource:
-              - !Sub arn:aws:s3:::${pArtifactBucket}/*
-              - !Sub arn:aws:s3:::${pCloudtraailBucket}/*
+              - !Sub arn:${AWS::Partition}:s3:::${pArtifactBucket}/*
+              - !Sub arn:${AWS::Partition}:s3:::${pCloudtraailBucket}/*
           - Sid: AllowFullCodeCommitOnTeamRepositories
             Effect: Allow
             Action:
               - codecommit:*
             Resource:
-              - !Sub arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
+              - !Sub arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
           - Sid: AllowTeamKMSDataKeyUsage
             Effect: Allow
             Action:
@@ -137,7 +137,7 @@ Resources:
             Action:
               - ssm:GetParameter
               - ssm:GetParameters
-            Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/*
+            Resource: !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/*
           - Sid: AllowOctagonDynamoAccess
             Effect: Allow
             Action:
@@ -156,7 +156,7 @@ Resources:
               - dynamodb:ListStreams
               - dynamodb:ListShards
             Resource:
-              - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/octagon-*
+              - !Sub arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/octagon-*
           - Sid: AllowSQSManagement
             Effect: Allow
             Action:
@@ -171,29 +171,29 @@ Resources:
               - sqs:SendMessage
               - sqs:SendMessageBatch
             Resource:
-              - !Sub arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
+              - !Sub arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
           - Effect: Allow
             Action:
               - states:StartExecution
             Resource:
-              - !Sub arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:sdlf-${pTeamName}-*
+              - !Sub arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:stateMachine:sdlf-${pTeamName}-*
           - Effect: Allow
             Action:
               - glue:StartCrawler
             Resource:
-              - !Sub arn:aws:glue:${AWS::Region}:${AWS::AccountId}:crawler/sdlf-${pTeamName}-*
+              - !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:crawler/sdlf-${pTeamName}-*
           - Effect: Allow
             Action:
               - glue:GetJobRun
               - glue:GetJobRuns
               - glue:StartJobRun
             Resource:
-              - !Sub arn:aws:glue:${AWS::Region}:${AWS::AccountId}:job/sdlf-${pTeamName}-*
-              - !Sub arn:aws:glue:${AWS::Region}:${AWS::AccountId}:job/${pOrganizationName}-${pApplicationName}-${pEnvironment}-${pTeamName}-*
+              - !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:job/sdlf-${pTeamName}-*
+              - !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:job/${pOrganizationName}-${pApplicationName}-${pEnvironment}-${pTeamName}-*
           - Effect: Allow
             Action:
               - logs:CreateLogGroup
-            Resource: !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*
+            Resource: !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:*
           - Sid: AllowCloudWatchLogsReadOnlyAccess
             Effect: Allow
             Action:
@@ -202,9 +202,9 @@ Resources:
               - logs:GetLogEvents
               - logs:PutLogEvents
             Resource:
-              - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/sdlf-${pTeamName}-*
-              - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/sdlf-${pTeamName}-*
-              - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws-glue/jobs/sdlf-${pTeamName}-*
+              - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/sdlf-${pTeamName}-*
+              - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/sdlf-${pTeamName}-*
+              - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws-glue/jobs/sdlf-${pTeamName}-*
           - Sid: AllowCloudFormationReadOnlyAccess
             Effect: Allow
             Action:
@@ -213,7 +213,7 @@ Resources:
               - cloudformation:DescribeStackResource
               - cloudformation:DescribeStackResources
             Resource:
-              - !Sub arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack:sdlf-${pTeamName}:*
+              - !Sub arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stack:sdlf-${pTeamName}:*
           - Sid: AllowAthenaProcessing
             Effect: Allow
             Action:
@@ -229,9 +229,9 @@ Resources:
               - athena:GetQueryExecution
               - athena:GetQueryResults
             Resource:
-              - !Sub arn:aws:glue:${AWS::Region}:${AWS::AccountId}:*
-              - !Sub arn:aws:athena:${AWS::Region}:${AWS::AccountId}:*
-              - !Sub arn:aws:lakeformation:${AWS::Region}:${AWS::AccountId}:*
+              - !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:*
+              - !Sub arn:${AWS::Partition}:athena:${AWS::Region}:${AWS::AccountId}:*
+              - !Sub arn:${AWS::Partition}:lakeformation:${AWS::Region}:${AWS::AccountId}:*
           - Sid: AllowEMR
             Effect: Allow
             Action:
@@ -247,20 +247,20 @@ Resources:
               - events:DeleteRule
               - events:RemoveTargets
             Resource:
-              - !Sub arn:aws:events:${AWS::Region}:${AWS::AccountId}:rule/*
+              - !Sub arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:rule/*
           - Sid: GetSecrets
             Effect: Allow
             Action:
               - secretsmanager:GetSecretValue
             Resource:
-              - !Sub arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:SDLF/SQOOP/*
-              - !Sub arn:aws:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:sdlf/sqoop/*
+              - !Sub arn:${AWS::Partition}:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:SDLF/SQOOP/*
+              - !Sub arn:${AWS::Partition}:secretsmanager:${AWS::Region}:${AWS::AccountId}:secret:sdlf/sqoop/*
           - Sid: CallLambda
             Effect: Allow
             Action:
               - lambda:AddPermission
               - lambda:InvokeFunction
-            Resource: !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:sdlf-${pTeamName}*
+            Resource: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:sdlf-${pTeamName}*
 
   rCodePipelineRole:
     Type: AWS::IAM::Role
@@ -298,25 +298,25 @@ Resources:
                 Action:
                   - iam:PassRole
                 Resource:
-                  - !Sub arn:aws:iam::${AWS::AccountId}:role/sdlf-${pTeamName}-*
-                  - !Sub arn:aws:iam::${AWS::AccountId}:role/state-machine/sdlf-${pTeamName}-*
-                  - !Sub arn:aws:iam::${AWS::AccountId}:role/glue/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/state-machine/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/glue/sdlf-${pTeamName}-*
                   - !GetAtt rRoleCloudWatchEventRole.Arn
-                  - !Sub arn:aws:iam::${AWS::AccountId}:role/service-role/*
-                  - !Sub arn:aws:iam::${AWS::AccountId}:role/EMR*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/service-role/*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/EMR*
               - Effect: Allow
                 Action:
                   - iam:ListRoles
                 Resource:
-                  - !Sub arn:aws:iam::${AWS::AccountId}:role/*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/*
               - Effect: Allow
                 Action:
                   - iam:CreateRole
                 Resource:
-                  - !Sub arn:aws:iam::${AWS::AccountId}:role/sdlf-${pTeamName}-*
-                  - !Sub arn:aws:iam::${AWS::AccountId}:role/state-machine/sdlf-${pTeamName}-*
-                  - !Sub arn:aws:iam::${AWS::AccountId}:role/service-role/sdlf-${pTeamName}-*
-                  - !Sub arn:aws:iam::${AWS::AccountId}:role/glue/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/state-machine/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/service-role/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/glue/sdlf-${pTeamName}-*
                 Condition:
                   StringEquals:
                     iam:PermissionsBoundary: !Ref rTeamIAMManagedPolicy
@@ -325,18 +325,18 @@ Resources:
                   - iam:AttachRolePolicy
                   - iam:DetachRolePolicy
                 Resource:
-                  - !Sub arn:aws:iam::${AWS::AccountId}:role/sdlf-${pTeamName}-*
-                  - !Sub arn:aws:iam::${AWS::AccountId}:role/state-machine/sdlf-${pTeamName}-*
-                  - !Sub arn:aws:iam::${AWS::AccountId}:role/service-role/sdlf-${pTeamName}-*
-                  - !Sub arn:aws:iam::${AWS::AccountId}:role/glue/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/state-machine/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/service-role/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/glue/sdlf-${pTeamName}-*
                 Condition:
                   ArnEquals:
                     iam:PolicyARN:
-                      - !Sub arn:aws:iam::${AWS::AccountId}:policy/sdlf-${pTeamName}-*
-                      - arn:aws:iam::aws:policy/service-role/AmazonElasticMapReduceRole
-                      - arn:aws:iam::aws:policy/service-role/AmazonElasticMapReduceforEC2Role
-                      - arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore
-                      - arn:aws:iam::aws:policy/AmazonS3FullAccess
+                      - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:policy/sdlf-${pTeamName}-*
+                      - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AmazonElasticMapReduceRole
+                      - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AmazonElasticMapReduceforEC2Role
+                      - !Sub arn:${AWS::Partition}:iam::aws:policy/AmazonSSMManagedInstanceCore
+                      - !Sub arn:${AWS::Partition}:iam::aws:policy/AmazonS3FullAccess
               - Effect: Allow
                 Action:
                   - iam:DeleteRole
@@ -350,16 +350,16 @@ Resources:
                   - iam:UpdateRoleDescription
                   - iam:TagRole
                 Resource:
-                  - !Sub arn:aws:iam::${AWS::AccountId}:role/sdlf-${pTeamName}-*
-                  - !Sub arn:aws:iam::${AWS::AccountId}:role/state-machine/sdlf-${pTeamName}-*
-                  - !Sub arn:aws:iam::${AWS::AccountId}:role/service-role/sdlf-${pTeamName}-*
-                  - !Sub arn:aws:iam::${AWS::AccountId}:role/glue/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/state-machine/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/service-role/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/glue/sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - iam:ListPolicies
                   - iam:ListPolicyVersions
                 Resource:
-                  - !Sub arn:aws:iam::${AWS::AccountId}:policy/*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:policy/*
               - Effect: Allow
                 Action:
                   - iam:CreatePolicy
@@ -369,13 +369,13 @@ Resources:
                   - iam:GetPolicy
                   - iam:GetPolicyVersion
                 Resource:
-                  - !Sub arn:aws:iam::${AWS::AccountId}:policy/sdlf-${pTeamName}-*
-                  - !Sub arn:aws:iam::${AWS::AccountId}:policy/state-machine/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:policy/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:policy/state-machine/sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - iam:*InstanceProfile
                 Resource:
-                  - !Sub arn:aws:iam::${AWS::AccountId}:instance-profile/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:instance-profile/sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - codecommit:CancelUploadArchive
@@ -384,7 +384,7 @@ Resources:
                   - codecommit:GetUploadArchiveStatus
                   - codecommit:UploadArchive
                 Resource:
-                  - !Sub arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - events:DeleteRule
@@ -392,7 +392,7 @@ Resources:
                   - events:PutRule
                   - events:PutTargets
                   - events:RemoveTargets
-                Resource: !Sub arn:aws:events:${AWS::Region}:${AWS::AccountId}:rule/sdlf-${pTeamName}-*
+                Resource: !Sub arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:rule/sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - lambda:GetLayerVersion
@@ -418,11 +418,11 @@ Resources:
                   - lambda:UpdateFunctionCode
                   - lambda:UpdateFunctionConfiguration
                   - lambda:UpdateFunctionConfiguration
-                Resource: !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:sdlf-${pTeamName}-*
+                Resource: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - lambda:InvokeFunction
-                Resource: !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:sdlf-foundations-rKibana*
+                Resource: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:sdlf-foundations-rKibana*
               - Effect: Allow
                 Action:
                   - lambda:CreateEventSourceMapping
@@ -441,14 +441,14 @@ Resources:
                   - cloudformation:ExecuteChangeSet
                   - cloudformation:SetStackPolicy
                   - cloudformation:UpdateStack
-                Resource: !Sub arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/sdlf-${pTeamName}-*
+                Resource: !Sub arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - cloudformation:CreateChangeSet
                   - cloudformation:DeleteChangeSet
                   - cloudformation:DescribeChangeSet
                   - cloudformation:ExecuteChangeSet
-                Resource: !Sub arn:aws:cloudformation:${AWS::Region}:aws:transform/*
+                Resource: !Sub arn:${AWS::Partition}:cloudformation:${AWS::Region}:aws:transform/*
               - Effect: Allow
                 Action:
                   - cloudformation:ValidateTemplate
@@ -459,7 +459,7 @@ Resources:
                   - codebuild:CreateProject
                   - codebuild:StartBuild
                   - codebuild:UpdateProject
-                Resource: !Sub arn:aws:codebuild:${AWS::Region}:${AWS::AccountId}:project/sdlf-${pTeamName}-*
+                Resource: !Sub arn:${AWS::Partition}:codebuild:${AWS::Region}:${AWS::AccountId}:project/sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - states:CreateActivity
@@ -467,25 +467,25 @@ Resources:
                   - states:ListActivities
                   - states:ListStateMachines
                   - states:TagResource
-                Resource: !Sub arn:aws:states:${AWS::Region}:${AWS::AccountId}:*
+                Resource: !Sub arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:*
               - Effect: Allow
                 Action:
                   - states:DeleteStateMachine
                   - states:DescribeStateMachine
                   - states:DescribeStateMachineForExecution
                   - states:UpdateStateMachine
-                Resource: !Sub arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:sdlf-${pTeamName}-*
+                Resource: !Sub arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:stateMachine:sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - states:DescribeActivity
                   - states:DeleteActivity
                   - states:GetActivityTask
-                Resource: !Sub arn:aws:states:${AWS::Region}:${AWS::AccountId}:activity:sdlf-${pTeamName}-*
+                Resource: !Sub arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:activity:sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - logs:CreateLogGroup
                   - logs:DescribeLogGroups
-                Resource: !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*
+                Resource: !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:*
               - Effect: Allow
                 Action:
                   - logs:CreateLogStream
@@ -496,8 +496,8 @@ Resources:
                   - logs:PutRetentionPolicy
                   - logs:TagLogGroup
                 Resource:
-                  - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/sdlf-${pTeamName}-*:log-stream:*
-                  - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/sdlf-${pTeamName}-*:log-stream:*
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/sdlf-${pTeamName}-*:log-stream:*
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/sdlf-${pTeamName}-*:log-stream:*
               - Effect: Allow
                 Action:
                   - cloudwatch:DeleteAlarms
@@ -506,11 +506,11 @@ Resources:
                   - cloudwatch:PutMetricData
                   - cloudwatch:SetAlarmState
                 Resource:
-                  - !Sub arn:aws:cloudwatch:${AWS::Region}:${AWS::AccountId}:alarm:sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:cloudwatch:${AWS::Region}:${AWS::AccountId}:alarm:sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - sqs:ListQueues
-                Resource: !Sub arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:*
+                Resource: !Sub arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:*
               - Effect: Allow
                 Action:
                   - sqs:AddPermission
@@ -521,7 +521,7 @@ Resources:
                   - sqs:GetQueueAttributes
                   - sqs:SetQueueAttributes
                   - sqs:TagQueue
-                Resource: !Sub arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
+                Resource: !Sub arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - s3:CreateBucket
@@ -540,10 +540,10 @@ Resources:
                   - s3:PutObject
                   - s3:SetBucketEncryption
                 Resource:
-                  - !Sub arn:aws:s3:::${pCFNBucket}
-                  - !Sub arn:aws:s3:::${pCFNBucket}/*
-                  - !Sub arn:aws:s3:::${pPipelineBucket}
-                  - !Sub arn:aws:s3:::${pPipelineBucket}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pCFNBucket}
+                  - !Sub arn:${AWS::Partition}:s3:::${pCFNBucket}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pPipelineBucket}
+                  - !Sub arn:${AWS::Partition}:s3:::${pPipelineBucket}/*
               - Effect: Allow
                 Action:
                   - ssm:AddTagsToResource
@@ -555,12 +555,12 @@ Resources:
                   - ssm:GetParametersByPath
                   - ssm:ListTagsForResource
                   - ssm:RemoveTagsFromResource
-                Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/*
+                Resource: !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/*
               - Effect: Allow
                 Action:
                   - ssm:DeleteParameter
                   - ssm:PutParameter
-                Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/*/${pTeamName}/*
+                Resource: !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/*/${pTeamName}/*
               - Effect: Allow
                 Action:
                   - kms:CreateGrant
@@ -573,7 +573,7 @@ Resources:
                   - !Ref pKMSInfraKeyId
               - Effect: Allow
                 Action: sts:AssumeRole
-                Resource: !Sub arn:aws:iam::${pSharedDevOpsAccountId}:role/sdlf-cicd-team-codecommit-${pEnvironment}-${pTeamName}
+                Resource: !Sub arn:${AWS::Partition}:iam::${pSharedDevOpsAccountId}:role/sdlf-cicd-team-codecommit-${pEnvironment}-${pTeamName}
               - Effect: Allow
                 Action: ec2:DescribeSubnets
                 Resource: "*"
@@ -588,14 +588,14 @@ Resources:
                   - dynamodb:*Backup
                   - dynamodb:*Backups
                 Resource:
-                  - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/octagon-${pTeamName}-*
-                  - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/octagon-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - iam:CreateRole
                 Resource:
-                  - !Sub arn:aws:iam::${AWS::AccountId}:role/sdlf-${pTeamName}-*-emr-ec2
-                  - !Sub arn:aws:iam::${AWS::AccountId}:role/sdlf-${pTeamName}-*-emr-Role
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/sdlf-${pTeamName}-*-emr-ec2
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/sdlf-${pTeamName}-*-emr-Role
 
   rCloudWatchRepositoryTriggerRole:
     Type: AWS::IAM::Role
@@ -619,10 +619,10 @@ Resources:
                 Action:
                   - codebuild:BatchGetBuilds
                   - codebuild:StartBuild
-                Resource: !Sub arn:aws:codebuild:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
+                Resource: !Sub arn:${AWS::Partition}:codebuild:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
               - Effect: Allow
                 Action: codepipeline:StartPipelineExecution
-                Resource: !Sub arn:aws:codepipeline:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
+                Resource: !Sub arn:${AWS::Partition}:codepipeline:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
 
   rTransformValidateRole:
     Type: AWS::IAM::Role
@@ -658,13 +658,13 @@ Resources:
                   - codecommit:List*
                   - codecommit:UploadArchive
                 Resource:
-                  - !Sub arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - logs:CreateLogGroup
                   - logs:CreateLogStream
                   - logs:PutLogEvents
-                Resource: !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/sdlf-${pTeamName}*
+                Resource: !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/sdlf-${pTeamName}*
               - Effect: Allow
                 Action:
                   - s3:GetBucketAcl
@@ -673,8 +673,8 @@ Resources:
                   - s3:GetObjectVersion
                   - s3:PutObject
                 Resource:
-                  - !Sub arn:aws:s3:::${pPipelineBucket}/*
-                  - !Sub arn:aws:s3:::${pCFNBucket}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pPipelineBucket}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pCFNBucket}/*
               - Effect: Allow
                 Action:
                   - lambda:List*
@@ -682,7 +682,7 @@ Resources:
               - Effect: Allow
                 Action:
                   - lambda:GetLayer*
-                Resource: !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:layer:sdlf-${pTeamName}-*
+                Resource: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:layer:sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - kms:CreateGrant
@@ -713,7 +713,7 @@ Resources:
             Statement:
               - Effect: Allow
                 Action: sts:AssumeRole
-                Resource: !Sub arn:aws:iam::${pSharedDevOpsAccountId}:role/sdlf-cicd-team-codecommit-${pEnvironment}-${pTeamName}
+                Resource: !Sub arn:${AWS::Partition}:iam::${pSharedDevOpsAccountId}:role/sdlf-cicd-team-codecommit-${pEnvironment}-${pTeamName}
               - Effect: Allow
                 Action:
                   - iam:DeleteRole
@@ -729,9 +729,9 @@ Resources:
                   - iam:CreateRole
                   - iam:PassRole
                 Resource:
-                  - !Sub arn:aws:iam::${AWS::AccountId}:role/sdlf-${pTeamName}-*
-                  - !Sub arn:aws:iam::${AWS::AccountId}:role/service-role/sdlf-${pTeamName}-*
-                  - !Sub arn:aws:iam::${pSharedDevOpsAccountId}:role/sdlf-cicd-team-codecommit-${pEnvironment}-${pTeamName}
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/service-role/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:iam::${pSharedDevOpsAccountId}:role/sdlf-cicd-team-codecommit-${pEnvironment}-${pTeamName}
               - Effect: Allow
                 Action:
                   - cloudformation:CreateChangeSet
@@ -743,14 +743,14 @@ Resources:
                   - cloudformation:ExecuteChangeSet
                   - cloudformation:SetStackPolicy
                   - cloudformation:UpdateStack
-                Resource: !Sub arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/sdlf-${pTeamName}-*
+                Resource: !Sub arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - cloudformation:CreateChangeSet
                   - cloudformation:DeleteChangeSet
                   - cloudformation:DescribeChangeSet
                   - cloudformation:ExecuteChangeSet
-                Resource: !Sub arn:aws:cloudformation:${AWS::Region}:aws:transform/*
+                Resource: !Sub arn:${AWS::Partition}:cloudformation:${AWS::Region}:aws:transform/*
               - Effect: Allow
                 Action:
                   - ssm:AddTagsToResource
@@ -762,13 +762,13 @@ Resources:
                   - ssm:GetParametersByPath
                   - ssm:ListTagsForResource
                   - ssm:RemoveTagsFromResource
-                Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/*
+                Resource: !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/*
               - Effect: Allow
                 Action:
                   - ssm:DeleteParameter
                   - ssm:DeleteParameters
                   - ssm:PutParameter
-                Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/*/${pTeamName}/*
+                Resource: !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/*/${pTeamName}/*
               - Effect: Allow
                 Action:
                   - dynamodb:DeleteItem
@@ -778,8 +778,8 @@ Resources:
                   - dynamodb:Scan
                   - dynamodb:UpdateItem
                 Resource:
-                  - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/octagon-Pipelines-${pEnvironment}
-                  - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/octagon-Datasets-${pEnvironment}
+                  - !Sub arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/octagon-Pipelines-${pEnvironment}
+                  - !Sub arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/octagon-Datasets-${pEnvironment}
               - Effect: Allow
                 Action:
                   - dynamodb:CreateTable
@@ -791,8 +791,8 @@ Resources:
                   - dynamodb:*Backup
                   - dynamodb:*Backups
                 Resource:
-                  - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/octagon-${pTeamName}-*
-                  - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/octagon-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - athena:CreateWorkGroup
@@ -800,7 +800,7 @@ Resources:
                   - athena:UpdateWorkGroup
                   - athena:GetWorkGroup
                 Resource:
-                  - !Sub arn:aws:athena:${AWS::Region}:${AWS::AccountId}:workgroup/${pTeamName}*
+                  - !Sub arn:${AWS::Partition}:athena:${AWS::Region}:${AWS::AccountId}:workgroup/${pTeamName}*
               - Effect: Allow
                 Action:
                   - events:DeleteRule
@@ -810,7 +810,7 @@ Resources:
                   - events:PutRule
                   - events:PutTargets
                   - events:RemoveTargets
-                Resource: !Sub arn:aws:events:${AWS::Region}:${AWS::AccountId}:rule/sdlf-${pTeamName}-*
+                Resource: !Sub arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:rule/sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - codepipeline:CreatePipeline
@@ -818,7 +818,7 @@ Resources:
                   - codepipeline:GetPipelineState
                   - codepipeline:GetPipeline
                   - codepipeline:UpdatePipeline
-                Resource: !Sub arn:aws:codepipeline:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
+                Resource: !Sub arn:${AWS::Partition}:codepipeline:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - codebuild:BatchGetProjects
@@ -826,16 +826,16 @@ Resources:
                   - codebuild:CreateProject
                   - codebuild:DeleteProject
                   - codebuild:UpdateProject
-                Resource: !Sub arn:aws:codebuild:${AWS::Region}:${AWS::AccountId}:project/sdlf-${pTeamName}-*
+                Resource: !Sub arn:${AWS::Partition}:codebuild:${AWS::Region}:${AWS::AccountId}:project/sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - s3:ListBucket
-                Resource: !Sub arn:aws:s3:::${pCFNBucket}
+                Resource: !Sub arn:${AWS::Partition}:s3:::${pCFNBucket}
               - Effect: Allow
                 Action:
                   - s3:GetObject
                   - s3:PutObject
-                Resource: !Sub arn:aws:s3:::${pCFNBucket}/*
+                Resource: !Sub arn:${AWS::Partition}:s3:::${pCFNBucket}/*
               - Effect: Allow
                 Action:
                   - kms:CreateGrant
@@ -852,7 +852,7 @@ Resources:
                   - logs:CreateLogStream
                   - logs:PutLogEvents
                 Resource:
-                  - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - lakeformation:GetDataAccess
@@ -876,7 +876,7 @@ Resources:
                   - sqs:SetQueueAttributes
                   - sqs:TagQueue
                   - sqs:UntagQueue
-                Resource: !Sub arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
+                Resource: !Sub arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - glue:TagResource
@@ -889,7 +889,7 @@ Resources:
                   - glue:GetCrawler
                   - glue:GetCrawlers
                   - glue:UpdateCrawler
-                Resource: !Sub arn:aws:glue:${AWS::Region}:${AWS::AccountId}:crawler/sdlf-${pTeamName}-*
+                Resource: !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:crawler/sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - glue:CreateDatabase
@@ -899,12 +899,12 @@ Resources:
                   - glue:UpdateDatabase
                   - glue:*Table
                 Resource:
-                  - !Sub arn:aws:glue:${AWS::Region}:${AWS::AccountId}:catalog
-                  - !Sub arn:aws:glue:${AWS::Region}:${AWS::AccountId}:database/${pOrganizationName}_${pApplicationName}_${pEnvironment}_${pTeamName}_*
-                  - !Sub arn:aws:glue:${AWS::Region}:${AWS::AccountId}:database/*${pTeamName}*
-                  - !Sub arn:aws:glue:${AWS::Region}:${AWS::AccountId}:table/*
-                  - !Sub arn:aws:glue:${AWS::Region}:${AWS::AccountId}:userDefinedFunction/*${pTeamName}*
-                  - !Sub arn:aws:glue:${AWS::Region}:${AWS::AccountId}:userDefinedFunction/${pTeamName}*
+                  - !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:catalog
+                  - !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:database/${pOrganizationName}_${pApplicationName}_${pEnvironment}_${pTeamName}_*
+                  - !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:database/*${pTeamName}*
+                  - !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:table/*
+                  - !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:userDefinedFunction/*${pTeamName}*
+                  - !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:userDefinedFunction/${pTeamName}*
               - Effect: Allow
                 Action:
                   - lambda:AddPermission
@@ -925,7 +925,7 @@ Resources:
                   - lambda:UpdateFunctionCode
                   - lambda:UpdateFunctionConfiguration
                   - lambda:UpdateFunctionConfiguration
-                Resource: !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:sdlf-${pTeamName}*
+                Resource: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:sdlf-${pTeamName}*
               - Effect: Allow
                 Action:
                   - lambda:CreateEventSourceMapping
@@ -957,7 +957,7 @@ Resources:
                   - logs:CreateLogStream
                   - logs:PutLogEvents
                 Resource:
-                  - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - s3:GetBucketAcl
@@ -966,12 +966,12 @@ Resources:
                   - s3:GetObjectVersion
                   - s3:PutObject
                 Resource:
-                  - !Sub arn:aws:s3:::${pPipelineBucket}/*
-                  - !Sub arn:aws:s3:::${pCFNBucket}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pPipelineBucket}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pCFNBucket}/*
               - Effect: Allow
                 Action: codecommit:GitPull
                 Resource:
-                  - !Sub arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - kms:CreateGrant
@@ -1009,7 +1009,7 @@ Resources:
               - Effect: Allow
                 Action:
                   - lambda:InvokeFunction
-                Resource: !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:sdlf-${pTeamName}-*
+                Resource: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - states:DescribeStateMachine
@@ -1026,7 +1026,7 @@ Resources:
                   - events:DescribeRule
                   - events:PutRule
                   - events:PutTargets
-                Resource: !Sub arn:aws:events:${AWS::Region}:${AWS::AccountId}:rule/StepFunctionsGetEventsForStepFunctionsExecutionRule
+                Resource: !Sub arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:rule/StepFunctionsGetEventsForStepFunctionsExecutionRule
               - Effect: Allow
                 Action:
                   - elasticmapreduce:DescribeCluster
@@ -1043,17 +1043,17 @@ Resources:
                   - elasticmapreduce:ModifyInstanceFleet
                   - elasticmapreduce:ModifyInstanceGroups
                   - elasticmapreduce:SetTerminationProtection
-                Resource: !Sub arn:aws:elasticmapreduce:${AWS::Region}:${AWS::AccountId}:cluster/*
+                Resource: !Sub arn:${AWS::Partition}:elasticmapreduce:${AWS::Region}:${AWS::AccountId}:cluster/*
               - Effect: Allow
                 Action:
                   - iam:PassRole
-                Resource: !Sub arn:aws:iam::${AWS::AccountId}:role/EMR*
+                Resource: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/EMR*
               - Effect: Allow
                 Action:
                   - iam:CreateServiceLinkedRole
                   - iam:PutRolePolicy
                   - iam:UpdateRoleDescription
-                Resource: !Sub arn:aws:iam::${AWS::AccountId}:role/aws-service-role/elasticmapreduce.amazonaws.com/AWSServiceRoleForEMRCleanup*
+                Resource: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/aws-service-role/elasticmapreduce.amazonaws.com/AWSServiceRoleForEMRCleanup*
                 Condition:
                   StringLike:
                     iam:AWSServiceName: elasticmapreduce.amazonaws.com
@@ -1090,7 +1090,7 @@ Resources:
               - Effect: Allow
                 Action:
                   - lambda:InvokeFunction
-                Resource: !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:sdlf-${pTeamName}-*
+                Resource: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:sdlf-${pTeamName}-*
         - PolicyName: !Sub sdlf-${pTeamName}-describe-state-machines
           PolicyDocument:
             Version: 2012-10-17
@@ -1098,7 +1098,7 @@ Resources:
               - Effect: Allow
                 Action:
                   - states:ListStateMachines
-                Resource: !Sub arn:aws:states:${AWS::Region}:${AWS::AccountId}:*
+                Resource: !Sub arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:*
         - PolicyName: !Sub sdlf-${pTeamName}-dataset-state-machine
           PolicyDocument:
             Version: 2012-10-17
@@ -1108,7 +1108,7 @@ Resources:
                   - states:DescribeStateMachineForExecution
                   - states:DescribeStateMachine
                   - states:StartExecution
-                Resource: !Sub arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:sdlf-${pTeamName}-*
+                Resource: !Sub arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:stateMachine:sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - s3:ListBucket
@@ -1116,10 +1116,10 @@ Resources:
                   - s3:GetObjectVersion
                   - s3:GetBucketVersioning
                 Resource:
-                  - !Sub arn:aws:s3:::${pPipelineBucket}
-                  - !Sub arn:aws:s3:::${pCentralBucket}
-                  - !Sub arn:aws:s3:::${pStageBucket}
-                  - !Sub arn:aws:s3:::${pAnalyticsBucket}
+                  - !Sub arn:${AWS::Partition}:s3:::${pPipelineBucket}
+                  - !Sub arn:${AWS::Partition}:s3:::${pCentralBucket}
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}
+                  - !Sub arn:${AWS::Partition}:s3:::${pAnalyticsBucket}
 
   rCodeBuildPublishLayerRole:
     Type: AWS::IAM::Role
@@ -1140,14 +1140,14 @@ Resources:
             Statement:
               - Effect: Allow
                 Action: lambda:PublishLayerVersion
-                Resource: !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:layer:sdlf-${pTeamName}-*
+                Resource: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:layer:sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - dynamodb:Get*
                   - dynamodb:Update*
                   - dynamodb:Put*
                 Resource:
-                  - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/octagon-*
+                  - !Sub arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/octagon-*
               - Effect: Allow
                 Action:
                   - ssm:AddTagsToResource
@@ -1159,12 +1159,12 @@ Resources:
                   - ssm:GetParametersByPath
                   - ssm:ListTagsForResource
                   - ssm:RemoveTagsFromResource
-                Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/*
+                Resource: !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/*
               - Effect: Allow
                 Action:
                   - ssm:PutParameter
                   - ssm:DeleteParameter
-                Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/*/${pTeamName}/*
+                Resource: !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/*/${pTeamName}/*
               - Effect: Allow
                 Action:
                   - s3:GetBucketAcl
@@ -1175,10 +1175,10 @@ Resources:
                   - s3:ListBucket
                   - s3:PutObject
                 Resource:
-                  - !Sub arn:aws:s3:::${pPipelineBucket}
-                  - !Sub arn:aws:s3:::${pPipelineBucket}/*
-                  - !Sub arn:aws:s3:::${pCFNBucket}
-                  - !Sub arn:aws:s3:::${pCFNBucket}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pPipelineBucket}
+                  - !Sub arn:${AWS::Partition}:s3:::${pPipelineBucket}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pCFNBucket}
+                  - !Sub arn:${AWS::Partition}:s3:::${pCFNBucket}/*
 
   rDatalakeCrawlerRole:
     Type: AWS::IAM::Role
@@ -1195,7 +1195,7 @@ Resources:
             Action:
               - sts:AssumeRole
       ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/service-role/AWSGlueServiceRole
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSGlueServiceRole
       Policies:
         - PolicyName: !Sub sdlf-${pTeamName}-glue-crawler
           PolicyDocument:
@@ -1210,21 +1210,21 @@ Resources:
               - Effect: Allow
                 Action:
                   - s3:CreateBucket
-                Resource: arn:aws:s3:::aws-glue-*
+                Resource: !Sub arn:${AWS::Partition}:s3:::aws-glue-*
               - Effect: Allow
                 Action:
                   - s3:DeleteObject
                   - s3:GetObject
                   - s3:PutObject
                 Resource:
-                  - arn:aws:s3:::aws-glue-*/*
-                  - arn:aws:s3:::*/*aws-glue-*/*
+                  - !Sub arn:${AWS::Partition}:s3:::aws-glue-*/*
+                  - !Sub arn:${AWS::Partition}:s3:::*/*aws-glue-*/*
               - Effect: Allow
                 Action:
                   - s3:GetObject
                 Resource:
-                  - arn:aws:s3:::crawler-public*
-                  - arn:aws:s3:::aws-glue-*
+                  - !Sub arn:${AWS::Partition}:s3:::crawler-public*
+                  - !Sub arn:${AWS::Partition}:s3:::aws-glue-*
               - Effect: Allow
                 Action:
                   - s3:ListObjectsV2
@@ -1236,14 +1236,14 @@ Resources:
                   - s3:PutObject
                   - s3:PutObjectVersion
                 Resource:
-                  - !Sub arn:aws:s3:::${pCentralBucket}/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pCentralBucket}/raw/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pStageBucket}/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pStageBucket}/stage/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pStageBucket}/pre-stage/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pStageBucket}/post-stage/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pAnalyticsBucket}/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pAnalyticsBucket}/analytics/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pCentralBucket}/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pCentralBucket}/raw/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/pre-stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/post-stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pAnalyticsBucket}/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pAnalyticsBucket}/analytics/${pTeamName}/*
               - Effect: Allow
                 Action:
                   - kms:DescribeKey

--- a/sdlf-utils/pipeline-examples/event-dataset-dependencies/sdlf-team/scripts/template-team-repos.yaml
+++ b/sdlf-utils/pipeline-examples/event-dataset-dependencies/sdlf-team/scripts/template-team-repos.yaml
@@ -44,7 +44,7 @@ Resources:
           - Effect: Allow
             Principal:
               AWS:
-                - !Sub arn:aws:iam::${pChildAccountId}:root
+                - !Sub arn:${AWS::Partition}:iam::${pChildAccountId}:root
             Action:
               - sts:AssumeRole
       Policies:
@@ -76,15 +76,15 @@ Resources:
                   - codecommit:GetUploadArchiveStatus
                   - codecommit:UploadArchive
                 Resource:
-                  - !Sub arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-*
+                  - !Sub arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-*
               - Effect: Allow
                 Action:
                   - s3:Get*
                   - s3:ListBucket*
                   - s3:Put*
                 Resource:
-                  - !Sub arn:aws:s3:::sdlf-cfn-artifacts-${AWS::Region}-${pChildAccountId}
-                  - !Sub arn:aws:s3:::sdlf-cfn-artifacts-${AWS::Region}-${pChildAccountId}/*
+                  - !Sub arn:${AWS::Partition}:s3:::sdlf-cfn-artifacts-${AWS::Region}-${pChildAccountId}
+                  - !Sub arn:${AWS::Partition}:s3:::sdlf-cfn-artifacts-${AWS::Region}-${pChildAccountId}/*
               - Effect: Allow
                 Action:
                   - kms:Encrypt
@@ -94,7 +94,7 @@ Resources:
                   - kms:DescribeKey
                   - kms:List*
                   - kms:Describe*
-                Resource: !Sub arn:aws:kms:${AWS::Region}:${pChildAccountId}:key/*
+                Resource: !Sub arn:${AWS::Partition}:kms:${AWS::Region}:${pChildAccountId}:key/*
                 Condition:
                   ForAllValues:StringLike:
                     aws:PrincipalArn: !Sub "*${pTeamName}*"
@@ -111,14 +111,14 @@ Resources:
               "CodeCommit Repository State Change"
             ],
             "resources": [
-              "arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-pipeline",
-              "arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-dataset",
-              "arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-datalakeLibrary",
-              "arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-pipLibrary",
-              "arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-stageA",
-              "arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-stageB",
-              "arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-stageC",
-              "arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-stageX"
+              "arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-pipeline",
+              "arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-dataset",
+              "arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-datalakeLibrary",
+              "arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-pipLibrary",
+              "arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-stageA",
+              "arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-stageB",
+              "arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-stageC",
+              "arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-stageX"
             ],
             "source": [
               "aws.codecommit"
@@ -139,9 +139,9 @@ Resources:
         - { cBranch: !FindInMap [pCodeCommitBranch, !Ref pEnvironment, branch] }
       State: ENABLED
       Targets:
-        - Arn: !Sub arn:aws:events:${AWS::Region}:${pChildAccountId}:event-bus/default
+        - Arn: !Sub arn:${AWS::Partition}:events:${AWS::Region}:${pChildAccountId}:event-bus/default
           Id: !Sub sdlf-cicd-team-codecommit-${pEnvironment}-${pTeamName}
-          RoleArn: !Sub arn:aws:iam::${AWS::AccountId}:role/sdlf-cicd-foundations-eventbus-${pEnvironment}
+          RoleArn: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/sdlf-cicd-foundations-eventbus-${pEnvironment}
 
   rPullRequestCreated:
     Condition: IsProduction
@@ -156,14 +156,14 @@ Resources:
               "CodeCommit Pull Request State Change"
             ],
             "resources": [
-              "arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-pipeline",
-              "arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-dataset",
-              "arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-datalakeLibrary",
-              "arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-pipLibrary",
-              "arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-stageA",
-              "arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-stageB",
-              "arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-stageC",
-              "arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-stageX"
+              "arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-pipeline",
+              "arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-dataset",
+              "arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-datalakeLibrary",
+              "arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-pipLibrary",
+              "arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-stageA",
+              "arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-stageB",
+              "arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-stageC",
+              "arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-stageX"
             ],
             "source": [
               "aws.codecommit"
@@ -181,6 +181,6 @@ Resources:
         - { cBranch: !FindInMap [pCodeCommitBranch, !Ref pEnvironment, branch] }
       State: ENABLED
       Targets:
-        - Arn: !Sub arn:aws:events:${AWS::Region}:${pChildAccountId}:event-bus/default
+        - Arn: !Sub arn:${AWS::Partition}:events:${AWS::Region}:${pChildAccountId}:event-bus/default
           Id: !Sub sdlf-cicd-team-codecommit-pr-${pEnvironment}-${pTeamName}
-          RoleArn: !Sub arn:aws:iam::${AWS::AccountId}:role/sdlf-cicd-foundations-eventbus-${pEnvironment}
+          RoleArn: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/sdlf-cicd-foundations-eventbus-${pEnvironment}

--- a/sdlf-utils/pipeline-examples/glue-jobs-deployer/glue-job.yaml
+++ b/sdlf-utils/pipeline-examples/glue-jobs-deployer/glue-job.yaml
@@ -40,14 +40,14 @@ Resources:
             Action: 
               - "sts:AssumeRole"
       ManagedPolicyArns: 
-        - "arn:aws:iam::aws:policy/service-role/AWSGlueServiceRole"
-        - "arn:aws:iam::aws:policy/AWSGlueConsoleFullAccess"
-        - "arn:aws:iam::aws:policy/AmazonDynamoDBFullAccess"
-        - "arn:aws:iam::aws:policy/AmazonS3FullAccess"
-        - "arn:aws:iam::aws:policy/AmazonRedshiftFullAccess"
-        - "arn:aws:iam::aws:policy/CloudWatchLogsFullAccess"
-        - "arn:aws:iam::aws:policy/CloudWatchFullAccess"
-        - "arn:aws:iam::aws:policy/AWSLakeFormationDataAdmin"
+        - !Sub "arn:${AWS::Partition}:iam::aws:policy/service-role/AWSGlueServiceRole"
+        - !Sub "arn:${AWS::Partition}:iam::aws:policy/AWSGlueConsoleFullAccess"
+        - !Sub "arn:${AWS::Partition}:iam::aws:policy/AmazonDynamoDBFullAccess"
+        - !Sub "arn:${AWS::Partition}:iam::aws:policy/AmazonS3FullAccess"
+        - !Sub "arn:${AWS::Partition}:iam::aws:policy/AmazonRedshiftFullAccess"
+        - !Sub "arn:${AWS::Partition}:iam::aws:policy/CloudWatchLogsFullAccess"
+        - !Sub "arn:${AWS::Partition}:iam::aws:policy/CloudWatchFullAccess"
+        - !Sub "arn:${AWS::Partition}:iam::aws:policy/AWSLakeFormationDataAdmin"
       Policies:
         - PolicyName: !Sub 'sdlf-${pTeam}-${pPipeline}-${pDataset}-glue-job-policy'
           PolicyDocument:

--- a/sdlf-utils/pipeline-examples/legislators/scripts/legislators-glue-job.yaml
+++ b/sdlf-utils/pipeline-examples/legislators/scripts/legislators-glue-job.yaml
@@ -31,9 +31,9 @@ Resources:
             Action:
               - sts:AssumeRole
       ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/service-role/AWSGlueServiceRole
-        - arn:aws:iam::aws:policy/AmazonS3FullAccess
-        - arn:aws:iam::aws:policy/CloudWatchLogsFullAccess
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSGlueServiceRole
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/AmazonS3FullAccess
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/CloudWatchLogsFullAccess
       Policies:
         - PolicyName: !Sub sdlf-${pTeamName}-${pDatasetName}-glue-job
           PolicyDocument:

--- a/sdlf-utils/pipeline-examples/manifests/dataset/template.yaml
+++ b/sdlf-utils/pipeline-examples/manifests/dataset/template.yaml
@@ -99,7 +99,7 @@ Resources:
       ScheduleExpression: "cron(*/5 * * * ? *)"
       Targets:
         - Id: !Sub sdlf-${pTeamName}-${pDatasetName}-rule-b
-          Arn: !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:sdlf-${pTeamName}-${pPipelineName}-routing-b
+          Arn: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:sdlf-${pTeamName}-${pPipelineName}-routing-b
           Input: !Sub |
             {
               "team": "${pTeamName}",

--- a/sdlf-utils/pipeline-examples/manifests/pipeline/nested-stacks/template-statemachine.yaml
+++ b/sdlf-utils/pipeline-examples/manifests/pipeline/nested-stacks/template-statemachine.yaml
@@ -53,7 +53,7 @@ Resources:
           Actions:
             -
               Name: Source
-              RoleArn: !Sub arn:aws:iam::${pSharedDevOpsAccountId}:role/sdlf-cicd-team-codecommit-${pEnv}-${pTeamName}
+              RoleArn: !Sub arn:${AWS::Partition}:iam::${pSharedDevOpsAccountId}:role/sdlf-cicd-team-codecommit-${pEnv}-${pTeamName}
               ActionTypeId:
                 Category: Source
                 Owner: AWS
@@ -152,7 +152,7 @@ Resources:
         detail-type:
           - CodeCommit Repository State Change
         resources:
-          - !Sub arn:aws:codecommit:${AWS::Region}:${pSharedDevOpsAccountId}:${pRepositoryName}
+          - !Sub arn:${AWS::Partition}:codecommit:${AWS::Region}:${pSharedDevOpsAccountId}:${pRepositoryName}
         detail:
           event:
             - referenceCreated
@@ -162,7 +162,7 @@ Resources:
           referenceName:
             - !Ref pBranchName
       Targets:
-        - Arn: !Sub arn:aws:codepipeline:${AWS::Region}:${AWS::AccountId}:${rStateMachinePipeline}
+        - Arn: !Sub arn:${AWS::Partition}:codepipeline:${AWS::Region}:${AWS::AccountId}:${rStateMachinePipeline}
           Id: !Sub sdlf-${pTeamName}-${pPipeline}-${pRepositoryName}-trigger
           RoleArn: !Ref pCloudWatchRepositoryTriggerRoleArn
 
@@ -181,7 +181,7 @@ Resources:
           project-name:
             - !Ref pBuildDatalakeLibrary
       Targets:
-        - Arn: !Sub arn:aws:codepipeline:${AWS::Region}:${AWS::AccountId}:${rStateMachinePipeline}
+        - Arn: !Sub arn:${AWS::Partition}:codepipeline:${AWS::Region}:${AWS::AccountId}:${rStateMachinePipeline}
           Id: !Sub sdlf-${pTeamName}-${pPipeline}-${pRepositoryName}-update
           RoleArn: !Ref pCloudWatchRepositoryTriggerRoleArn
 

--- a/sdlf-utils/pipeline-examples/manifests/scripts/weather-glue-job.yaml
+++ b/sdlf-utils/pipeline-examples/manifests/scripts/weather-glue-job.yaml
@@ -31,9 +31,9 @@ Resources:
             Action:
               - sts:AssumeRole
       ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/service-role/AWSGlueServiceRole
-        - arn:aws:iam::aws:policy/AmazonS3FullAccess
-        - arn:aws:iam::aws:policy/CloudWatchLogsFullAccess
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSGlueServiceRole
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/AmazonS3FullAccess
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/CloudWatchLogsFullAccess
       Policies:
         - PolicyName: !Sub sdlf-${pTeamName}-${pDatasetName}-glue-job
           PolicyDocument:

--- a/sdlf-utils/pipeline-examples/manifests/stageA/lambda/stage-a-process-object/test/test_template.yaml
+++ b/sdlf-utils/pipeline-examples/manifests/stageA/lambda/stage-a-process-object/test/test_template.yaml
@@ -68,8 +68,7 @@ Resources:
           TEST: True
       Handler: lambda_function.lambda_handler
       MemorySize: 512
-      Role: >-
-        arn:aws:iam::509480599834:role/service-role/qs-transform-object-phase-a-role
+      Role: !Sub arn:${AWS::Partition}:iam::509480599834:role/service-role/qs-transform-object-phase-a-role
       Runtime: python3.9
       Timeout: 120
       Layers: 

--- a/sdlf-utils/pipeline-examples/manifests/stageA/template.yaml
+++ b/sdlf-utils/pipeline-examples/manifests/stageA/template.yaml
@@ -144,17 +144,17 @@ Resources:
           - Effect: Allow
             Action:
               - logs:CreateLogGroup
-            Resource: !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*
+            Resource: !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:*
           - Effect: Allow
             Action:
               - logs:CreateLogStream
               - logs:PutLogEvents
-            Resource: !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/sdlf-${pTeamName}-*
+            Resource: !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/sdlf-${pTeamName}-*
           - Effect: Allow
             Action:
               - ssm:GetParameter
               - ssm:GetParameters
-            Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/*
+            Resource: !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/*
           - Effect: Allow
             Action:
               - dynamodb:BatchGetItem
@@ -168,7 +168,7 @@ Resources:
               - dynamodb:Scan
               - dynamodb:UpdateItem
             Resource:
-              - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/octagon-*
+              - !Sub arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/octagon-*
           - Effect: Allow
             Action:
               - kms:CreateGrant
@@ -247,15 +247,15 @@ Resources:
                 Action:
                   - s3:ListBucket
                 Resource:
-                  - !Sub arn:aws:s3:::${pStageBucket}
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}
               - Effect: Allow
                 Action:
                   - s3:GetObject
                 Resource:
-                  - !Sub arn:aws:s3:::${pStageBucket}/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pStageBucket}/stage/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pStageBucket}/pre-stage/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pStageBucket}/post-stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/pre-stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/post-stage/${pTeamName}/*
 
   # Step2 Role
   rRoleLambdaExecutionStep2:
@@ -283,20 +283,20 @@ Resources:
                   - s3:GetBucketVersioning
                   - s3:ListBucket
                 Resource:
-                  - !Sub arn:aws:s3:::${pDatasetBucket}
-                  - !Sub arn:aws:s3:::${pStageBucket}
-                  - !Sub arn:aws:s3:::${pArtifactsBucket}
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}
+                  - !Sub arn:${AWS::Partition}:s3:::${pArtifactsBucket}
               - Effect: Allow
                 Action:
                   - s3:GetObject
                   - s3:PutObject
                 Resource:
-                  - !Sub arn:aws:s3:::${pDatasetBucket}/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pDatasetBucket}/raw/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pStageBucket}/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pStageBucket}/stage/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pStageBucket}/pre-stage/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pStageBucket}/post-stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}/raw/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/pre-stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/post-stage/${pTeamName}/*
               - Effect: Allow
                 Action:
                   - kms:DescribeKey
@@ -339,20 +339,20 @@ Resources:
                   - sqs:SendMessage
                   - sqs:SendMessageBatch
                 Resource:
-                  - !Sub arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - s3:ListBucket
                 Resource:
-                  - !Sub arn:aws:s3:::${pStageBucket}
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}
               - Effect: Allow
                 Action:
                   - s3:GetObject
                 Resource:
-                  - !Sub arn:aws:s3:::${pStageBucket}/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pStageBucket}/stage/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pStageBucket}/pre-stage/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pStageBucket}/post-stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/pre-stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/post-stage/${pTeamName}/*
 
   # Step4 Role
   rRoleLambdaExecutionStep4:
@@ -380,21 +380,21 @@ Resources:
                   - s3:GetBucketVersioning
                   - s3:ListBucket
                 Resource:
-                  - !Sub arn:aws:s3:::${pDatasetBucket}
-                  - !Sub arn:aws:s3:::${pStageBucket}
-                  - !Sub arn:aws:s3:::${pArtifactsBucket}
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}
+                  - !Sub arn:${AWS::Partition}:s3:::${pArtifactsBucket}
               - Effect: Allow
                 Action:
                   - s3:GetObject
                   - s3:PutObject
                   - s3:CopyObject
                 Resource:
-                  - !Sub arn:aws:s3:::${pDatasetBucket}/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pDatasetBucket}/raw/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pStageBucket}/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pStageBucket}/stage/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pStageBucket}/pre-stage/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pStageBucket}/post-stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}/raw/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/pre-stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/post-stage/${pTeamName}/*
               - Effect: Allow
                 Action:
                   - kms:DescribeKey
@@ -432,20 +432,20 @@ Resources:
                   - s3:GetBucketVersioning
                   - s3:ListBucket
                 Resource:
-                  - !Sub arn:aws:s3:::${pDatasetBucket}
-                  - !Sub arn:aws:s3:::${pStageBucket}
-                  - !Sub arn:aws:s3:::${pArtifactsBucket}
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}
+                  - !Sub arn:${AWS::Partition}:s3:::${pArtifactsBucket}
               - Effect: Allow
                 Action:
                   - s3:GetObject
                   - s3:PutObject
                 Resource:
-                  - !Sub arn:aws:s3:::${pDatasetBucket}/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pDatasetBucket}/raw/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pStageBucket}/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pStageBucket}/stage/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pStageBucket}/pre-stage/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pStageBucket}/post-stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}/raw/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/pre-stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/post-stage/${pTeamName}/*
               - Effect: Allow
                 Action:
                   - kms:DescribeKey
@@ -483,21 +483,21 @@ Resources:
                   - s3:GetBucketVersioning
                   - s3:ListBucket
                 Resource:
-                  - !Sub arn:aws:s3:::${pDatasetBucket}
-                  - !Sub arn:aws:s3:::${pStageBucket}
-                  - !Sub arn:aws:s3:::${pArtifactsBucket}
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}
+                  - !Sub arn:${AWS::Partition}:s3:::${pArtifactsBucket}
               - Effect: Allow
                 Action:
                   - s3:GetObject
                   - s3:PutObject
                   - s3:CopyObject
                 Resource:
-                  - !Sub arn:aws:s3:::${pDatasetBucket}/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pDatasetBucket}/raw/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pStageBucket}/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pStageBucket}/stage/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pStageBucket}/pre-stage/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pStageBucket}/post-stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}/raw/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/pre-stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/post-stage/${pTeamName}/*
               - Effect: Allow
                 Action:
                   - kms:DescribeKey
@@ -535,20 +535,20 @@ Resources:
                   - s3:GetBucketVersioning
                   - s3:ListBucket
                 Resource:
-                  - !Sub arn:aws:s3:::${pDatasetBucket}
-                  - !Sub arn:aws:s3:::${pStageBucket}
-                  - !Sub arn:aws:s3:::${pArtifactsBucket}
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}
+                  - !Sub arn:${AWS::Partition}:s3:::${pArtifactsBucket}
               - Effect: Allow
                 Action:
                   - s3:GetObject
                   - s3:PutObject
                 Resource:
-                  - !Sub arn:aws:s3:::${pDatasetBucket}/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pDatasetBucket}/raw/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pStageBucket}/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pStageBucket}/stage/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pStageBucket}/pre-stage/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pStageBucket}/post-stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}/raw/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/pre-stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/post-stage/${pTeamName}/*
               - Effect: Allow
                 Action:
                   - kms:DescribeKey

--- a/sdlf-utils/pipeline-examples/manifests/stageB/lambda/stage-b-process-data/test/test_template.yaml
+++ b/sdlf-utils/pipeline-examples/manifests/stageB/lambda/stage-b-process-data/test/test_template.yaml
@@ -63,8 +63,7 @@ Resources:
           TEST: True
       Handler: lambda_function.lambda_handler
       MemorySize: 512
-      Role: >-
-        arn:aws:iam::509480599834:role/service-role/qs-transform-object-phase-a-role
+      Role: !Sub arn:${AWS::Partition}:iam::509480599834:role/service-role/qs-transform-object-phase-a-role
       Runtime: python3.9
       Timeout: 120
       Layers: 

--- a/sdlf-utils/pipeline-examples/manifests/stageB/template.yaml
+++ b/sdlf-utils/pipeline-examples/manifests/stageB/template.yaml
@@ -92,17 +92,17 @@ Resources:
           - Effect: Allow
             Action:
               - logs:CreateLogGroup
-            Resource: !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*
+            Resource: !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:*
           - Effect: Allow
             Action:
               - logs:CreateLogStream
               - logs:PutLogEvents
-            Resource: !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/sdlf-${pTeamName}-*
+            Resource: !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/sdlf-${pTeamName}-*
           - Effect: Allow
             Action:
               - ssm:GetParameter
               - ssm:GetParameters
-            Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/*
+            Resource: !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/*
           - Effect: Allow
             Action:
               - dynamodb:BatchGetItem
@@ -116,7 +116,7 @@ Resources:
               - dynamodb:Scan
               - dynamodb:UpdateItem
             Resource:
-              - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/octagon-*
+              - !Sub arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/octagon-*
           - Effect: Allow
             Action:
               - kms:CreateGrant
@@ -167,7 +167,7 @@ Resources:
                   - sqs:SendMessage
                   - sqs:SendMessageBatch
                 Resource:
-                  - !Sub arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
 
   # Step1 Role
   rRoleLambdaExecutionStep1:
@@ -194,17 +194,17 @@ Resources:
                 Action:
                   - s3:ListBucket
                 Resource:
-                  - !Sub arn:aws:s3:::${pDatasetBucket}
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}
               - Effect: Allow
                 Action:
                   - s3:GetObject
                   - s3:PutObject
                 Resource:
-                  - !Sub arn:aws:s3:::${pDatasetBucket}/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pDatasetBucket}/stage/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pDatasetBucket}/pre-stage/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pDatasetBucket}/post-stage/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pDatasetBucket}/analytics/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}/stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}/pre-stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}/post-stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}/analytics/${pTeamName}/*
               - Effect: Allow
                 Action:
                   - kms:DescribeKey
@@ -220,7 +220,7 @@ Resources:
                   - glue:GetJobRun
                   - glue:StartJobRun
                 Resource:
-                  - !Sub arn:aws:glue:${AWS::Region}:${AWS::AccountId}:job/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:job/sdlf-${pTeamName}-*
 
   # Step2 Role
   rRoleLambdaExecutionStep2:
@@ -247,7 +247,7 @@ Resources:
                 Action:
                   - glue:StartCrawler
                 Resource:
-                  - !Sub arn:aws:glue:${AWS::Region}:${AWS::AccountId}:crawler/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:crawler/sdlf-${pTeamName}-*
 
   # Step3 Role
   rRoleLambdaExecutionStep3:
@@ -274,18 +274,18 @@ Resources:
                 Action:
                   - s3:ListBucket
                 Resource:
-                  - !Sub arn:aws:s3:::${pDatasetBucket}
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}
               - Effect: Allow
                 Action:
                   - s3:GetObject
                   - s3:PutObject
                   - s3:DeleteObject
                 Resource:
-                  - !Sub arn:aws:s3:::${pDatasetBucket}/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pDatasetBucket}/stage/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pDatasetBucket}/pre-stage/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pDatasetBucket}/post-stage/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pDatasetBucket}/analytics/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}/stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}/pre-stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}/post-stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}/analytics/${pTeamName}/*
               - Effect: Allow
                 Action:
                   - kms:DescribeKey
@@ -322,17 +322,17 @@ Resources:
                 Action:
                   - s3:ListBucket
                 Resource:
-                  - !Sub arn:aws:s3:::${pDatasetBucket}
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}
               - Effect: Allow
                 Action:
                   - s3:GetObject
                   - s3:PutObject
                 Resource:
-                  - !Sub arn:aws:s3:::${pDatasetBucket}/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pDatasetBucket}/stage/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pDatasetBucket}/pre-stage/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pDatasetBucket}/post-stage/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pDatasetBucket}/analytics/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}/stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}/pre-stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}/post-stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}/analytics/${pTeamName}/*
               - Effect: Allow
                 Action:
                   - kms:DescribeKey
@@ -369,17 +369,17 @@ Resources:
                 Action:
                   - s3:ListBucket
                 Resource:
-                  - !Sub arn:aws:s3:::${pDatasetBucket}
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}
               - Effect: Allow
                 Action:
                   - s3:GetObject
                   - s3:PutObject
                 Resource:
-                  - !Sub arn:aws:s3:::${pDatasetBucket}/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pDatasetBucket}/stage/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pDatasetBucket}/pre-stage/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pDatasetBucket}/post-stage/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pDatasetBucket}/analytics/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}/stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}/pre-stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}/post-stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}/analytics/${pTeamName}/*
               - Effect: Allow
                 Action:
                   - kms:DescribeKey
@@ -425,7 +425,7 @@ Resources:
                   - sqs:SendMessage
                   - sqs:SendMessageBatch
                 Resource:
-                  - !Sub arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
 
   ######## LAMBDA FUNCTIONS #########
   rLambdaRoutingStep:

--- a/sdlf-utils/pipeline-examples/topic-modelling/stageA/template.yaml
+++ b/sdlf-utils/pipeline-examples/topic-modelling/stageA/template.yaml
@@ -147,17 +147,17 @@ Resources:
           - Effect: Allow
             Action:
               - logs:CreateLogGroup
-            Resource: !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*
+            Resource: !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:*
           - Effect: Allow
             Action:
               - logs:CreateLogStream
               - logs:PutLogEvents
-            Resource: !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/sdlf-${pTeamName}-*
+            Resource: !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/sdlf-${pTeamName}-*
           - Effect: Allow
             Action:
               - ssm:GetParameter
               - ssm:GetParameters
-            Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/*
+            Resource: !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/*
           - Effect: Allow
             Action:
               - dynamodb:BatchGetItem
@@ -171,7 +171,7 @@ Resources:
               - dynamodb:Scan
               - dynamodb:UpdateItem
             Resource:
-              - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/octagon-*
+              - !Sub arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/octagon-*
           - Effect: Allow
             Action:
               - kms:CreateGrant
@@ -250,15 +250,15 @@ Resources:
                 Action:
                   - s3:ListBucket
                 Resource:
-                  - !Sub arn:aws:s3:::${pStageBucket}
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}
               - Effect: Allow
                 Action:
                   - s3:GetObject
                 Resource:
-                  - !Sub arn:aws:s3:::${pStageBucket}/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pStageBucket}/stage/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pStageBucket}/pre-stage/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pStageBucket}/post-stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/pre-stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/post-stage/${pTeamName}/*
 
   # Step2 Role
   rRoleLambdaExecutionStep2:
@@ -286,20 +286,20 @@ Resources:
                   - s3:GetBucketVersioning
                   - s3:ListBucket
                 Resource:
-                  - !Sub arn:aws:s3:::${pDatasetBucket}
-                  - !Sub arn:aws:s3:::${pStageBucket}
-                  - !Sub arn:aws:s3:::${pArtifactsBucket}
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}
+                  - !Sub arn:${AWS::Partition}:s3:::${pArtifactsBucket}
               - Effect: Allow
                 Action:
                   - s3:GetObject
                   - s3:PutObject
                 Resource:
-                  - !Sub arn:aws:s3:::${pDatasetBucket}/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pDatasetBucket}/raw/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pStageBucket}/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pStageBucket}/stage/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pStageBucket}/pre-stage/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pStageBucket}/post-stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}/raw/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/pre-stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/post-stage/${pTeamName}/*
               - Effect: Allow
                 Action:
                   - kms:DescribeKey
@@ -342,20 +342,20 @@ Resources:
                   - sqs:SendMessage
                   - sqs:SendMessageBatch
                 Resource:
-                  - !Sub arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - s3:ListBucket
                 Resource:
-                  - !Sub arn:aws:s3:::${pStageBucket}
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}
               - Effect: Allow
                 Action:
                   - s3:GetObject
                 Resource:
-                  - !Sub arn:aws:s3:::${pStageBucket}/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pStageBucket}/stage/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pStageBucket}/pre-stage/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pStageBucket}/post-stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/pre-stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/post-stage/${pTeamName}/*
 
   # Error Handling Lambda Role
   rRoleLambdaExecutionErrorStep:
@@ -439,8 +439,8 @@ Resources:
       Timeout: 600
       Role: !GetAtt rRoleLambdaExecutionStep2.Arn
       Layers:
-        - !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:layer:sdlf-${pTeamName}-Pandas:1
-        - !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:layer:sdlf-${pTeamName}-LangDetect:1
+        - !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:layer:sdlf-${pTeamName}-Pandas:1
+        - !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:layer:sdlf-${pTeamName}-LangDetect:1
 
   rLambdaStep3:
     Type: AWS::Serverless::Function

--- a/sdlf-utils/pipeline-examples/topic-modelling/stageB/template.yaml
+++ b/sdlf-utils/pipeline-examples/topic-modelling/stageB/template.yaml
@@ -119,17 +119,17 @@ Resources:
           - Effect: Allow
             Action:
               - logs:CreateLogGroup
-            Resource: !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*
+            Resource: !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:*
           - Effect: Allow
             Action:
               - logs:CreateLogStream
               - logs:PutLogEvents
-            Resource: !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/sdlf-${pTeamName}-*
+            Resource: !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/sdlf-${pTeamName}-*
           - Effect: Allow
             Action:
               - ssm:GetParameter
               - ssm:GetParameters
-            Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/*
+            Resource: !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/*
           - Effect: Allow
             Action:
               - dynamodb:BatchGetItem
@@ -143,7 +143,7 @@ Resources:
               - dynamodb:Scan
               - dynamodb:UpdateItem
             Resource:
-              - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/octagon-*
+              - !Sub arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/octagon-*
           - Effect: Allow
             Action:
               - kms:CreateGrant
@@ -195,7 +195,7 @@ Resources:
                   - sqs:SendMessage
                   - sqs:SendMessageBatch
                 Resource:
-                  - !Sub arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
 
   # Step1 Role
   rRoleLambdaExecutionStep1:
@@ -224,18 +224,18 @@ Resources:
                 Action:
                   - s3:ListBucket
                 Resource:
-                  - !Sub arn:aws:s3:::${pDatasetBucket}
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}
               - Effect: Allow
                 Action:
                   - s3:GetObject
                   - s3:PutObject
                   - s3:DeleteObject
                 Resource:
-                  - !Sub arn:aws:s3:::${pDatasetBucket}/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pDatasetBucket}/stage/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pDatasetBucket}/pre-stage/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pDatasetBucket}/post-stage/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pDatasetBucket}/analytics/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}/stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}/pre-stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}/post-stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}/analytics/${pTeamName}/*
               - Effect: Allow
                 Action:
                   - comprehend:DescribeTopicsDetectionJob
@@ -260,7 +260,7 @@ Resources:
                   - glue:GetJobRun
                   - glue:StartJobRun
                 Resource:
-                  - !Sub arn:aws:glue:${AWS::Region}:${AWS::AccountId}:job/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:job/sdlf-${pTeamName}-*
 
   # Step2 Role
   rRoleLambdaExecutionStep2:
@@ -287,7 +287,7 @@ Resources:
                 Action:
                   - glue:StartCrawler
                 Resource:
-                  - !Sub arn:aws:glue:${AWS::Region}:${AWS::AccountId}:crawler/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:crawler/sdlf-${pTeamName}-*
 
   # Step3 Role
   rRoleLambdaExecutionStep3:
@@ -316,16 +316,16 @@ Resources:
                 Action:
                   - s3:ListBucket
                 Resource:
-                  - !Sub arn:aws:s3:::${pDatasetBucket}
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}
               - Effect: Allow
                 Action:
                   - s3:GetObject
                 Resource:
-                  - !Sub arn:aws:s3:::${pDatasetBucket}/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pDatasetBucket}/stage/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pDatasetBucket}/pre-stage/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pDatasetBucket}/post-stage/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pDatasetBucket}/analytics/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}/stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}/pre-stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}/post-stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}/analytics/${pTeamName}/*
               - Effect: Allow
                 Action:
                   - kendra:BatchPutDocument
@@ -510,7 +510,7 @@ Resources:
                   - sqs:SendMessage
                   - sqs:SendMessageBatch
                 Resource:
-                  - !Sub arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
 
   ######## LAMBDA FUNCTIONS #########
   rLambdaRoutingStep:
@@ -588,8 +588,8 @@ Resources:
       Timeout: 900
       Role: !GetAtt rRoleLambdaExecutionStep4.Arn
       Layers:
-        - !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:layer:sdlf-${pTeamName}-Pandas:1
-        - !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:layer:sdlf-${pTeamName}-JSONLines:1
+        - !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:layer:sdlf-${pTeamName}-Pandas:1
+        - !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:layer:sdlf-${pTeamName}-JSONLines:1
 
   rLambdaStep5:
     Type: AWS::Serverless::Function
@@ -601,7 +601,7 @@ Resources:
       Timeout: 900
       Role: !GetAtt rRoleLambdaExecutionStep5.Arn
       Layers:
-        - !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:layer:sdlf-${pTeamName}-Pandas:1
+        - !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:layer:sdlf-${pTeamName}-Pandas:1
 
   rLambdaStep6:
     Type: AWS::Serverless::Function
@@ -613,7 +613,7 @@ Resources:
       Timeout: 900
       Role: !GetAtt rRoleLambdaExecutionStep6.Arn
       Layers:
-        - !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:layer:sdlf-${pTeamName}-Pandas:1
+        - !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:layer:sdlf-${pTeamName}-Pandas:1
 
   rLambdaStep7:
     Type: AWS::Serverless::Function

--- a/sdlf-utils/pipeline-examples/topic-modelling/template-iam.yaml
+++ b/sdlf-utils/pipeline-examples/topic-modelling/template-iam.yaml
@@ -52,17 +52,17 @@ Resources:
             Action:
               - s3:GetBucketLocation
               - s3:ListAllMyBuckets
-            Resource: arn:aws:s3:::*
+            Resource: !Sub arn:${AWS::Partition}:s3:::*
           - Sid: AllowTeamBucketList
             Effect: Allow
             Action:
               - s3:ListBucket
             Resource:
               [
-                !Sub "arn:aws:s3:::${pPipelineBucket}",
-                !Sub "arn:aws:s3:::${pCentralBucket}",
-                !Sub "arn:aws:s3:::${pStageBucket}",
-                !Sub "arn:aws:s3:::${pAnalyticsBucket}",
+                !Sub "arn:${AWS::Partition}:s3:::${pPipelineBucket}",
+                !Sub "arn:${AWS::Partition}:s3:::${pCentralBucket}",
+                !Sub "arn:${AWS::Partition}:s3:::${pStageBucket}",
+                !Sub "arn:${AWS::Partition}:s3:::${pAnalyticsBucket}",
               ]
           - Sid: AllowTeamPrefixActions
             Effect: Allow
@@ -71,27 +71,27 @@ Resources:
               - s3:GetObject
               - s3:PutObject
             Resource:
-              - !Sub arn:aws:s3:::${pPipelineBucket}/${pTeamName}/*
+              - !Sub arn:${AWS::Partition}:s3:::${pPipelineBucket}/${pTeamName}/*
               - !If [
                   CreateMultipleBuckets,
-                  !Sub "arn:aws:s3:::${pCentralBucket}/${pTeamName}/*",
-                  !Sub "arn:aws:s3:::${pCentralBucket}/raw/${pTeamName}/*",
+                  !Sub "arn:${AWS::Partition}:s3:::${pCentralBucket}/${pTeamName}/*",
+                  !Sub "arn:${AWS::Partition}:s3:::${pCentralBucket}/raw/${pTeamName}/*",
                 ]
-              - !Sub arn:aws:s3:::${pStageBucket}/${pTeamName}/*
-              - !Sub arn:aws:s3:::${pStageBucket}/pre-stage/${pTeamName}/*
-              - !Sub arn:aws:s3:::${pStageBucket}/stage/${pTeamName}/*
-              - !Sub arn:aws:s3:::${pStageBucket}/post-stage/${pTeamName}/*
+              - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/${pTeamName}/*
+              - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/pre-stage/${pTeamName}/*
+              - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/stage/${pTeamName}/*
+              - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/post-stage/${pTeamName}/*
               - !If [
                   CreateMultipleBuckets,
-                  !Sub "arn:aws:s3:::${pAnalyticsBucket}/${pTeamName}/*",
-                  !Sub "arn:aws:s3:::${pAnalyticsBucket}/analytics/${pTeamName}/*",
+                  !Sub "arn:${AWS::Partition}:s3:::${pAnalyticsBucket}/${pTeamName}/*",
+                  !Sub "arn:${AWS::Partition}:s3:::${pAnalyticsBucket}/analytics/${pTeamName}/*",
                 ]
           - Sid: AllowFullCodeCommitOnTeamRepositories
             Effect: Allow
             Action:
               - codecommit:*
             Resource:
-              - !Sub arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
+              - !Sub arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
           - Sid: AllowTeamKMSDataKeyUsage
             Effect: Allow
             Action:
@@ -109,7 +109,7 @@ Resources:
             Action:
               - ssm:GetParameter
               - ssm:GetParameters
-            Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/*
+            Resource: !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/*
           - Sid: AllowOctagonDynamoAccess
             Effect: Allow
             Action:
@@ -124,7 +124,7 @@ Resources:
               - dynamodb:Scan
               - dynamodb:UpdateItem
             Resource:
-              - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/octagon-*
+              - !Sub arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/octagon-*
           - Sid: AllowSQSManagement
             Effect: Allow
             Action:
@@ -139,29 +139,29 @@ Resources:
               - sqs:SendMessage
               - sqs:SendMessageBatch
             Resource:
-              - !Sub arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
+              - !Sub arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
           - Effect: Allow
             Action:
               - states:StartExecution
             Resource:
-              - !Sub arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:sdlf-${pTeamName}-*
+              - !Sub arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:stateMachine:sdlf-${pTeamName}-*
           - Effect: Allow
             Action:
               - glue:StartCrawler
             Resource:
-              - !Sub arn:aws:glue:${AWS::Region}:${AWS::AccountId}:crawler/sdlf-${pTeamName}-*
+              - !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:crawler/sdlf-${pTeamName}-*
           - Effect: Allow
             Action:
               - glue:GetJobRun
               - glue:GetJobRuns
               - glue:StartJobRun
             Resource:
-              - !Sub arn:aws:glue:${AWS::Region}:${AWS::AccountId}:job/sdlf-${pTeamName}-*
-              - !Sub arn:aws:glue:${AWS::Region}:${AWS::AccountId}:job/${pOrganizationName}-${pApplicationName}-${pEnvironment}-${pTeamName}-*
+              - !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:job/sdlf-${pTeamName}-*
+              - !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:job/${pOrganizationName}-${pApplicationName}-${pEnvironment}-${pTeamName}-*
           - Effect: Allow
             Action:
               - logs:CreateLogGroup
-            Resource: !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*
+            Resource: !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:*
           - Sid: AllowCloudWatchLogsReadOnlyAccess
             Effect: Allow
             Action:
@@ -170,9 +170,9 @@ Resources:
               - logs:GetLogEvents
               - logs:PutLogEvents
             Resource:
-              - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/sdlf-${pTeamName}-*
-              - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/sdlf-${pTeamName}-*
-              - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws-glue/jobs/sdlf-${pTeamName}-*
+              - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/sdlf-${pTeamName}-*
+              - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/sdlf-${pTeamName}-*
+              - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws-glue/jobs/sdlf-${pTeamName}-*
           - Sid: AllowCloudFormationReadOnlyAccess
             Effect: Allow
             Action:
@@ -181,7 +181,7 @@ Resources:
               - cloudformation:DescribeStackResource
               - cloudformation:DescribeStackResources
             Resource:
-              - !Sub arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack:sdlf-${pTeamName}:*
+              - !Sub arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stack:sdlf-${pTeamName}:*
           - Sid: AllowComprehend
             Effect: Allow
             Action:
@@ -250,25 +250,25 @@ Resources:
                   - iam:PassRole
                   - iam:UpdateAssumeRolePolicy
                 Resource:
-                  - !Sub arn:aws:iam::${AWS::AccountId}:role/sdlf-${pTeamName}-states-execution
-                  - !Sub arn:aws:iam::${AWS::AccountId}:role/state-machine/sdlf-${pTeamName}-*
-                  - !Sub arn:aws:iam::${AWS::AccountId}:role/glue/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/sdlf-${pTeamName}-states-execution
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/state-machine/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/glue/sdlf-${pTeamName}-*
                   - !GetAtt rRoleCloudWatchEventRole.Arn
-                  - !Sub arn:aws:iam::${AWS::AccountId}:role/service-role/*
-                  - !Sub arn:aws:iam::${AWS::AccountId}:role/EMR*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/service-role/*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/EMR*
               - Effect: Allow
                 Action:
                   - iam:ListRoles
                 Resource:
-                  - !Sub arn:aws:iam::${AWS::AccountId}:role/*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/*
               - Effect: Allow
                 Action:
                   - iam:CreateRole
                 Resource:
-                  - !Sub arn:aws:iam::${AWS::AccountId}:role/sdlf-${pTeamName}-*
-                  - !Sub arn:aws:iam::${AWS::AccountId}:role/state-machine/sdlf-${pTeamName}-*
-                  - !Sub arn:aws:iam::${AWS::AccountId}:role/service-role/sdlf-${pTeamName}-*
-                  - !Sub arn:aws:iam::${AWS::AccountId}:role/glue/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/state-machine/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/service-role/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/glue/sdlf-${pTeamName}-*
                 Condition:
                   StringEquals:
                     iam:PermissionsBoundary: !Ref rTeamIAMManagedPolicy
@@ -278,14 +278,14 @@ Resources:
                   - iam:DetachRolePolicy
                   - iam:UpdateAssumeRolePolicy
                 Resource:
-                  - !Sub arn:aws:iam::${AWS::AccountId}:role/sdlf-${pTeamName}-*
-                  - !Sub arn:aws:iam::${AWS::AccountId}:role/state-machine/sdlf-${pTeamName}-*
-                  - !Sub arn:aws:iam::${AWS::AccountId}:role/service-role/sdlf-${pTeamName}-*
-                  - !Sub arn:aws:iam::${AWS::AccountId}:role/glue/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/state-machine/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/service-role/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/glue/sdlf-${pTeamName}-*
                 Condition:
                   ArnEquals:
                     iam:PolicyARN:
-                      - !Sub arn:aws:iam::${AWS::AccountId}:policy/sdlf-${pTeamName}-*
+                      - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:policy/sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - iam:DeleteRole
@@ -299,16 +299,16 @@ Resources:
                   - iam:UpdateRoleDescription
                   - iam:TagRole
                 Resource:
-                  - !Sub arn:aws:iam::${AWS::AccountId}:role/sdlf-${pTeamName}-*
-                  - !Sub arn:aws:iam::${AWS::AccountId}:role/state-machine/sdlf-${pTeamName}-*
-                  - !Sub arn:aws:iam::${AWS::AccountId}:role/service-role/sdlf-${pTeamName}-*
-                  - !Sub arn:aws:iam::${AWS::AccountId}:role/glue/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/state-machine/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/service-role/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/glue/sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - iam:ListPolicies
                   - iam:ListPolicyVersions
                 Resource:
-                  - !Sub arn:aws:iam::${AWS::AccountId}:policy/*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:policy/*
               - Effect: Allow
                 Action:
                   - iam:CreatePolicy
@@ -318,8 +318,8 @@ Resources:
                   - iam:GetPolicy
                   - iam:GetPolicyVersion
                 Resource:
-                  - !Sub arn:aws:iam::${AWS::AccountId}:policy/sdlf-${pTeamName}-*
-                  - !Sub arn:aws:iam::${AWS::AccountId}:policy/state-machine/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:policy/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:policy/state-machine/sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - codecommit:CancelUploadArchive
@@ -328,7 +328,7 @@ Resources:
                   - codecommit:GetUploadArchiveStatus
                   - codecommit:UploadArchive
                 Resource:
-                  - !Sub arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - events:DeleteRule
@@ -336,7 +336,7 @@ Resources:
                   - events:PutRule
                   - events:PutTargets
                   - events:RemoveTargets
-                Resource: !Sub arn:aws:events:${AWS::Region}:${AWS::AccountId}:rule/sdlf-${pTeamName}-*
+                Resource: !Sub arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:rule/sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - lambda:GetLayerVersion
@@ -362,11 +362,11 @@ Resources:
                   - lambda:UpdateFunctionCode
                   - lambda:UpdateFunctionConfiguration
                   - lambda:UpdateFunctionConfiguration
-                Resource: !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:sdlf-${pTeamName}-*
+                Resource: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - lambda:InvokeFunction
-                Resource: !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:sdlf-foundations-rKibana*
+                Resource: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:sdlf-foundations-rKibana*
               - Effect: Allow
                 Action:
                   - lambda:CreateEventSourceMapping
@@ -385,14 +385,14 @@ Resources:
                   - cloudformation:ExecuteChangeSet
                   - cloudformation:SetStackPolicy
                   - cloudformation:UpdateStack
-                Resource: !Sub arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/sdlf-${pTeamName}-*
+                Resource: !Sub arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - cloudformation:CreateChangeSet
                   - cloudformation:DeleteChangeSet
                   - cloudformation:DescribeChangeSet
                   - cloudformation:ExecuteChangeSet
-                Resource: !Sub arn:aws:cloudformation:${AWS::Region}:aws:transform/*
+                Resource: !Sub arn:${AWS::Partition}:cloudformation:${AWS::Region}:aws:transform/*
               - Effect: Allow
                 Action:
                   - cloudformation:ValidateTemplate
@@ -403,7 +403,7 @@ Resources:
                   - codebuild:CreateProject
                   - codebuild:StartBuild
                   - codebuild:UpdateProject
-                Resource: !Sub arn:aws:codebuild:${AWS::Region}:${AWS::AccountId}:project/sdlf-${pTeamName}-*
+                Resource: !Sub arn:${AWS::Partition}:codebuild:${AWS::Region}:${AWS::AccountId}:project/sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - states:CreateActivity
@@ -411,25 +411,25 @@ Resources:
                   - states:ListActivities
                   - states:ListStateMachines
                   - states:TagResource
-                Resource: !Sub arn:aws:states:${AWS::Region}:${AWS::AccountId}:*
+                Resource: !Sub arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:*
               - Effect: Allow
                 Action:
                   - states:DeleteStateMachine
                   - states:DescribeStateMachine
                   - states:DescribeStateMachineForExecution
                   - states:UpdateStateMachine
-                Resource: !Sub arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:sdlf-${pTeamName}-*
+                Resource: !Sub arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:stateMachine:sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - states:DescribeActivity
                   - states:DeleteActivity
                   - states:GetActivityTask
-                Resource: !Sub arn:aws:states:${AWS::Region}:${AWS::AccountId}:activity:sdlf-${pTeamName}-*
+                Resource: !Sub arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:activity:sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - logs:CreateLogGroup
                   - logs:DescribeLogGroups
-                Resource: !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*
+                Resource: !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:*
               - Effect: Allow
                 Action:
                   - logs:CreateLogStream
@@ -440,8 +440,8 @@ Resources:
                   - logs:PutRetentionPolicy
                   - logs:TagLogGroup
                 Resource:
-                  - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/sdlf-${pTeamName}-*:log-stream:*
-                  - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/sdlf-${pTeamName}-*:log-stream:*
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/sdlf-${pTeamName}-*:log-stream:*
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/sdlf-${pTeamName}-*:log-stream:*
               - Effect: Allow
                 Action:
                   - cloudwatch:DeleteAlarms
@@ -450,11 +450,11 @@ Resources:
                   - cloudwatch:PutMetricData
                   - cloudwatch:SetAlarmState
                 Resource:
-                  - !Sub arn:aws:cloudwatch:${AWS::Region}:${AWS::AccountId}:alarm:sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:cloudwatch:${AWS::Region}:${AWS::AccountId}:alarm:sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - sqs:ListQueues
-                Resource: !Sub arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:*
+                Resource: !Sub arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:*
               - Effect: Allow
                 Action:
                   - sqs:AddPermission
@@ -465,7 +465,7 @@ Resources:
                   - sqs:GetQueueAttributes
                   - sqs:SetQueueAttributes
                   - sqs:TagQueue
-                Resource: !Sub arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
+                Resource: !Sub arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - s3:CreateBucket
@@ -484,10 +484,10 @@ Resources:
                   - s3:PutObject
                   - s3:SetBucketEncryption
                 Resource:
-                  - !Sub arn:aws:s3:::${pCFNBucket}
-                  - !Sub arn:aws:s3:::${pCFNBucket}/*
-                  - !Sub arn:aws:s3:::${pPipelineBucket}
-                  - !Sub arn:aws:s3:::${pPipelineBucket}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pCFNBucket}
+                  - !Sub arn:${AWS::Partition}:s3:::${pCFNBucket}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pPipelineBucket}
+                  - !Sub arn:${AWS::Partition}:s3:::${pPipelineBucket}/*
               - Effect: Allow
                 Action:
                   - ssm:AddTagsToResource
@@ -499,12 +499,12 @@ Resources:
                   - ssm:GetParametersByPath
                   - ssm:ListTagsForResource
                   - ssm:RemoveTagsFromResource
-                Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/*
+                Resource: !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/*
               - Effect: Allow
                 Action:
                   - ssm:DeleteParameter
                   - ssm:PutParameter
-                Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/*/${pTeamName}/*
+                Resource: !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/*/${pTeamName}/*
               - Effect: Allow
                 Action:
                   - kms:CreateGrant
@@ -517,7 +517,7 @@ Resources:
                   - !Ref pKMSInfraKeyId
               - Effect: Allow
                 Action: sts:AssumeRole
-                Resource: !Sub arn:aws:iam::${pSharedDevOpsAccountId}:role/sdlf-cicd-team-codecommit-${pEnvironment}-${pTeamName}
+                Resource: !Sub arn:${AWS::Partition}:iam::${pSharedDevOpsAccountId}:role/sdlf-cicd-team-codecommit-${pEnvironment}-${pTeamName}
 
   rCloudWatchRepositoryTriggerRole:
     Type: AWS::IAM::Role
@@ -541,10 +541,10 @@ Resources:
                 Action:
                   - codebuild:BatchGetBuilds
                   - codebuild:StartBuild
-                Resource: !Sub arn:aws:codebuild:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
+                Resource: !Sub arn:${AWS::Partition}:codebuild:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
               - Effect: Allow
                 Action: codepipeline:StartPipelineExecution
-                Resource: !Sub arn:aws:codepipeline:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
+                Resource: !Sub arn:${AWS::Partition}:codepipeline:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
 
   rTransformValidateRole:
     Type: AWS::IAM::Role
@@ -580,13 +580,13 @@ Resources:
                   - codecommit:List*
                   - codecommit:UploadArchive
                 Resource:
-                  - !Sub arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - logs:CreateLogGroup
                   - logs:CreateLogStream
                   - logs:PutLogEvents
-                Resource: !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/sdlf-${pTeamName}*
+                Resource: !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/sdlf-${pTeamName}*
               - Effect: Allow
                 Action:
                   - s3:GetBucketAcl
@@ -595,8 +595,8 @@ Resources:
                   - s3:GetObjectVersion
                   - s3:PutObject
                 Resource:
-                  - !Sub arn:aws:s3:::${pPipelineBucket}/*
-                  - !Sub arn:aws:s3:::${pCFNBucket}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pPipelineBucket}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pCFNBucket}/*
               - Effect: Allow
                 Action:
                   - lambda:List*
@@ -604,7 +604,7 @@ Resources:
               - Effect: Allow
                 Action:
                   - lambda:GetLayer*
-                Resource: !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:layer:sdlf-${pTeamName}-*
+                Resource: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:layer:sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - kms:CreateGrant
@@ -635,15 +635,15 @@ Resources:
             Statement:
               - Effect: Allow
                 Action: sts:AssumeRole
-                Resource: !Sub arn:aws:iam::${pSharedDevOpsAccountId}:role/sdlf-cicd-team-codecommit-${pEnvironment}-${pTeamName}
+                Resource: !Sub arn:${AWS::Partition}:iam::${pSharedDevOpsAccountId}:role/sdlf-cicd-team-codecommit-${pEnvironment}-${pTeamName}
               - Effect: Allow
                 Action:
                   - iam:PassRole
                   - iam:UpdateAssumeRolePolicy
                 Resource:
-                  - !Sub arn:aws:iam::${AWS::AccountId}:role/sdlf-${pTeamName}-*
-                  - !Sub arn:aws:iam::${AWS::AccountId}:role/service-role/sdlf-${pTeamName}-*
-                  - !Sub arn:aws:iam::${pSharedDevOpsAccountId}:role/sdlf-cicd-team-codecommit-${pEnvironment}-${pTeamName}
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/service-role/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:iam::${pSharedDevOpsAccountId}:role/sdlf-cicd-team-codecommit-${pEnvironment}-${pTeamName}
               - Effect: Allow
                 Action:
                   - cloudformation:CreateChangeSet
@@ -655,14 +655,14 @@ Resources:
                   - cloudformation:ExecuteChangeSet
                   - cloudformation:SetStackPolicy
                   - cloudformation:UpdateStack
-                Resource: !Sub arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/sdlf-${pTeamName}-*
+                Resource: !Sub arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - cloudformation:CreateChangeSet
                   - cloudformation:DeleteChangeSet
                   - cloudformation:DescribeChangeSet
                   - cloudformation:ExecuteChangeSet
-                Resource: !Sub arn:aws:cloudformation:${AWS::Region}:aws:transform/*
+                Resource: !Sub arn:${AWS::Partition}:cloudformation:${AWS::Region}:aws:transform/*
               - Effect: Allow
                 Action:
                   - ssm:AddTagsToResource
@@ -674,13 +674,13 @@ Resources:
                   - ssm:GetParametersByPath
                   - ssm:ListTagsForResource
                   - ssm:RemoveTagsFromResource
-                Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/*
+                Resource: !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/*
               - Effect: Allow
                 Action:
                   - ssm:DeleteParameter
                   - ssm:DeleteParameters
                   - ssm:PutParameter
-                Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/*/${pTeamName}/*
+                Resource: !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/*/${pTeamName}/*
               - Effect: Allow
                 Action:
                   - dynamodb:DeleteItem
@@ -690,8 +690,8 @@ Resources:
                   - dynamodb:Scan
                   - dynamodb:UpdateItem
                 Resource:
-                  - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/octagon-Pipelines-${pEnvironment}
-                  - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/octagon-Datasets-${pEnvironment}
+                  - !Sub arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/octagon-Pipelines-${pEnvironment}
+                  - !Sub arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/octagon-Datasets-${pEnvironment}
               - Effect: Allow
                 Action:
                   - events:DeleteRule
@@ -701,7 +701,7 @@ Resources:
                   - events:PutRule
                   - events:PutTargets
                   - events:RemoveTargets
-                Resource: !Sub arn:aws:events:${AWS::Region}:${AWS::AccountId}:rule/sdlf-${pTeamName}-*
+                Resource: !Sub arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:rule/sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - codepipeline:CreatePipeline
@@ -709,7 +709,7 @@ Resources:
                   - codepipeline:GetPipelineState
                   - codepipeline:GetPipeline
                   - codepipeline:UpdatePipeline
-                Resource: !Sub arn:aws:codepipeline:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
+                Resource: !Sub arn:${AWS::Partition}:codepipeline:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - codebuild:BatchGetProjects
@@ -717,16 +717,16 @@ Resources:
                   - codebuild:CreateProject
                   - codebuild:DeleteProject
                   - codebuild:UpdateProject
-                Resource: !Sub arn:aws:codebuild:${AWS::Region}:${AWS::AccountId}:project/sdlf-${pTeamName}-*
+                Resource: !Sub arn:${AWS::Partition}:codebuild:${AWS::Region}:${AWS::AccountId}:project/sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - s3:ListBucket
-                Resource: !Sub arn:aws:s3:::${pCFNBucket}
+                Resource: !Sub arn:${AWS::Partition}:s3:::${pCFNBucket}
               - Effect: Allow
                 Action:
                   - s3:GetObject
                   - s3:PutObject
-                Resource: !Sub arn:aws:s3:::${pCFNBucket}/*
+                Resource: !Sub arn:${AWS::Partition}:s3:::${pCFNBucket}/*
               - Effect: Allow
                 Action:
                   - kms:CreateGrant
@@ -743,7 +743,7 @@ Resources:
                   - logs:CreateLogStream
                   - logs:PutLogEvents
                 Resource:
-                  - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - lakeformation:GetDataAccess
@@ -767,7 +767,7 @@ Resources:
                   - sqs:SetQueueAttributes
                   - sqs:TagQueue
                   - sqs:UntagQueue
-                Resource: !Sub arn:aws:sqs:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
+                Resource: !Sub arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - glue:TagResource
@@ -780,7 +780,7 @@ Resources:
                   - glue:GetCrawler
                   - glue:GetCrawlers
                   - glue:UpdateCrawler
-                Resource: !Sub arn:aws:glue:${AWS::Region}:${AWS::AccountId}:crawler/sdlf-${pTeamName}-*
+                Resource: !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:crawler/sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - glue:CreateDatabase
@@ -789,13 +789,13 @@ Resources:
                   - glue:GetDatabases
                   - glue:UpdateDatabase
                 Resource:
-                  - !Sub arn:aws:glue:${AWS::Region}:${AWS::AccountId}:catalog
-                  - !Sub arn:aws:glue:${AWS::Region}:${AWS::AccountId}:database/${pOrganizationName}_${pApplicationName}_${pEnvironment}_${pTeamName}_*
+                  - !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:catalog
+                  - !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:database/${pOrganizationName}_${pApplicationName}_${pEnvironment}_${pTeamName}_*
               - Effect: Allow
                 Action:
                   - lambda:AddPermission
                   - lambda:RemovePermission
-                Resource: !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:sdlf-${pTeamName}*
+                Resource: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:sdlf-${pTeamName}*
 
   rCodeBuildServiceRole:
     Type: AWS::IAM::Role
@@ -820,7 +820,7 @@ Resources:
                   - logs:CreateLogStream
                   - logs:PutLogEvents
                 Resource:
-                  - !Sub arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - s3:GetBucketAcl
@@ -829,12 +829,12 @@ Resources:
                   - s3:GetObjectVersion
                   - s3:PutObject
                 Resource:
-                  - !Sub arn:aws:s3:::${pPipelineBucket}/*
-                  - !Sub arn:aws:s3:::${pCFNBucket}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pPipelineBucket}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pCFNBucket}/*
               - Effect: Allow
                 Action: codecommit:GitPull
                 Resource:
-                  - !Sub arn:aws:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
+                  - !Sub arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - kms:CreateGrant
@@ -872,7 +872,7 @@ Resources:
               - Effect: Allow
                 Action:
                   - lambda:InvokeFunction
-                Resource: !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:sdlf-${pTeamName}-*
+                Resource: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - states:DescribeStateMachine
@@ -889,7 +889,7 @@ Resources:
                   - events:DescribeRule
                   - events:PutRule
                   - events:PutTargets
-                Resource: !Sub arn:aws:events:${AWS::Region}:${AWS::AccountId}:rule/StepFunctionsGetEventsForStepFunctionsExecutionRule
+                Resource: !Sub arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:rule/StepFunctionsGetEventsForStepFunctionsExecutionRule
               - Effect: Allow
                 Action:
                   - elasticmapreduce:DescribeCluster
@@ -906,17 +906,17 @@ Resources:
                   - elasticmapreduce:ModifyInstanceFleet
                   - elasticmapreduce:ModifyInstanceGroups
                   - elasticmapreduce:SetTerminationProtection
-                Resource: !Sub arn:aws:elasticmapreduce:${AWS::Region}:${AWS::AccountId}:cluster/*
+                Resource: !Sub arn:${AWS::Partition}:elasticmapreduce:${AWS::Region}:${AWS::AccountId}:cluster/*
               - Effect: Allow
                 Action:
                   - iam:PassRole
-                Resource: !Sub arn:aws:iam::${AWS::AccountId}:role/EMR*
+                Resource: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/EMR*
               - Effect: Allow
                 Action:
                   - iam:CreateServiceLinkedRole
                   - iam:PutRolePolicy
                   - iam:UpdateRoleDescription
-                Resource: !Sub arn:aws:iam::${AWS::AccountId}:role/aws-service-role/elasticmapreduce.amazonaws.com/AWSServiceRoleForEMRCleanup*
+                Resource: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/aws-service-role/elasticmapreduce.amazonaws.com/AWSServiceRoleForEMRCleanup*
                 Condition:
                   StringLike:
                     iam:AWSServiceName: elasticmapreduce.amazonaws.com
@@ -953,7 +953,7 @@ Resources:
               - Effect: Allow
                 Action:
                   - lambda:InvokeFunction
-                Resource: !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:function:sdlf-${pTeamName}-*
+                Resource: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:sdlf-${pTeamName}-*
         - PolicyName: !Sub sdlf-${pTeamName}-describe-state-machines
           PolicyDocument:
             Version: 2012-10-17
@@ -961,7 +961,7 @@ Resources:
               - Effect: Allow
                 Action:
                   - states:ListStateMachines
-                Resource: !Sub arn:aws:states:${AWS::Region}:${AWS::AccountId}:*
+                Resource: !Sub arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:*
         - PolicyName: !Sub sdlf-${pTeamName}-dataset-state-machine
           PolicyDocument:
             Version: 2012-10-17
@@ -971,7 +971,7 @@ Resources:
                   - states:DescribeStateMachineForExecution
                   - states:DescribeStateMachine
                   - states:StartExecution
-                Resource: !Sub arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:sdlf-${pTeamName}-*
+                Resource: !Sub arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:stateMachine:sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - s3:ListBucket
@@ -979,10 +979,10 @@ Resources:
                   - s3:GetObjectVersion
                   - s3:GetBucketVersioning
                 Resource:
-                  - !Sub arn:aws:s3:::${pPipelineBucket}
-                  - !Sub arn:aws:s3:::${pCentralBucket}
-                  - !Sub arn:aws:s3:::${pStageBucket}
-                  - !Sub arn:aws:s3:::${pAnalyticsBucket}
+                  - !Sub arn:${AWS::Partition}:s3:::${pPipelineBucket}
+                  - !Sub arn:${AWS::Partition}:s3:::${pCentralBucket}
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}
+                  - !Sub arn:${AWS::Partition}:s3:::${pAnalyticsBucket}
 
   rCodeBuildPublishLayerRole:
     Type: AWS::IAM::Role
@@ -1003,14 +1003,14 @@ Resources:
             Statement:
               - Effect: Allow
                 Action: lambda:PublishLayerVersion
-                Resource: !Sub arn:aws:lambda:${AWS::Region}:${AWS::AccountId}:layer:sdlf-${pTeamName}-*
+                Resource: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:layer:sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - dynamodb:Get*
                   - dynamodb:Update*
                   - dynamodb:Put*
                 Resource:
-                  - !Sub arn:aws:dynamodb:${AWS::Region}:${AWS::AccountId}:table/octagon-*
+                  - !Sub arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/octagon-*
               - Effect: Allow
                 Action:
                   - ssm:AddTagsToResource
@@ -1022,12 +1022,12 @@ Resources:
                   - ssm:GetParametersByPath
                   - ssm:ListTagsForResource
                   - ssm:RemoveTagsFromResource
-                Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/*
+                Resource: !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/*
               - Effect: Allow
                 Action:
                   - ssm:PutParameter
                   - ssm:DeleteParameter
-                Resource: !Sub arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/*/${pTeamName}/*
+                Resource: !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/*/${pTeamName}/*
               - Effect: Allow
                 Action:
                   - s3:GetBucketAcl
@@ -1038,10 +1038,10 @@ Resources:
                   - s3:ListBucket
                   - s3:PutObject
                 Resource:
-                  - !Sub arn:aws:s3:::${pPipelineBucket}
-                  - !Sub arn:aws:s3:::${pPipelineBucket}/*
-                  - !Sub arn:aws:s3:::${pCFNBucket}
-                  - !Sub arn:aws:s3:::${pCFNBucket}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pPipelineBucket}
+                  - !Sub arn:${AWS::Partition}:s3:::${pPipelineBucket}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pCFNBucket}
+                  - !Sub arn:${AWS::Partition}:s3:::${pCFNBucket}/*
 
   rDatalakeCrawlerRole:
     Type: AWS::IAM::Role
@@ -1058,7 +1058,7 @@ Resources:
             Action:
               - sts:AssumeRole
       ManagedPolicyArns:
-        - arn:aws:iam::aws:policy/service-role/AWSGlueServiceRole
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSGlueServiceRole
       Policies:
         - PolicyName: !Sub sdlf-${pTeamName}-glue-crawler
           PolicyDocument:
@@ -1073,21 +1073,21 @@ Resources:
               - Effect: Allow
                 Action:
                   - s3:CreateBucket
-                Resource: arn:aws:s3:::aws-glue-*
+                Resource: !Sub arn:${AWS::Partition}:s3:::aws-glue-*
               - Effect: Allow
                 Action:
                   - s3:DeleteObject
                   - s3:GetObject
                   - s3:PutObject
                 Resource:
-                  - arn:aws:s3:::aws-glue-*/*
-                  - arn:aws:s3:::*/*aws-glue-*/*
+                  - !Sub arn:${AWS::Partition}:s3:::aws-glue-*/*
+                  - !Sub arn:${AWS::Partition}:s3:::*/*aws-glue-*/*
               - Effect: Allow
                 Action:
                   - s3:GetObject
                 Resource:
-                  - arn:aws:s3:::crawler-public*
-                  - arn:aws:s3:::aws-glue-*
+                  - !Sub arn:${AWS::Partition}:s3:::crawler-public*
+                  - !Sub arn:${AWS::Partition}:s3:::aws-glue-*
               - Effect: Allow
                 Action:
                   - s3:ListObjectsV2
@@ -1099,14 +1099,14 @@ Resources:
                   - s3:PutObject
                   - s3:PutObjectVersion
                 Resource:
-                  - !Sub arn:aws:s3:::${pCentralBucket}/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pCentralBucket}/raw/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pStageBucket}/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pStageBucket}/stage/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pStageBucket}/pre-stage/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pStageBucket}/post-stage/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pAnalyticsBucket}/${pTeamName}/*
-                  - !Sub arn:aws:s3:::${pAnalyticsBucket}/analytics/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pCentralBucket}/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pCentralBucket}/raw/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/pre-stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/post-stage/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pAnalyticsBucket}/${pTeamName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pAnalyticsBucket}/analytics/${pTeamName}/*
               - Effect: Allow
                 Action:
                   - kms:DescribeKey


### PR DESCRIPTION
*Issue #, if available:*
#90 

*Description of changes:*
The change mostly consists in replacing `arn:aws` with `arn:${AWS::Partition}` everywhere. It needed a bit more care than this as sometimes `!Sub` wasn't used as there was no need - need now present due to the use of `${AWS::Partition}`.

There also seems to be no way of getting the partition from the cli in a direct way - it's easy enough to get from the profile ARN but I would be glad to be proved wrong here.

The AWS partition used still needs to support all services SDLF requires. An an example the default SDLF installation has been tested successfully on AWS GovCloud `us-gov-west-1`. However it would not work on `us-gov-east-1` as CodePipeline [is not available in that region](https://aws.amazon.com/about-aws/global-infrastructure/regional-product-services/).

All ingestion/pipelines/changes examples from [sdlf-utils](https://github.com/awslabs/aws-serverless-data-lake-framework/blob/master/sdlf-utils/README.md) have been carefully updated too but not all of them were tested. If there is any issue, please let us know.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
