### PR TITLE
add emr tagging permissions

### DIFF
--- a/sdlf-team/nested-stacks/template-iam.yaml
+++ b/sdlf-team/nested-stacks/template-iam.yaml
@@ -861,6 +861,7 @@ Resources:
                 Action:
                   - elasticmapreduce:DescribeCluster
                   - elasticmapreduce:RunJobFlow
+                  - elasticmapreduce:AddTags
                   - elasticmapreduce:TerminateJobFlows
                 Resource: "*"
               - Effect: Allow

--- a/sdlf-utils/ingestion-examples/sqoop/sdlf-team/nested-stacks/template-iam.yaml
+++ b/sdlf-utils/ingestion-examples/sqoop/sdlf-team/nested-stacks/template-iam.yaml
@@ -1030,6 +1030,7 @@ Resources:
                 Action:
                   - elasticmapreduce:DescribeCluster
                   - elasticmapreduce:RunJobFlow
+                  - elasticmapreduce:AddTags
                   - elasticmapreduce:TerminateJobFlows
                 Resource: "*"
               - Effect: Allow

--- a/sdlf-utils/pipeline-examples/event-dataset-dependencies/sdlf-team/nested-stacks/template-iam.yaml
+++ b/sdlf-utils/pipeline-examples/event-dataset-dependencies/sdlf-team/nested-stacks/template-iam.yaml
@@ -1031,6 +1031,7 @@ Resources:
                 Action:
                   - elasticmapreduce:DescribeCluster
                   - elasticmapreduce:RunJobFlow
+                  - elasticmapreduce:AddTags
                   - elasticmapreduce:TerminateJobFlows
                 Resource: "*"
               - Effect: Allow

--- a/sdlf-utils/pipeline-examples/topic-modelling/template-iam.yaml
+++ b/sdlf-utils/pipeline-examples/topic-modelling/template-iam.yaml
@@ -894,6 +894,7 @@ Resources:
                 Action:
                   - elasticmapreduce:DescribeCluster
                   - elasticmapreduce:RunJobFlow
+                  - elasticmapreduce:AddTags
                   - elasticmapreduce:TerminateJobFlows
                 Resource: "*"
               - Effect: Allow


### PR DESCRIPTION
> Amazon Elastic Map Reduce (EMR) will soon require permission for the “elasticmapreduce:AddTags” IAM action, which supports tagging when creating an Amazon EMR cluster. Beginning April 24, 2023, this permission will be required in addition to permission for the “elasticmapreduce:RunJobFlow” IAM action, in order to create a cluster with tags.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
