### PR TITLE
CloudFormationManagedUploadInfrastructure permissions update

### DIFF
--- a/sdlf-cicd/nested-stacks/template-cicd-cfn-module.yaml
+++ b/sdlf-cicd/nested-stacks/template-cicd-cfn-module.yaml
@@ -114,6 +114,8 @@ Resources:
                   - s3:PutBucketPolicy
                   - s3:PutBucketVersioning
                   - s3:PutEncryptionConfiguration
+                  - s3:PutBucketPublicAccessBlock
+                  - s3:DeleteBucketPublicAccessBlock
                   - s3:PutObject # necessary for cfn submit
                   - s3:SetBucketEncryption
                 Resource:


### PR DESCRIPTION
*Description of changes:*
CloudFormationManagedUploadInfrastructure now requires s3:PutBucketPublicAccessBlock

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
