### PR TITLE
Create a role for Lake Formation data access

### DIFF
--- a/sdlf-cicd/template-cicd-child-foundations.yaml
+++ b/sdlf-cicd/template-cicd-child-foundations.yaml
@@ -353,6 +353,11 @@ Resources:
                       - glue.amazonaws.com
                       - lambda.amazonaws.com
                       - states.amazonaws.com
+                      - lakeformation.amazonaws.com
+              - Effect: Allow
+                Action: iam:PassRole
+                Resource:
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/sdlf-foundations-*-rLakeFormationDataAccess-*
               - Effect: Allow
                 Action:
                   - iam:GetRole
@@ -374,7 +379,6 @@ Resources:
                   - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/sdlf-*
                   - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/state-machine/sdlf-*
                   - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/service-role/sdlf-*
-                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/aws-service-role/lakeformation.amazonaws.com/AWSServiceRoleForLakeFormationDataAccess
               - Effect: Allow
                 Action:
                   - iam:ListPolicyVersions

--- a/sdlf-foundations/nested-stacks/template-kms.yaml
+++ b/sdlf-foundations/nested-stacks/template-kms.yaml
@@ -2,6 +2,32 @@ AWSTemplateFormatVersion: 2010-09-09
 Description: KMS resources to be created by the common stack
 
 Resources:
+  rLakeFormationDataAccessRole: # https://docs.aws.amazon.com/lake-formation/latest/dg/registration-role.html
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lakeformation.amazonaws.com
+                - glue.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: CloudWatchLogs
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+            - Effect: Allow
+              Action:
+                - logs:CreateLogStream
+                - logs:CreateLogGroup
+                - logs:PutLogEvents
+              Resource:
+                - !Sub "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws-lakeformation-acceleration/*"
+                - !Sub "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws-lakeformation-acceleration/*:log-stream:*"
+
   ######## KMS #########
   rKMSKey:
     Type: AWS::KMS::Key
@@ -101,6 +127,18 @@ Resources:
                 kms:ViaService: !Sub es.${AWS::Region}.amazonaws.com
               Bool:
                 kms:GrantIsForAWSResource: true
+          - Sid: Allow LakeFormation access
+            Effect: Allow
+            Principal:
+              AWS: !GetAtt rLakeFormationDataAccessRole.Arn
+            Action:
+              - kms:Encrypt*
+              - kms:Decrypt*
+              - kms:ReEncrypt*
+              - kms:GenerateDataKey*
+              - kms:Describe*
+            Resource: "*"
+
 
   rKMSKeyAlias:
     Type: AWS::KMS::Alias
@@ -117,7 +155,19 @@ Resources:
       Value: !GetAtt rKMSKey.Arn
       Description: Arn of the KMS key
 
+  rLakeFormationDataAccessRoleSsm:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: /SDLF/IAM/LakeFormationDataAccessRoleArn
+      Type: String
+      Value: !GetAtt rLakeFormationDataAccessRole.Arn
+      Description: Lake Formation Data Access Role
+
 Outputs:
   oKMSKeyId:
     Description: Arn of the KMS key
     Value: !GetAtt rKMSKey.Arn
+
+  oLakeFormationDataAccessRole:
+    Description: Name of the Lake FOrmation Data Access role
+    Value: !Ref rLakeFormationDataAccessRole

--- a/sdlf-foundations/nested-stacks/template-s3.yaml
+++ b/sdlf-foundations/nested-stacks/template-s3.yaml
@@ -11,6 +11,8 @@ Parameters:
     Type: String
   pKMSKeyId:
     Type: String
+  pLakeFormationDataAccessRole:
+    Type: String
   pNumBuckets:
     Type: String
   pOrganizationName:
@@ -30,6 +32,61 @@ Globals:
     KmsKeyArn: !Ref pKMSKeyId
 
 Resources:
+  rLakeFormationDataAccessRolePolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: sdlf-lakeformation
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action:
+              - s3:GetObject*
+              - s3:GetBucket*
+              - s3:List*
+              - s3:DeleteObject*
+              - s3:PutObject
+              - s3:PutObjectLegalHold
+              - s3:PutObjectRetention
+              - s3:PutObjectTagging
+              - s3:PutObjectVersionTagging
+              - s3:Abort*
+            Resource:
+              !If [
+                CreateMultipleBuckets,
+                [
+                  !Sub "arn:${AWS::Partition}:s3:::${rRawBucket}",
+                  !Sub "arn:${AWS::Partition}:s3:::${rStageBucket}",
+                  !Sub "arn:${AWS::Partition}:s3:::${rAnalyticsBucket}",
+                  !Sub "arn:${AWS::Partition}:s3:::${rDataQualityBucket}",
+                  !Sub "arn:${AWS::Partition}:s3:::${rRawBucket}/*",
+                  !Sub "arn:${AWS::Partition}:s3:::${rStageBucket}/*",
+                  !Sub "arn:${AWS::Partition}:s3:::${rAnalyticsBucket}/*",
+                  !Sub "arn:${AWS::Partition}:s3:::${rDataQualityBucket}/*",
+                ],
+                [
+                  !Sub "arn:${AWS::Partition}:s3:::${rCentralBucket}",
+                  !Sub "arn:${AWS::Partition}:s3:::${rDataQualityBucket}",
+                  !Sub "arn:${AWS::Partition}:s3:::${rCentralBucket}/*",
+                  !Sub "arn:${AWS::Partition}:s3:::${rDataQualityBucket}/*",
+                ]
+              ]
+          - Effect: Allow
+            Action:
+              - kms:Encrypt*
+              - kms:Decrypt*
+              - kms:ReEncrypt*
+              - kms:GenerateDataKey*
+              - kms:Describe*
+            Resource: "*"
+            Condition:
+              "ForAnyValue:StringLike":
+                "kms:ResourceAliases":
+                  - alias/sdlf-kms-key
+                  - alias/sdlf-*-kms-data-key
+      Roles:
+        - !Ref pLakeFormationDataAccessRole
+
   ####### S3 Buckets #########
   rPipelineBucket:
     Type: AWS::S3::Bucket
@@ -120,9 +177,11 @@ Resources:
   rCentralBucketLakeFormationS3Registration:
     Type: AWS::LakeFormation::Resource
     Condition: CreateSingleBucket
+    DependsOn: rLakeFormationDataAccessRolePolicy
     Properties:
       ResourceArn: !Sub arn:${AWS::Partition}:s3:::${rCentralBucket}/
-      UseServiceLinkedRole: True
+      RoleArn: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/${pLakeFormationDataAccessRole}
+      UseServiceLinkedRole: False
 
   rRawBucket:
     Type: AWS::S3::Bucket
@@ -175,9 +234,11 @@ Resources:
   rRawBucketLakeFormationS3Registration:
     Type: AWS::LakeFormation::Resource
     Condition: CreateMultipleBuckets
+    DependsOn: rLakeFormationDataAccessRolePolicy
     Properties:
       ResourceArn: !Sub arn:${AWS::Partition}:s3:::${rRawBucket}/
-      UseServiceLinkedRole: True
+      RoleArn: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/${pLakeFormationDataAccessRole}
+      UseServiceLinkedRole: False
 
   rStageBucket:
     Type: AWS::S3::Bucket
@@ -230,9 +291,11 @@ Resources:
   rStageBucketLakeFormationS3Registration:
     Type: AWS::LakeFormation::Resource
     Condition: CreateMultipleBuckets
+    DependsOn: rLakeFormationDataAccessRolePolicy
     Properties:
       ResourceArn: !Sub arn:${AWS::Partition}:s3:::${rStageBucket}/
-      UseServiceLinkedRole: True
+      RoleArn: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/${pLakeFormationDataAccessRole}
+      UseServiceLinkedRole: False
 
   rAnalyticsBucket:
     Type: AWS::S3::Bucket
@@ -285,9 +348,11 @@ Resources:
   rAnalyticsBucketLakeFormationS3Registration:
     Type: AWS::LakeFormation::Resource
     Condition: CreateMultipleBuckets
+    DependsOn: rLakeFormationDataAccessRolePolicy
     Properties:
       ResourceArn: !Sub arn:${AWS::Partition}:s3:::${rAnalyticsBucket}/
-      UseServiceLinkedRole: True
+      RoleArn: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/${pLakeFormationDataAccessRole}
+      UseServiceLinkedRole: False
 
   rDataQualityBucket:
     Type: AWS::S3::Bucket
@@ -328,9 +393,11 @@ Resources:
 
   rDataQualityBucketLakeFormationS3Registration:
     Type: AWS::LakeFormation::Resource
+    DependsOn: rLakeFormationDataAccessRolePolicy
     Properties:
       ResourceArn: !Sub arn:${AWS::Partition}:s3:::${rDataQualityBucket}/
-      UseServiceLinkedRole: True
+      RoleArn: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/${pLakeFormationDataAccessRole}
+      UseServiceLinkedRole: False
 
   rAthenaBucket:
     Type: AWS::S3::Bucket

--- a/sdlf-foundations/template.yaml
+++ b/sdlf-foundations/template.yaml
@@ -96,6 +96,7 @@ Resources:
         pCustomBucketPrefix: !Ref pCustomBucketPrefix
         pEnvironment: !Ref pEnvironment
         pKMSKeyId: !GetAtt [rKMSStack, Outputs.oKMSKeyId]
+        pLakeFormationDataAccessRole: !GetAtt [rKMSStack, Outputs.oLakeFormationDataAccessRole]
         pNumBuckets: !Ref pNumBuckets
         pOrganizationName: !Ref pOrganizationName
         pCloudWatchLogsRetentionInDays: !Ref pCloudWatchLogsRetentionInDays

--- a/sdlf-team/nested-stacks/template-kms.yaml
+++ b/sdlf-team/nested-stacks/template-kms.yaml
@@ -8,6 +8,9 @@ Parameters:
     Type: String
   pTeamName:
     Type: String
+  pLakeFormationDataAccessRole:
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: /SDLF/IAM/LakeFormationDataAccessRoleArn
 
 Resources:
   ######## KMS #########
@@ -123,17 +126,14 @@ Resources:
             Resource: "*"
           - Sid: Allow Lake Formation permissions
             Action:
-              - kms:Decrypt
-              - kms:DescribeKey
-              - kms:Encrypt
-              - kms:GenerateDataKey*
+              - kms:Encrypt*
+              - kms:Decrypt*
               - kms:ReEncrypt*
+              - kms:GenerateDataKey*
+              - kms:Describe*
             Effect: Allow
             Principal:
-              AWS:
-                [
-                  !Sub "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/aws-service-role/lakeformation.amazonaws.com/AWSServiceRoleForLakeFormationDataAccess",
-                ]
+              AWS: !Ref pLakeFormationDataAccessRole
             Resource: "*"
 
   rKMSDataKeyAlias:


### PR DESCRIPTION
*Issue #, if available:*
#137 

*Description of changes:*
By default a service role is created automatically when registering a bucket for the first time. But that doesn't quite work for us at it doesn't do that in CloudFormation: #137

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
