### PR TITLE
move the states execution role from sdlf-team to sdlf-stage*

### DIFF
--- a/sdlf-stageA/template.yaml
+++ b/sdlf-stageA/template.yaml
@@ -71,10 +71,6 @@ Parameters:
     Description: ARN of the Kinesis stream that collates logs
     Type: AWS::SSM::Parameter::Value<String>
     Default: /SDLF/Lambda/KibanaStreamArn
-  pStatesExecutionRole:
-    Type: AWS::SSM::Parameter::Value<String>
-    Description: The ARN of the States Execution Role
-    Default: "{{resolve:ssm:/SDLF/IAM/engineering/StatesExecutionRoleArn}}"
   pCloudWatchLogsRetentionInDays:
     Description: The number of days log events are kept in CloudWatch Logs
     Type: Number
@@ -603,6 +599,78 @@ Resources:
           Value: !Ref rLambdaErrorStep
 
   ######## STATE MACHINE #########
+  rStatesExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      PermissionsBoundary: !Sub "{{resolve:ssm:/SDLF/IAM/${pTeamName}/TeamPermissionsBoundary}}"
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - !Sub states.${AWS::Region}.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: !Sub sdlf-${pTeamName}-states-execution
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - lambda:InvokeFunction
+                Resource: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:sdlf-${pTeamName}-*
+              - Effect: Allow
+                Action:
+                  - states:DescribeExecution
+                  - states:StopExecution
+                Resource: "*"
+              - Effect: Allow
+                Action:
+                  - events:DescribeRule
+                  - events:PutRule
+                  - events:PutTargets
+                Resource: !Sub arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:rule/StepFunctionsGetEventsForStepFunctionsExecutionRule
+              - Effect: Allow
+                Action:
+                  - elasticmapreduce:DescribeCluster
+                  - elasticmapreduce:RunJobFlow
+                  - elasticmapreduce:AddTags
+                  - elasticmapreduce:TerminateJobFlows
+                Resource: "*"
+              - Effect: Allow
+                Action:
+                  - elasticmapreduce:AddJobFlowSteps
+                  - elasticmapreduce:CancelSteps
+                  - elasticmapreduce:DescribeStep
+                  - elasticmapreduce:ListInstanceFleets
+                  - elasticmapreduce:ListInstanceGroups
+                  - elasticmapreduce:ModifyInstanceFleet
+                  - elasticmapreduce:ModifyInstanceGroups
+                  - elasticmapreduce:SetTerminationProtection
+                Resource: !Sub arn:${AWS::Partition}:elasticmapreduce:${AWS::Region}:${AWS::AccountId}:cluster/*
+              - Effect: Allow
+                Action:
+                  - iam:PassRole
+                Resource: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/EMR*
+              - Effect: Allow
+                Action:
+                  - iam:CreateServiceLinkedRole
+                  - iam:PutRolePolicy
+                  - iam:UpdateRoleDescription
+                Resource: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/aws-service-role/elasticmapreduce.amazonaws.com/AWSServiceRoleForEMRCleanup*
+                Condition:
+                  StringLike:
+                    iam:AWSServiceName: elasticmapreduce.amazonaws.com
+              - Effect: Allow
+                Action:
+                  - xray:PutTraceSegments
+                  - xray:PutTelemetryRecords
+                  - xray:GetSamplingRules
+                  - xray:GetSamplingTargets
+                  - xray:GetSamplingStatisticSummaries
+                Resource: "*"
+
   rStateMachine:
     Type: AWS::Serverless::StateMachine
     Properties:
@@ -613,7 +681,7 @@ Resources:
         lStep2: !GetAtt rLambdaStep2.Arn
         lStep3: !GetAtt rLambdaStep3.Arn
         lError: !GetAtt rLambdaErrorStep.Arn
-      Role: !Ref pStatesExecutionRole
+      Role: !GetAtt rStatesExecutionRole.Arn
       Tracing:
         Enabled: !If [EnableTracing, true, false]
 

--- a/sdlf-stageB/template.yaml
+++ b/sdlf-stageB/template.yaml
@@ -71,10 +71,6 @@ Parameters:
     Description: ARN of the Kinesis stream that collates logs
     Type: AWS::SSM::Parameter::Value<String>
     Default: /SDLF/Lambda/KibanaStreamArn
-  pStatesExecutionRole:
-    Type: AWS::SSM::Parameter::Value<String>
-    Description: The ARN of the States Execution Role
-    Default: "{{resolve:ssm:/SDLF/IAM/engineering/StatesExecutionRoleArn}}"
   pCloudWatchLogsRetentionInDays:
     Description: The number of days log events are kept in CloudWatch Logs
     Type: Number
@@ -608,6 +604,78 @@ Resources:
           Value: !Ref rLambdaErrorStep
 
   ######## STEP FUNCTION #########
+  rStatesExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      PermissionsBoundary: !Sub "{{resolve:ssm:/SDLF/IAM/${pTeamName}/TeamPermissionsBoundary}}"
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - !Sub states.${AWS::Region}.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: !Sub sdlf-${pTeamName}-states-execution
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - lambda:InvokeFunction
+                Resource: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:sdlf-${pTeamName}-*
+              - Effect: Allow
+                Action:
+                  - states:DescribeExecution
+                  - states:StopExecution
+                Resource: "*"
+              - Effect: Allow
+                Action:
+                  - events:DescribeRule
+                  - events:PutRule
+                  - events:PutTargets
+                Resource: !Sub arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:rule/StepFunctionsGetEventsForStepFunctionsExecutionRule
+              - Effect: Allow
+                Action:
+                  - elasticmapreduce:DescribeCluster
+                  - elasticmapreduce:RunJobFlow
+                  - elasticmapreduce:AddTags
+                  - elasticmapreduce:TerminateJobFlows
+                Resource: "*"
+              - Effect: Allow
+                Action:
+                  - elasticmapreduce:AddJobFlowSteps
+                  - elasticmapreduce:CancelSteps
+                  - elasticmapreduce:DescribeStep
+                  - elasticmapreduce:ListInstanceFleets
+                  - elasticmapreduce:ListInstanceGroups
+                  - elasticmapreduce:ModifyInstanceFleet
+                  - elasticmapreduce:ModifyInstanceGroups
+                  - elasticmapreduce:SetTerminationProtection
+                Resource: !Sub arn:${AWS::Partition}:elasticmapreduce:${AWS::Region}:${AWS::AccountId}:cluster/*
+              - Effect: Allow
+                Action:
+                  - iam:PassRole
+                Resource: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/EMR*
+              - Effect: Allow
+                Action:
+                  - iam:CreateServiceLinkedRole
+                  - iam:PutRolePolicy
+                  - iam:UpdateRoleDescription
+                Resource: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/aws-service-role/elasticmapreduce.amazonaws.com/AWSServiceRoleForEMRCleanup*
+                Condition:
+                  StringLike:
+                    iam:AWSServiceName: elasticmapreduce.amazonaws.com
+              - Effect: Allow
+                Action:
+                  - xray:PutTraceSegments
+                  - xray:PutTelemetryRecords
+                  - xray:GetSamplingRules
+                  - xray:GetSamplingTargets
+                  - xray:GetSamplingStatisticSummaries
+                Resource: "*"
+
   rStateMachine:
     Type: AWS::Serverless::StateMachine
     Properties:
@@ -619,7 +687,7 @@ Resources:
         lStep3: !GetAtt rLambdaStep3.Arn
         lCheckJob: !GetAtt rLambdaJobCheckStep.Arn
         lError: !GetAtt rLambdaErrorStep.Arn
-      Role: !Ref pStatesExecutionRole
+      Role: !GetAtt rStatesExecutionRole.Arn
       Tracing:
         Enabled: !If [EnableTracing, true, false]
 

--- a/sdlf-team/template.yaml
+++ b/sdlf-team/template.yaml
@@ -404,79 +404,6 @@ Resources:
             Resource:
               - !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:sdlf-${pTeamName}-*
 
-  rStatesExecutionRole:
-    Type: AWS::IAM::Role
-    Properties:
-      RoleName: !Sub sdlf-${pTeamName}-states-execution
-      AssumeRolePolicyDocument:
-        Version: "2012-10-17"
-        Statement:
-          - Effect: Allow
-            Principal:
-              Service:
-                - !Sub states.${AWS::Region}.amazonaws.com
-            Action: sts:AssumeRole
-      Path: /
-      Policies:
-        - PolicyName: !Sub sdlf-${pTeamName}-states-execution
-          PolicyDocument:
-            Version: "2012-10-17"
-            Statement:
-              - Effect: Allow
-                Action:
-                  - lambda:InvokeFunction
-                Resource: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:sdlf-${pTeamName}-*
-              - Effect: Allow
-                Action:
-                  - states:DescribeExecution
-                  - states:StopExecution
-                Resource: "*"
-              - Effect: Allow
-                Action:
-                  - events:DescribeRule
-                  - events:PutRule
-                  - events:PutTargets
-                Resource: !Sub arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:rule/StepFunctionsGetEventsForStepFunctionsExecutionRule
-              - Effect: Allow
-                Action:
-                  - elasticmapreduce:DescribeCluster
-                  - elasticmapreduce:RunJobFlow
-                  - elasticmapreduce:AddTags
-                  - elasticmapreduce:TerminateJobFlows
-                Resource: "*"
-              - Effect: Allow
-                Action:
-                  - elasticmapreduce:AddJobFlowSteps
-                  - elasticmapreduce:CancelSteps
-                  - elasticmapreduce:DescribeStep
-                  - elasticmapreduce:ListInstanceFleets
-                  - elasticmapreduce:ListInstanceGroups
-                  - elasticmapreduce:ModifyInstanceFleet
-                  - elasticmapreduce:ModifyInstanceGroups
-                  - elasticmapreduce:SetTerminationProtection
-                Resource: !Sub arn:${AWS::Partition}:elasticmapreduce:${AWS::Region}:${AWS::AccountId}:cluster/*
-              - Effect: Allow
-                Action:
-                  - iam:PassRole
-                Resource: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/EMR*
-              - Effect: Allow
-                Action:
-                  - iam:CreateServiceLinkedRole
-                  - iam:PutRolePolicy
-                  - iam:UpdateRoleDescription
-                Resource: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/aws-service-role/elasticmapreduce.amazonaws.com/AWSServiceRoleForEMRCleanup*
-                Condition:
-                  StringLike:
-                    iam:AWSServiceName: elasticmapreduce.amazonaws.com
-              - Effect: Allow
-                Action:
-                  - xray:PutTraceSegments
-                  - xray:PutTelemetryRecords
-                  - xray:GetSamplingRules
-                  - xray:GetSamplingTargets
-                  - xray:GetSamplingStatisticSummaries
-                Resource: "*"
-
   rRoleCloudWatchEventRole:
     Type: AWS::IAM::Role
     Properties:
@@ -623,13 +550,6 @@ Resources:
       Type: String
       Value: !Ref rRoleCloudWatchEventRole
       Description: The name of the CloudWatch Event role that triggers the State Machines
-  rStatesExecutionRoleArnSsm:
-    Type: AWS::SSM::Parameter
-    Properties:
-      Name: !Sub /SDLF/IAM/${pTeamName}/StatesExecutionRoleArn
-      Type: String
-      Value: !GetAtt rStatesExecutionRole.Arn
-      Description: The ARN of the States Execution role
   rDatalakeCrawlerRoleArnSsm:
     Type: AWS::SSM::Parameter
     Properties:


### PR DESCRIPTION
*Description of changes:*
`rStatesExecutionRole` is relevant when used with the default `stageA` and `stageB`, but we can imagine other stages not relying on this role and not requiring these permissions. This may be the case if they're not using Step Functions for example.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
