### PR TITLE
disable cfn_nag W76 SPCM too high

### DIFF
--- a/.cfn-nag-deny-list.yml
+++ b/.cfn-nag-deny-list.yml
@@ -1,4 +1,6 @@
 RulesToSuppress:
+- id: W76
+  reason: too experimental. https://stelligent.com/2020/03/27/thought-experiment-proposed-complexity-metric-for-iam-policy-documents/
 - id: W89
   reason: SDLF does not support running in VPC by default
 - id: W92


### PR DESCRIPTION
*Description of changes:*

SPCM is an interesting experiment described here:
https://stelligent.com/2020/03/27/thought-experiment-proposed-complexity-metric-for-iam-policy-documents/

It's a tad too experimental for us. We might enable it back in the future but it is proving challenging to take full advantages of conditions in policies and keep the SCPM low at the same time. This is by design, as described in the article linked above, but we consider conditions important enough to uphold least privilege in SDLF.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
