### PR TITLE
rework sdlf-cicd rCodeBuildRole IAM role to avoid using wildcards

### DIFF
--- a/sdlf-cicd/template-cicd-child-foundations.yaml
+++ b/sdlf-cicd/template-cicd-child-foundations.yaml
@@ -7,6 +7,10 @@ Parameters:
     Type: String
     AllowedValues: ["false", "true"]
     Default: "false"
+  pCustomBucketPrefix:
+    Description: S3 Bucket Prefix if different from default. Must be a valid S3 Bucket name
+    Type: String
+    Default: sdlf
   pEnvironment:
     Description: Environment name
     Type: String
@@ -95,8 +99,131 @@ Resources:
                 aws:SecureTransport: False
 
   ######## IAM #########
+  rCfnCodeBuildRolePolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W13
+            reason: The actions with "*" are all ones that do not have resource limitations associated with them
+    Properties:
+      Description: Managed policy for sdlf-cicd-codebuild
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action:
+              - cloudformation:ListStacks # W13 exception
+              - cloudformation:ValidateTemplate # W13 exception
+              - iam:ListPolicies # W13 exception
+              - iam:ListRoles # W13 exception
+              - lambda:ListFunctions # W13 exception
+              - states:ListStateMachines # W13 exception
+              - glue:CreateCrawler # W13 exception
+              - glue:CreateSecurityConfiguration # W13 exception
+              - glue:DeleteSecurityConfiguration # W13 exception
+              - elasticmapreduce:CreateSecurityConfiguration # W13 exception
+              - elasticmapreduce:DeleteSecurityConfiguration # W13 exception
+              - elasticmapreduce:DescribeSecurityConfiguration # W13 exception
+              - elasticmapreduce:ListSecurityConfigurations # W13 exception
+              - lakeformation:DeregisterResource # W13 exception
+              - lakeformation:GetDataAccess # W13 exception
+              - lakeformation:GrantPermissions # W13 exception
+              - lakeformation:PutDataLakeSettings # W13 exception
+              - lakeformation:RegisterResource # W13 exception
+              - lakeformation:RevokePermissions # W13 exception
+              - lakeformation:UpdateResource # W13 exception
+              - sns:ListTopics # W13 exception
+              - sqs:ListQueues # W13 exception
+              - kms:CreateKey # W13 exception
+              - kms:ListAliases # W13 exception
+              - kms:ListKeys # W13 exception
+            Resource: "*"
+
+  rCfnOptionalCodeBuildRolePolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W13
+            reason: The actions with "*" are all ones that do not have resource limitations associated with them
+    Properties:
+      Description: Managed policy for sdlf-cicd-codebuild
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action:
+              - cloudtrail:DescribeTrails # W13 exception
+            Resource: "*"
+          - Effect: Allow
+            Action:
+              - cloudtrail:AddTags
+              - cloudtrail:CreateTrail
+              - cloudtrail:DeleteTrail
+              - cloudtrail:ListTags
+              - cloudtrail:PutEventSelectors
+              - cloudtrail:RemoveTags
+              - cloudtrail:StartLogging
+              - cloudtrail:StopLogging
+              - cloudtrail:UpdateTrail
+            Resource: !Sub arn:${AWS::Partition}:cloudtrail:${AWS::Region}:${AWS::AccountId}:trail/sdlf-*
+          - Effect: Allow
+            Action:
+              - s3:Get*
+            Resource: !Sub arn:${AWS::Partition}:s3:::solutions-${AWS::Region}/centralized-logging/*
+          - Effect: Allow
+            Action:
+              - es:ListDomainNames # W13 exception
+            Resource: "*"
+          - Effect: Allow
+            Action:
+              - es:CreateElasticsearchDomain
+              - es:DescribeElasticsearchDomain
+              - es:DeleteElasticsearchDomain
+              - es:UpdateElasticsearchDomainConfig
+              - es:AddTags
+              - es:ListTags
+              - es:RemoveTags
+            Resource: !Sub arn:${AWS::Partition}:es:${AWS::Region}:${AWS::AccountId}:domain/sdlf
+          - Effect: Allow
+            Action:
+              - cognito-identity:CreateIdentityPool # W13 exception
+              - cognito-identity:SetIdentityPoolRoles # W13 exception
+              - cognito-idp:CreateUserPool # W13 exception
+            Resource: "*"
+          - Effect: Allow
+            Action:
+              - cognito-identity:DeleteIdentityPool
+              - cognito-identity:DescribeIdentityPool
+              - cognito-identity:GetIdentityPoolRoles
+              - cognito-identity:UpdateIdentityPool
+            Resource:
+              - !Sub arn:${AWS::Partition}:cognito-identity:${AWS::Region}:${AWS::AccountId}:identitypool/${AWS::Region}_*
+              - !Sub arn:${AWS::Partition}:cognito-identity:${AWS::Region}:${AWS::AccountId}:identitypool/${AWS::Region}:*
+          - Effect: Allow
+            Action:
+              - cognito-idp:AdminCreateUser
+              - cognito-idp:AdminDeleteUser
+              - cognito-idp:CreateGroup
+              - cognito-idp:CreateResourceServer
+              - cognito-idp:CreateUserPoolClient
+              - cognito-idp:CreateUserPoolDomain
+              - cognito-idp:DeleteGroup
+              - cognito-idp:DeleteUserPool
+              - cognito-idp:DeleteUserPoolClient
+              - cognito-idp:UpdateGroup
+              - cognito-idp:UpdateUserPool
+              - cognito-idp:UpdateUserPoolClient
+            Resource: !Sub arn:${AWS::Partition}:cognito-idp:${AWS::Region}:${AWS::AccountId}:userpool/${AWS::Region}_*
+
   rCodeBuildRole:
     Type: AWS::IAM::Role
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W11
+            reason: The actions with "*" are all ones that do not have resource limitations associated with them
     Properties:
       RoleName: sdlf-cicd-codebuild
       AssumeRolePolicyDocument:
@@ -106,18 +233,18 @@ Resources:
             Principal:
               Service: codebuild.amazonaws.com
             Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - !Ref rCfnCodeBuildRolePolicy
+        - !Ref rCfnOptionalCodeBuildRolePolicy
       Policies:
         - PolicyName: sdlf-cicd-codebuild
           PolicyDocument:
             Version: 2012-10-17
             Statement:
-              - Resource: !Sub arn:${AWS::Partition}:iam::${pSharedDevOpsAccountId}:role/sdlf-cicd-foundations-codecommit-${pEnvironment}
-                Effect: Allow
+              - Effect: Allow
                 Action: sts:AssumeRole
-              - Resource:
-                  - !Sub arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/sdlf-*
-                  - !Sub arn:${AWS::Partition}:cloudformation:${AWS::Region}:aws:transform/*
-                Effect: Allow
+                Resource: !Sub arn:${AWS::Partition}:iam::${pSharedDevOpsAccountId}:role/sdlf-cicd-foundations-codecommit-${pEnvironment}
+              - Effect: Allow
                 Action:
                   - cloudformation:CreateChangeSet
                   - cloudformation:CreateStack
@@ -128,15 +255,12 @@ Resources:
                   - cloudformation:ExecuteChangeSet
                   - cloudformation:SetStackPolicy
                   - cloudformation:UpdateStack
-              - Resource: "*"
-                Effect: Allow
-                Action:
                   - cloudformation:GetTemplate
                   - cloudformation:GetTemplateSummary
-                  - cloudformation:ListStacks
-                  - cloudformation:ValidateTemplate
-              - Resource: !Sub arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/octagon-*
-                Effect: Allow
+                Resource:
+                  - !Sub arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/sdlf-*
+                  - !Sub arn:${AWS::Partition}:cloudformation:${AWS::Region}:aws:transform/*
+              - Effect: Allow
                 Action:
                   - dynamodb:CreateTable
                   - dynamodb:DeleteTable
@@ -149,8 +273,8 @@ Resources:
                   - dynamodb:UpdateTimeToLive
                   - dynamodb:DescribeContinuousBackups
                   - dynamodb:UpdateContinuousBackups
-              - Resource: !Sub arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:rule/sdlf-*
-                Effect: Allow
+                Resource: !Sub arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/octagon-*
+              - Effect: Allow
                 Action:
                   - events:DeleteRule
                   - events:DescribeRule
@@ -159,49 +283,53 @@ Resources:
                   - events:PutRule
                   - events:PutTargets
                   - events:RemoveTargets
-              - Resource: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/*
-                Effect: Allow
+                Resource: !Sub arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:rule/sdlf-*
+              - Effect: Allow
                 Action: iam:PassRole
+                Resource:
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/sdlf-*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/state-machine/sdlf-*
                 Condition:
                   StringEqualsIfExists:
                     iam:PassedToService:
                       - cloudformation.amazonaws.com
+                      - cloudtrail.amazonaws.com
                       - codebuild.amazonaws.com
                       - codepipeline.amazonaws.com
+                      - events.amazonaws.com
+                      - glue.amazonaws.com
                       - lambda.amazonaws.com
-              - Resource: "*"
-                Effect: Allow
+                      - states.amazonaws.com
+              - Effect: Allow
                 Action:
                   - iam:GetRole
                   - iam:GetRolePolicy
-                  - iam:ListPolicies
                   - iam:ListPolicyVersions
-                  - iam:ListRoles
                   - iam:ListRolePolicies
-              - Resource: !Sub arn:${AWS::Partition}:iam::${pSharedDevOpsAccountId}:role/sdlf-cicd-team-codecommit-${pEnvironment}-*
-                Effect: Allow
-                Action: iam:PassRole
-              - Resource:
-                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/sdlf-*
-                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/aws-service-role/*
-                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/service-role/*
-                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/state-machine/sdlf-*
-                Effect: Allow
-                Action:
                   - iam:AttachRolePolicy
                   - iam:CreateRole
                   - iam:CreateServiceLinkedRole
                   - iam:DeleteRole
                   - iam:DeleteRolePolicy
                   - iam:DetachRolePolicy
-                  - iam:PassRole
                   - iam:PutRolePolicy
                   - iam:TagRole
                   - iam:UntagRole
                   - iam:UpdateRole
                   - iam:UpdateRoleDescription
-              - Resource: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:policy/sdlf-*
-                Effect: Allow
+                Resource:
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/sdlf-*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/state-machine/sdlf-*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/service-role/sdlf-*
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/aws-service-role/lakeformation.amazonaws.com/AWSServiceRoleForLakeFormationDataAccess
+              - Effect: Allow
+                Action:
+                  - iam:ListPolicyVersions
+                Resource: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:policy/sdlf-*
+              - Effect: Allow
+                Action: iam:PassRole
+                Resource: !Sub arn:${AWS::Partition}:iam::${pSharedDevOpsAccountId}:role/sdlf-cicd-team-codecommit-${pEnvironment}-*
+              - Effect: Allow
                 Action:
                   - iam:CreatePolicy
                   - iam:CreatePolicyVersion
@@ -209,11 +337,8 @@ Resources:
                   - iam:DeletePolicyVersion
                   - iam:GetPolicy
                   - iam:GetPolicyVersion
-              - Resource: "*"
-                Effect: "Allow"
-                Action: lambda:ListFunctions
-              - Resource: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:sdlf-*
-                Effect: Allow
+                Resource: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:policy/sdlf-*
+              - Effect: Allow
                 Action:
                   - lambda:AddPermission
                   - lambda:CreateAlias
@@ -238,36 +363,36 @@ Resources:
                   - lambda:UpdateAlias
                   - lambda:UpdateFunctionCode
                   - lambda:UpdateFunctionConfiguration
-              - Resource: "*"
-                Effect: "Allow"
+                Resource: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:sdlf-*
+              - Effect: "Allow"
                 Action:
-                  - lambda:CreateEventSourceMapping
-                  - lambda:GetEventSourceMapping
-                  - lambda:UpdateEventSourceMapping
-                  - lambda:DeleteEventSourceMapping
-              - Resource: "*"
-                Effect: Allow
+                  - lambda:CreateEventSourceMapping # can only be controlled through lambda:FunctionArn condition key
+                  - lambda:GetEventSourceMapping # can only be controlled through lambda:FunctionArn condition key
+                  - lambda:UpdateEventSourceMapping # can only be controlled through lambda:FunctionArn condition key
+                  - lambda:DeleteEventSourceMapping # can only be controlled through lambda:FunctionArn condition key
+                Resource: "*"
+                Condition:
+                  StringLikeIfExists:
+                    "lambda:FunctionArn": !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:sdlf-*
+              - Effect: Allow
                 Action:
                   - states:CreateStateMachine
-                  - states:ListStateMachines
                   - states:TagResource
                   - states:UntagResource
-              - Resource: !Sub "arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:stateMachine:sdlf-*"
-                Effect: Allow
-                Action:
                   - states:DeleteStateMachine
                   - states:DescribeStateMachine
                   - states:UpdateStateMachine
-              - Resource: "*"
-                Effect: "Allow"
+                Resource: !Sub arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:stateMachine:sdlf-*
+              - Effect: "Allow"
                 Action:
                   - logs:CreateLogGroup
                   - logs:DescribeLogGroups
-              - Resource:
-                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:sdlf-*:log-stream:*
-                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/sdlf-*:log-stream:*
-                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/sdlf-*:log-stream:*
-                Effect: Allow
+                Resource:
+                  - !Sub "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group::log-stream:"
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:sdlf-*
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/sdlf-*
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/sdlf-*
+              - Effect: Allow
                 Action:
                   - logs:PutRetentionPolicy
                   - logs:CreateLogStream
@@ -277,8 +402,11 @@ Resources:
                   - logs:PutLogEvents
                   - logs:TagLogGroup
                   - logs:UntagLogGroup
-              - Resource: !Sub arn:${AWS::Partition}:cloudwatch:${AWS::Region}:${AWS::AccountId}:alarm:sdlf-*
-                Effect: Allow
+                Resource:
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:sdlf-*:log-stream:*
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/sdlf-*:log-stream:*
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/sdlf-*:log-stream:*
+              - Effect: Allow
                 Action:
                   - cloudwatch:DeleteAlarms
                   - cloudwatch:DescribeAlarms
@@ -288,11 +416,8 @@ Resources:
                   - cloudwatch:PutMetricAlarm
                   - cloudwatch:PutMetricData
                   - cloudwatch:SetAlarmState
-              - Resource: !Sub arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:*
-                Effect: Allow
-                Action: sns:ListTopics
-              - Resource: !Sub arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:sdlf-*
-                Effect: Allow
+                Resource: !Sub arn:${AWS::Partition}:cloudwatch:${AWS::Region}:${AWS::AccountId}:alarm:sdlf-*
+              - Effect: Allow
                 Action:
                   - sns:CreateTopic
                   - sns:DeleteTopic
@@ -302,8 +427,8 @@ Resources:
                   - sns:Subscribe
                   - sns:Unsubscribe
                   - sns:TagResource
-              - Resource: "*"
-                Effect: Allow
+                Resource: !Sub arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:sdlf-*
+              - Effect: Allow
                 Action:
                   - s3:CreateBucket
                   - s3:DeleteBucket
@@ -312,27 +437,26 @@ Resources:
                   - s3:List*
                   - s3:Put*
                   - s3:SetBucketEncryption
-              - Resource: !Sub arn:${AWS::Partition}:codebuild:${AWS::Region}:${AWS::AccountId}:project/sdlf-*
-                Effect: Allow
+                Resource:
+                  - !Sub "arn:${AWS::Partition}:s3:::${pCustomBucketPrefix}*"
+                  - !Sub "arn:${AWS::Partition}:s3:::*-${pEnvironment}-${AWS::Region}-${AWS::AccountId}-*"
+              - Effect: Allow
                 Action:
                   - codebuild:BatchGetProjects
                   - codebuild:BatchGetBuilds
                   - codebuild:CreateProject
                   - codebuild:DeleteProject
                   - codebuild:UpdateProject
-              - Resource: !Sub arn:${AWS::Partition}:codepipeline:${AWS::Region}:${AWS::AccountId}:sdlf-*
-                Effect: Allow
+                Resource: !Sub arn:${AWS::Partition}:codebuild:${AWS::Region}:${AWS::AccountId}:project/sdlf-*
+              - Effect: Allow
                 Action:
                   - codepipeline:CreatePipeline
                   - codepipeline:DeletePipeline
                   - codepipeline:GetPipelineState
                   - codepipeline:GetPipeline
                   - codepipeline:UpdatePipeline
-              - Resource: !Sub arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:*
-                Effect: Allow
-                Action: sqs:ListQueues
-              - Resource: !Sub arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:sdlf-*
-                Effect: Allow
+                Resource: !Sub arn:${AWS::Partition}:codepipeline:${AWS::Region}:${AWS::AccountId}:sdlf-*
+              - Effect: Allow
                 Action:
                   - sqs:AddPermission
                   - sqs:CreateQueue
@@ -341,7 +465,6 @@ Resources:
                   - sqs:DeleteQueue
                   - sqs:GetQueueAttributes
                   - sqs:GetQueueUrl
-                  - sqs:ListQueues
                   - sqs:ListQueueTags
                   - sqs:RemovePermission
                   - sqs:SendMessage
@@ -349,8 +472,8 @@ Resources:
                   - sqs:SetQueueAttributes
                   - sqs:TagQueue
                   - sqs:UntagQueue
-              - Resource: !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/*
-                Effect: Allow
+                Resource: !Sub arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:sdlf-*
+              - Effect: Allow
                 Action:
                   - ssm:AddTagsToResource
                   - ssm:DeleteParameter
@@ -364,133 +487,77 @@ Resources:
                   - ssm:ListTagsForResource
                   - ssm:PutParameter
                   - ssm:RemoveTagsFromResource
-              - Resource: "*"
-                Effect: Allow
-                Action:
-                  - lakeformation:DeregisterResource
-                  - lakeformation:GetDataAccess
-                  - lakeformation:GrantPermissions
-                  - lakeformation:PutDataLakeSettings
-                  - lakeformation:RegisterResource
-                  - lakeformation:RevokePermissions
-                  - lakeformation:UpdateResource
-              - Resource: "*"
-                Effect: Allow
-                Action:
-                  - cloudtrail:DescribeTrails
-              - Resource: !Sub arn:${AWS::Partition}:cloudtrail:${AWS::Region}:${AWS::AccountId}:trail/sdlf-*
-                Effect: Allow
-                Action:
-                  - cloudtrail:AddTags
-                  - cloudtrail:CreateTrail
-                  - cloudtrail:DeleteTrail
-                  - cloudtrail:ListTags
-                  - cloudtrail:PutEventSelectors
-                  - cloudtrail:RemoveTags
-                  - cloudtrail:StartLogging
-                  - cloudtrail:StopLogging
-                  - cloudtrail:UpdateTrail
-              - Resource: "*"
-                Effect: Allow
+                Resource: !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/*
+              - Effect: Allow
                 Action:
                   - kms:CreateAlias
-                  - kms:CreateKey
                   - kms:DeleteAlias
-                  - kms:ListAliases
-                  - kms:ListGrants
-                  - kms:ListKeyPolicies
-                  - kms:ListKeys
-                  - kms:ListResourceTags
                   - kms:UpdateAlias
-              - Resource:
+                Resource:
+                 - !Sub arn:${AWS::Partition}:kms:${AWS::Region}:${AWS::AccountId}:alias/sdlf-*
+                 - !Sub arn:${AWS::Partition}:kms:${AWS::Region}:${AWS::AccountId}:key/*
+              - Effect: Allow
+                Action:
+                  - kms:TagResource
+                  - kms:UntagResource
+                  - kms:UpdateKeyDescription
+                Resource:
                   - !Sub arn:${AWS::Partition}:kms:${AWS::Region}:${AWS::AccountId}:key/*
                   - !Sub arn:${AWS::Partition}:kms:${AWS::Region}:${pSharedDevOpsAccountId}:key/*
-                Effect: Allow
+              - Effect: Allow
                 Action:
                   - kms:CreateGrant
                   - kms:Decrypt
                   - kms:DescribeKey
-                  - kms:DisableKey
-                  - kms:DisableKeyRotation
-                  - kms:EnableKey
-                  - kms:EnableKeyRotation
+                  - kms:DisableKey* # DisableKey, DisableKeyRotation
+                  - kms:EnableKey* # EnableKey, EnableKeyRotation
                   - kms:Encrypt
                   - kms:GenerateDataKey
                   - kms:GetKeyPolicy
                   - kms:PutKeyPolicy
-                  - kms:ReEncryptFrom
-                  - kms:ReEncryptTo
+                  - kms:ReEncrypt* # ReEncryptFrom, ReEncryptTo
                   - kms:RetireGrant
                   - kms:RevokeGrant
                   - kms:ScheduleKeyDeletion
-                  - kms:TagResource
-                  - kms:UntagResource
-                  - kms:UpdateKeyDescription
-              - Resource: "*"
-                Effect: Allow
+                  - kms:ListGrants
+                  - kms:ListKeyPolicies
+                  - kms:ListResourceTags
+                Resource:
+                  - !Sub arn:${AWS::Partition}:kms:${AWS::Region}:${AWS::AccountId}:key/*
+                  - !Sub arn:${AWS::Partition}:kms:${AWS::Region}:${pSharedDevOpsAccountId}:key/*
+              - Effect: Allow
                 Action:
-                  - elasticmapreduce:AddTags
-                  - elasticmapreduce:CreateSecurityConfiguration
-                  - elasticmapreduce:DeleteSecurityConfiguration
-                  - elasticmapreduce:DescribeSecurityConfiguration
-                  - elasticmapreduce:ListSecurityConfigurations
-                  - elasticmapreduce:RemoveTags
-              - Resource: "*"
-                Effect: Allow
-                Action:
-                  - glue:CreateCrawler
-                  - glue:CreateDatabase
-                  - glue:CreateJob
-                  - glue:CreateSecurityConfiguration
-                  - glue:DeleteCrawler
-                  - glue:DeleteDatabase
-                  - glue:DeleteJob
-                  - glue:DeleteSecurityConfiguration
-                  - glue:Get*
                   - glue:PutDataCatalogEncryptionSettings
+                  - glue:CreateDatabase
+                  - glue:UpdateDatabase
+                  - glue:DeleteDatabase
                   - glue:SearchTables
-                  - glue:StopCrawler
+                  - glue:GetDatabase
+                Resource:
+                  - !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:catalog
+                  - !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:database/sdlf-*
+                  - !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:table/sdlf-*/*
+                  - !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:userDefinedFunction/sdlf-*/*
+                  - !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:database/*_data_quality_db
+                  - !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:table/*_data_quality_db/*
+                  - !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:userDefinedFunction/*_data_quality_db/*
+              - Effect: Allow
+                Action:
+                  - glue:CreateJob
+                  - glue:UpdateJob
+                  - glue:DeleteJob
                   - glue:TagResource
                   - glue:UntagResource
+                Resource: !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:job/sdlf-*
+              - Effect: Allow
+                Action:
+                  - glue:GetCrawler
+                  - glue:DeleteCrawler
+                  - glue:StopCrawler
                   - glue:UpdateCrawler
-                  - glue:UpdateDatabase
-                  - glue:UpdateJob
-              - Resource: !Sub arn:${AWS::Partition}:es:${AWS::Region}:${AWS::AccountId}:domain/*
-                Effect: Allow
-                Action:
-                  - es:AddTags
-                  - es:ListDomainNames
-                  - es:ListTags
-                  - es:RemoveTags
-              - Resource: !Sub arn:${AWS::Partition}:es:${AWS::Region}:${AWS::AccountId}:domain/sdlf
-                Effect: Allow
-                Action:
-                  - es:CreateElasticsearchDomain
-                  - es:DescribeElasticsearchDomain
-                  - es:DeleteElasticsearchDomain
-                  - es:UpdateElasticsearchDomainConfig
-              - Resource: "*"
-                Effect: Allow
-                Action:
-                  - cognito-identity:CreateIdentityPool
-                  - cognito-identity:DeleteIdentityPool
-                  - cognito-identity:DescribeIdentityPool
-                  - cognito-identity:GetIdentityPoolRoles
-                  - cognito-identity:UpdateIdentityPool
-                  - cognito-identity:SetIdentityPoolRoles
-                  - cognito-idp:AdminCreateUser
-                  - cognito-idp:AdminDeleteUser
-                  - cognito-idp:CreateGroup
-                  - cognito-idp:CreateResourceServer
-                  - cognito-idp:CreateUserPool
-                  - cognito-idp:CreateUserPoolClient
-                  - cognito-idp:CreateUserPoolDomain
-                  - cognito-idp:DeleteGroup
-                  - cognito-idp:DeleteUserPool
-                  - cognito-idp:DeleteUserPoolClient
-                  - cognito-idp:UpdateGroup
-                  - cognito-idp:UpdateUserPool
-                  - cognito-idp:UpdateUserPoolClient
+                  - glue:TagResource
+                  - glue:UntagResource
+                Resource: !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:crawler/sdlf-*
 
   rCodePipelineRole:
     Type: AWS::IAM::Role


### PR DESCRIPTION
*Issue #, if available:*
#91 

*Description of changes:*
cfn_nag was complaining about rCodeBuildRole and the use of wildcards. This PR fixes that.

Due to the policy getting longer it was necessary to create IAM policies and attach them to the role instead of putting everything in inline policies. This is why the specific profile used to deploy child accounts (./deploy.sh -t) now requires the following permissions in addition to existing ones:
```
iam:GetPolicy
iam:CreatePolicy
iam:DeletePolicy
iam:DetachRolePolicy
iam:ListPolicyVersions
iam:CreatePolicyVersion
iam:DeletePolicyVersion
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
