### PR TITLE
Build CloudFormation module version only when needed

### DIFF
--- a/sdlf-cicd/nested-stacks/template-cicd-cfn-module.yaml
+++ b/sdlf-cicd/nested-stacks/template-cicd-cfn-module.yaml
@@ -178,15 +178,26 @@ Resources:
                 - python3 sam-translate.py --template-file=template.yaml --output-template=translated-template.json
                 - # aws cloudformation validate-template --template-body file://./translated-template.json
                 - |-
-                    mkdir module
-                    cd module
-                    cfn init --artifact-type MODULE --type-name "$DOMAIN_NAME::$TEAM_NAME::$MODULE_NAME::MODULE" && rm fragments/sample.json
-                    cp -i -a ../translated-template.json fragments/
-
                     temp_role=$(aws sts assume-role --role-arn "arn:${AWS::Partition}:iam::$DOMAIN_ACCOUNT_ID:role/sdlf-cicd-domain-crossaccount-cfn-modules" --role-session-name "codebuild-cfn-module")
                     export AWS_ACCESS_KEY_ID=$(echo $temp_role | jq .Credentials.AccessKeyId | xargs)
                     export AWS_SECRET_ACCESS_KEY=$(echo $temp_role | jq .Credentials.SecretAccessKey | xargs)
                     export AWS_SESSION_TOKEN=$(echo $temp_role | jq .Credentials.SessionToken | xargs)
+
+                    # compare hashes to avoid creating a new module version when there is no change
+                    NEW_MODULE="$CODEBUILD_RESOLVED_SOURCE_VERSION"
+                    if CURRENT_MODULE=$(aws ssm get-parameter --name "/SDLF/CFN/$DOMAIN_NAME-$TEAM_NAME-$MODULE_NAME-MODULE" --query "Parameter.Value" --output text); then
+                      echo "Current module version commit id: $CURRENT_MODULE"
+                      echo "New module version commit id: $NEW_MODULE"
+                      if [ "$NEW_MODULE" == "$CURRENT_MODULE" ]; then
+                        echo "No change since last build, exiting module creation."
+                        exit 0
+                      fi
+                    fi
+
+                    mkdir module
+                    cd module
+                    cfn init --artifact-type MODULE --type-name "$DOMAIN_NAME::$TEAM_NAME::$MODULE_NAME::MODULE" && rm fragments/sample.json
+                    cp -i -a ../translated-template.json fragments/
 
                     cfn submit --role-arn "arn:${AWS::Partition}:iam::$DOMAIN_ACCOUNT_ID:role/sdlf-cicd-cfn-modules" > cfn.log 2>&1
                     if grep "ValidationError.*CloudFormationManagedUploadInfrastructure.*CREATE_IN_PROGRESS" cfn.log; then
@@ -202,6 +213,7 @@ Resources:
                     TYPE_VERSION_ARN=$(grep "ProgressStatus.*status COMPLETED" cfn.log | tr "'" '"' | jq -r '.TypeVersionArn')
                     echo "registering new cloudformation module version as default: $TYPE_VERSION_ARN"
                     aws cloudformation set-type-default-version --type MODULE --arn "$TYPE_VERSION_ARN" || exit 1
+                    aws ssm put-parameter --name "/SDLF/CFN/$DOMAIN_NAME-$TEAM_NAME-$MODULE_NAME-MODULE" --type "String" --value "$NEW_MODULE" --overwrite
                     echo "done"
                     cd ..
                     rm -Rf module

--- a/sdlf-cicd/template-cicd-domain-roles.yaml
+++ b/sdlf-cicd/template-cicd-domain-roles.yaml
@@ -55,6 +55,12 @@ Resources:
                   "ForAnyValue:StringLike":
                     "kms:ResourceAliases": !Ref pDevOpsKMSKey
               - Effect: Allow
+                Action:
+                  - ssm:GetParameter
+                  - ssm:GetParameters
+                  - ssm:PutParameter
+                Resource: !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/CFN/*
+              - Effect: Allow
                 Action: iam:PassRole
                 Resource: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/sdlf-cicd-cfn-modules
                 # Condition:


### PR DESCRIPTION
*Description of changes:*
When building a new CloudFormation module, store the git commit id of the source in SSM Parameter Store. This commit id is then compared against when building new versions. If the commit id hasn't changed, nothing is built.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
