### PR TITLE
avoid wildcards in sdlf-lakeformation-admin role permissions

### DIFF
--- a/sdlf-cicd/template-cicd-child-foundations.yaml
+++ b/sdlf-cicd/template-cicd-child-foundations.yaml
@@ -589,7 +589,10 @@ Resources:
                 Action:
                   - logs:AssociateKmsKey
                   - logs:CreateLogGroup
-                Resource: "*"
+                Resource:
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:sdlf-*
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/sdlf-*
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/sdlf-*
               - Sid: CreateLogStream
                 Effect: Allow
                 Action:


### PR DESCRIPTION
*Issue #, if available:*
#91 

*Description of changes:*
cfn_nag was complaining about rDataLakeAdminRole and the use of wildcards. This PR fixes that.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
