### PR TITLE
avoid wildcards in data quality lambda permissions

### DIFF
--- a/sdlf-foundations/nested-stacks/template-glue.yaml
+++ b/sdlf-foundations/nested-stacks/template-glue.yaml
@@ -100,7 +100,16 @@ Resources:
                 Action:
                   - glue:GetJobRun
                   - glue:StartJobRun
-                Resource: "*"
+                Resource: !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:job/sdlf-data-quality-*
+              - Effect: Allow
+                Action:
+                  - ssm:GetParameter
+                Resource: !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/Glue/*
+              - Effect: Allow
+                Action:
+                  - dynamodb:GetItem
+                Resource:
+                  - !Sub arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/octagon-*
 
   # Step2 Role
   rRoleLambdaExecutionStep2:
@@ -125,7 +134,7 @@ Resources:
               - Effect: Allow
                 Action:
                   - glue:StartCrawler
-                Resource: "*"
+                Resource: !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:crawler/sdlf-data-quality-*
 
   rStatesExecutionRole:
     Type: AWS::IAM::Role


### PR DESCRIPTION
*Issue #, if available:*
#91 

*Description of changes:*
cfn_nag was complaining about rRoleLambdaExecutionStep1 and rRoleLambdaExecutionStep2, and their use of wildcards in IAM permissions. This PR fixes that.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
