### PR TITLE
Improve our cfn-lint posture

### DIFF
--- a/sdlf-cicd/template-cicd-sdlf-repositories.yaml
+++ b/sdlf-cicd/template-cicd-sdlf-repositories.yaml
@@ -78,6 +78,11 @@ Resources:
   ######## CODECOMMIT #########
   rCicdCodeCommit:
     Type: AWS::CodeCommit::Repository
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - E3002
     Properties:
       Code:
         BranchName: master
@@ -87,6 +92,11 @@ Resources:
 
   rFoundationsCodeCommit:
     Type: AWS::CodeCommit::Repository
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - E3002
     Properties:
       Code:
         BranchName: master
@@ -96,6 +106,11 @@ Resources:
 
   rTeamCodeCommit:
     Type: AWS::CodeCommit::Repository
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - E3002
     Properties:
       Code:
         BranchName: master
@@ -105,6 +120,11 @@ Resources:
 
   rPipelineCodeCommit:
     Type: AWS::CodeCommit::Repository
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - E3002
     Properties:
       Code:
         BranchName: master
@@ -114,6 +134,11 @@ Resources:
 
   rDatasetCodeCommit:
     Type: AWS::CodeCommit::Repository
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - E3002
     Properties:
       Code:
         BranchName: master
@@ -123,6 +148,11 @@ Resources:
 
   rStageACodeCommit:
     Type: AWS::CodeCommit::Repository
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - E3002
     Properties:
       Code:
         BranchName: master
@@ -132,6 +162,11 @@ Resources:
 
   rStageBCodeCommit:
     Type: AWS::CodeCommit::Repository
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - E3002
     Properties:
       Code:
         BranchName: master
@@ -141,6 +176,11 @@ Resources:
 
   rDatalakeLibraryCodeCommit:
     Type: AWS::CodeCommit::Repository
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - E3002
     Properties:
       Code:
         BranchName: master
@@ -150,6 +190,11 @@ Resources:
 
   rPipLibraryCodeCommit:
     Type: AWS::CodeCommit::Repository
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - E3002
     Properties:
       Code:
         BranchName: master

--- a/sdlf-foundations/template.yaml
+++ b/sdlf-foundations/template.yaml
@@ -1524,3 +1524,6 @@ Outputs:
   oPipelineReference:
     Description: CodePipeline reference this stack has been deployed with
     Value: !Ref pPipelineReference
+  oChildAccountId:
+    Description: Child AWS account ID
+    Value: !Ref pChildAccountId

--- a/sdlf-stageA/template.yaml
+++ b/sdlf-stageA/template.yaml
@@ -112,7 +112,7 @@ Globals:
     Runtime: python3.9
     Handler: lambda_function.lambda_handler
     Layers:
-      - !Sub "{{resolve:ssm:/SDLF/Lambda/LatestDatalakeLibraryLayer}}"
+      - "{{resolve:ssm:/SDLF/Lambda/LatestDatalakeLibraryLayer}}"
     KmsKeyArn: !Sub "{{resolve:ssm:/SDLF/KMS/${pTeamName}/InfraKeyId}}"
 
 Resources:

--- a/sdlf-stageB/template.yaml
+++ b/sdlf-stageB/template.yaml
@@ -112,7 +112,7 @@ Globals:
     Runtime: python3.9
     Handler: lambda_function.lambda_handler
     Layers:
-      - !Sub "{{resolve:ssm:/SDLF/Lambda/LatestDatalakeLibraryLayer}}"
+      - "{{resolve:ssm:/SDLF/Lambda/LatestDatalakeLibraryLayer}}"
     KmsKeyArn: !Sub "{{resolve:ssm:/SDLF/KMS/${pTeamName}/InfraKeyId}}"
 
 Resources:


### PR DESCRIPTION
*Description of changes:*
cfn-lint mistakenly complains (E3002) about the Code parameter for CodeCommit. The sam transform takes care of replacing the Code value - so there is no real issue here.

A couple other fixes to cfn-lint findings.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
