### PR TITLE
migration to EventBridge Scheduler

### DIFF
--- a/sdlf-cicd/template-cicd-domain-roles.yaml
+++ b/sdlf-cicd/template-cicd-domain-roles.yaml
@@ -726,6 +726,18 @@ Resources:
                   - codepipeline:GetPipelineState
                   - codepipeline:GetPipeline
                   - codepipeline:UpdatePipeline
+              - Resource:
+                  - !Sub arn:${AWS::Partition}:scheduler:${AWS::Region}:${AWS::AccountId}:schedule-group/sdlf-*
+                  - !Sub arn:${AWS::Partition}:scheduler:${AWS::Region}:${AWS::AccountId}:schedule/sdlf-*
+                Effect: Allow
+                Action:
+                  - scheduler:GetScheduleGroup
+                  - scheduler:CreateScheduleGroup
+                  - scheduler:DeleteScheduleGroup
+                  - scheduler:ListTagsForResource
+                  - scheduler:UntagResource
+                  - scheduler:TagResource
+                  - scheduler:DeleteSchedule
               - Resource: !Sub arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:*
                 Effect: Allow
                 Action: sqs:ListQueues
@@ -941,6 +953,21 @@ Resources:
                 Condition:
                   "ForAnyValue:StringLike":
                     "kms:ResourceAliases": !Ref pDevOpsKMSKey
+        - PolicyName: sdlf-pipeline-interface
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Resource:
+                  - !Sub arn:${AWS::Partition}:scheduler:${AWS::Region}:${AWS::AccountId}:schedule/sdlf-*
+                Effect: Allow
+                Action:
+                  - scheduler:ListTagsForResource
+                  - scheduler:UntagResource
+                  - scheduler:TagResource
+                  - scheduler:DeleteSchedule
+                  - scheduler:GetSchedule
+                  - scheduler:CreateSchedule
+                  - scheduler:UpdateSchedule
 
   rCodeBuildPublishLayerRole:
     Type: AWS::IAM::Role

--- a/sdlf-foundations/template.yaml
+++ b/sdlf-foundations/template.yaml
@@ -928,6 +928,11 @@ Resources:
                   - kms:GenerateDataKey*
                   - kms:ReEncrypt*
                 Resource: !GetAtt rKMSKey.Arn
+              - Effect: Allow
+                Action:
+                  - ssm:GetParameter
+                  - ssm:GetParameters
+                Resource: !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/EventBridge/*
 
   ####### SSM #######
   rS3ArtifactBucketSsm:
@@ -981,7 +986,6 @@ Resources:
       Value: !Ref rDeadLetterQueueRouting
       Description: URL of dead letter routing queue
 
-  ######## DYNAMODB #########
   ######## DYNAMODB #########
   rDynamoOctagonObjectMetadata:
     Type: AWS::DynamoDB::Table

--- a/sdlf-pipeline/template.yaml
+++ b/sdlf-pipeline/template.yaml
@@ -179,74 +179,58 @@ Resources:
         Fn::GetAtt: [rQueueRoutingStep, Arn]
       FunctionName: !Ref pLambdaRoutingStep
 
-  rPostStateRule:
-    Type: AWS::Events::Rule
+  rPostStateScheduleRole:
+    Type: AWS::IAM::Role
     Condition: ScheduleBased
     Properties:
-      Name:
-        Fn::Sub:
-          - sdlf-${pTeamName}-${pPipelineName}-schedule-rule-${pStageName}
-          - pTeamName:
-              Ref: pTeamName
-            pPipelineName:
-              Ref: pPipelineName
-            pStageName:
-              Ref: pStageName
-      Description:
-        Fn::Sub:
-          - Trigger ${pStageName} Routing Lambda on a specified schedule
-          - pStageName:
-              Ref: pStageName
-      State: ENABLED
-      ScheduleExpression:
-        Ref: pSchedule
-      Targets:
-        - Id:
-            Fn::Sub:
-              - sdlf-${pTeamName}-${pPipelineName}-schedule-rule-${pStageName}
-              - pTeamName:
-                  Ref: pTeamName
-                pPipelineName:
-                  Ref: pPipelineName
-                pStageName:
-                  Ref: pStageName
-          Arn: !Ref pLambdaRoutingStep
-          Input:
-            Fn::Sub:
-              - |
-                {
-                  "team": "${pTeamName}",
-                  "pipeline": "${pPipelineName}",
-                  "pipeline_stage": "${pStageName}",
-                  "trigger_type": "${pTriggerType}",
-                  "org": "${pOrg}",
-                  "domain": "${pDomain}",
-                  "env": "${pEnv}"
-                }
-              - pTeamName:
-                  Ref: pTeamName
-                pPipelineName:
-                  Ref: pPipelineName
-                pStageName:
-                  Ref: pStageName
-                pTriggerType:
-                  Ref: pTriggerType
-                pOrg:
-                  Ref: pOrg
-                pDomain:
-                  Ref: pDomain
-                pEnv:
-                  Ref: pEnv
+      PermissionsBoundary: !Sub "{{resolve:ssm:/SDLF/IAM/${pTeamName}/TeamPermissionsBoundary}}"
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - scheduler.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      Policies:
+        - PolicyName: sdlf-schedule
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - lambda:InvokeFunction
+                Resource:
+                  - !Ref pLambdaRoutingStep
+                  - !Sub "${pLambdaRoutingStep}:*"
+              - Effect: Allow
+                Action:
+                  - kms:Decrypt
+                Resource:
+                  - !Sub "{{resolve:ssm:/SDLF/KMS/${pTeamName}/InfraKeyId}}"
 
-  rPermissionEventsInvokeRoutingLambda:
-    Type: AWS::Lambda::Permission
+  rPostStateSchedule:
+    Type: AWS::Scheduler::Schedule
     Condition: ScheduleBased
     Properties:
-      FunctionName: !Ref pLambdaRoutingStep
-      Action: lambda:InvokeFunction
-      Principal: events.amazonaws.com
-      SourceArn:
-        Fn::GetAtt: [rPostStateRule, Arn]
+      Description: !Sub Trigger ${pStageName} Routing Lambda on a specified schedule
+      GroupName: !Sub "{{resolve:ssm:/SDLF/EventBridge/${pTeamName}/ScheduleGroupName}}"
+      KmsKeyArn: !Sub "{{resolve:ssm:/SDLF/KMS/${pTeamName}/InfraKeyId}}"
+      Name: !Sub sdlf-${pTeamName}-${pPipelineName}-schedule-rule-${pStageName}
+      ScheduleExpression: !Ref pSchedule
+      FlexibleTimeWindow:
+        Mode: "OFF"
+      State: ENABLED
+      Target:
+        Arn: !Sub arn:${AWS::Partition}:scheduler:::aws-sdk:lambda:invoke
+        RoleArn: !GetAtt rPostStateScheduleRole.Arn
+        Input: !Sub >-
+          {
+            "FunctionName": "${pLambdaRoutingStep}",
+            "InvocationType": "Event",
+            "Payload": "{\n \"team\": \"${pTeamName}\",\n \"pipeline\": \"${pPipelineName}\",\n \"pipeline_stage\": \"${pStageName}\",\n \"trigger_type\": \"${pTriggerType}\",\n \"org\": \"${pOrg}\",\n \"domain\": \"${pDomain}\",\n \"env\": \"${pEnv}\"\n }"
+          }
 
   ######## SSM OUTPUTS #########
   rQueueRoutingStepSsm:

--- a/sdlf-team/template.yaml
+++ b/sdlf-team/template.yaml
@@ -177,6 +177,11 @@ Resources:
       AliasName: !Sub alias/sdlf-${pTeamName}-kms-data-key
       TargetKeyId: !Ref rKMSDataKey
 
+  rScheduleGroup:
+    Type: AWS::Scheduler::ScheduleGroup
+    Properties:
+      Name: !Sub sdlf-${pTeamName}
+
   rGlueSecurityConfiguration:
     Type: AWS::Glue::SecurityConfiguration
     Properties:
@@ -235,6 +240,13 @@ Resources:
       Value: !GetAtt rKMSDataKey.Arn
       Description: !Sub Arn of the ${pTeamName} KMS data key
 
+  rScheduleGroupSsm:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub /SDLF/EventBridge/${pTeamName}/ScheduleGroupName
+      Type: String
+      Value: !Ref rScheduleGroup
+      Description: !Sub Name of the ${pTeamName} schedule group
   #### END KMS STACK
 
   ######## IAM #########
@@ -386,6 +398,11 @@ Resources:
               - cloudformation:DescribeStackResources
             Resource:
               - !Sub arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stack:sdlf-${pTeamName}:*
+          - Effect: Allow
+            Action:
+              - lambda:InvokeFunction
+            Resource:
+              - !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:sdlf-${pTeamName}-*
 
   rStatesExecutionRole:
     Type: AWS::IAM::Role
@@ -1270,6 +1287,7 @@ Resources:
               - states:ListActivities
               - states:ListStateMachines
               - states:TagResource
+              - states:UntagResource
             Resource: !Sub arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:*
           - Effect: Allow
             Action:


### PR DESCRIPTION
*Issue #, if available:*
#168 

*Description of changes:*
https://aws.amazon.com/blogs/compute/introducing-amazon-eventbridge-scheduler/

Create a schedule group per team, then create schedules in this group when required.

The main driver behind this change is to avoid hitting the [fairly low number of EventBridge rules](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-quota.html#eb-limits) that can be created in a single event bus.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
