### PR TITLE
Explicit CloudFormation removal policy

### DIFF
--- a/sdlf-cicd/template-codecommit-pr-check.yaml
+++ b/sdlf-cicd/template-codecommit-pr-check.yaml
@@ -133,6 +133,8 @@ Resources:
 
   rPullRequestLambdaLogGroup:
     Type: AWS::Logs::LogGroup
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
     Properties:
       LogGroupName: !Sub /aws/lambda/${rPullRequestLambdaFunction}
       KmsKeyId: !Ref pKMSKeyArn
@@ -390,6 +392,8 @@ Resources:
 
   rCodeBuildResultLambdaLogGroup:
     Type: AWS::Logs::LogGroup
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
     Properties:
       LogGroupName: !Sub /aws/lambda/${rCodeBuildResultFunction}
       KmsKeyId: !Ref pKMSKeyArn

--- a/sdlf-foundations/template.yaml
+++ b/sdlf-foundations/template.yaml
@@ -657,16 +657,21 @@ Resources:
   ######## Lambda & SQS #########
   rQueueCatalog:
     Type: AWS::SQS::Queue
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
     Properties:
       QueueName: sdlf-catalog-queue
       RedrivePolicy:
         deadLetterTargetArn: !GetAtt rDeadLetterQueueCatalog.Arn
         maxReceiveCount: 1
       VisibilityTimeout: 60
+      MessageRetentionPeriod: 604800
       KmsMasterKeyId: !GetAtt rKMSKey.Arn
 
   rDeadLetterQueueCatalog:
     Type: AWS::SQS::Queue
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
     Properties:
       QueueName: sdlf-catalog-dlq
       MessageRetentionPeriod: 1209600
@@ -675,16 +680,21 @@ Resources:
 
   rQueueRouting:
     Type: AWS::SQS::Queue
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
     Properties:
       QueueName: sdlf-routing-queue
       RedrivePolicy:
         deadLetterTargetArn: !GetAtt rDeadLetterQueueRouting.Arn
         maxReceiveCount: 1
       VisibilityTimeout: 60
+      MessageRetentionPeriod: 604800
       KmsMasterKeyId: !GetAtt rKMSKey.Arn
 
   rDeadLetterQueueRouting:
     Type: AWS::SQS::Queue
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
     Properties:
       QueueName: sdlf-routing-dlq
       MessageRetentionPeriod: 1209600
@@ -741,6 +751,8 @@ Resources:
 
   rLambdaRoutingLogGroup:
     Type: AWS::Logs::LogGroup
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaRouting}
       RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
@@ -762,6 +774,8 @@ Resources:
 
   rLambdaCatalogRedriveLogGroup:
     Type: AWS::Logs::LogGroup
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaCatalogRedrive}
       RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
@@ -780,8 +794,11 @@ Resources:
       MemorySize: 256
       Timeout: 60
       Role: !GetAtt rRoleLambdaExecution.Arn
+
   rLambdaRoutingRedriveLogGroup:
     Type: AWS::Logs::LogGroup
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaRoutingRedrive}
       RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
@@ -1460,6 +1477,8 @@ Resources:
 
   rLambdaReplicateLogGroup:
     Type: AWS::Logs::LogGroup
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaReplicate}
       RetentionInDays: !Ref pCloudWatchLogsRetentionInDays

--- a/sdlf-pipeline/template.yaml
+++ b/sdlf-pipeline/template.yaml
@@ -100,6 +100,8 @@ Resources:
 
   rQueueRoutingStep:
     Type: AWS::SQS::Queue
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
     Properties:
       QueueName:
         Fn::Sub:
@@ -117,6 +119,7 @@ Resources:
           Fn::GetAtt: [rDeadLetterQueueRoutingStep, Arn]
         maxReceiveCount: 1
       VisibilityTimeout: 60
+      MessageRetentionPeriod: 604800
       KmsMasterKeyId:
         Fn::Sub:
           - "{{resolve:ssm:/SDLF/KMS/${pTeamName}/InfraKeyId}}"
@@ -125,6 +128,8 @@ Resources:
 
   rDeadLetterQueueRoutingStep:
     Type: AWS::SQS::Queue
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
     Properties:
       QueueName:
         Fn::Sub:

--- a/sdlf-stageA/template.yaml
+++ b/sdlf-stageA/template.yaml
@@ -458,6 +458,8 @@ Resources:
   ######## CLOUDWATCH #########
   rLambdaRoutingStepLogGroup:
     Type: AWS::Logs::LogGroup
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaRoutingStep}
       RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
@@ -493,6 +495,8 @@ Resources:
 
   rLambdaRedriveStepLogGroup:
     Type: AWS::Logs::LogGroup
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaRedriveStep}
       RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
@@ -509,6 +513,8 @@ Resources:
 
   rLambdaStep1LogGroup:
     Type: AWS::Logs::LogGroup
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaStep1}
       RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
@@ -525,6 +531,8 @@ Resources:
 
   rLambdaStep2LogGroup:
     Type: AWS::Logs::LogGroup
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaStep2}
       RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
@@ -541,6 +549,8 @@ Resources:
 
   rLambdaStep3LogGroup:
     Type: AWS::Logs::LogGroup
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaStep3}
       RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
@@ -557,6 +567,8 @@ Resources:
 
   rLambdaErrorStepLogGroup:
     Type: AWS::Logs::LogGroup
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaErrorStep}
       RetentionInDays: !Ref pCloudWatchLogsRetentionInDays

--- a/sdlf-stageB/template.yaml
+++ b/sdlf-stageB/template.yaml
@@ -445,6 +445,8 @@ Resources:
   ######## CLOUDWATCH #########
   rLambdaRoutingStepLogGroup:
     Type: AWS::Logs::LogGroup
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaRoutingStep}
       RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
@@ -480,6 +482,8 @@ Resources:
 
   rLambdaRedriveStepLogGroup:
     Type: AWS::Logs::LogGroup
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaRedriveStep}
       RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
@@ -496,6 +500,8 @@ Resources:
 
   rLambdaStep1LogGroup:
     Type: AWS::Logs::LogGroup
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaStep1}
       RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
@@ -512,6 +518,8 @@ Resources:
 
   rLambdaJobCheckStepLogGroup:
     Type: AWS::Logs::LogGroup
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaJobCheckStep}
       RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
@@ -528,6 +536,8 @@ Resources:
 
   rLambdaStep2LogGroup:
     Type: AWS::Logs::LogGroup
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaStep2}
       RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
@@ -544,6 +554,8 @@ Resources:
 
   rLambdaStep3LogGroup:
     Type: AWS::Logs::LogGroup
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaStep3}
       RetentionInDays: !Ref pCloudWatchLogsRetentionInDays
@@ -560,6 +572,8 @@ Resources:
 
   rLambdaErrorStepLogGroup:
     Type: AWS::Logs::LogGroup
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
     Properties:
       LogGroupName: !Sub /aws/lambda/${rLambdaErrorStep}
       RetentionInDays: !Ref pCloudWatchLogsRetentionInDays


### PR DESCRIPTION
*Description of changes:*
cfn-lint recommends setting explicit values for UpdateReplacePolicy and DeletionPolicy on stateful resources:

> I3011 The default action when replacing/removing a resource is to delete it. Set explicit values for UpdateReplacePolicy / DeletionPolicy on potentially stateful resource: x

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
