### PR TITLE
Fix cfn_nag issues in sdlf-foundations

### DIFF
--- a/sdlf-foundations/template.yaml
+++ b/sdlf-foundations/template.yaml
@@ -72,7 +72,6 @@ Resources:
   rDataLakeAdminRole:
     Type: AWS::IAM::Role
     Properties:
-      RoleName: sdlf-lakeformation-admin
       AssumeRolePolicyDocument:
         Version: 2012-10-17
         Statement:
@@ -92,23 +91,17 @@ Resources:
           PolicyDocument:
             Version: 2012-10-17
             Statement:
-              - Sid: CreateLogGroup
-                Effect: Allow
+              - Effect: Allow
                 Action:
-                  - logs:AssociateKmsKey
                   - logs:CreateLogGroup
-                Resource:
-                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:sdlf-*
-                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/sdlf-*
-                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/sdlf-*
-              - Sid: CreateLogStream
-                Effect: Allow
-                Action:
                   - logs:CreateLogStream
                   - logs:PutLogEvents
+                  - logs:AssociateKmsKey
                 Resource:
-                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/sdlf-*
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/sdlf-glue-replication
                   - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/glue/*
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/sdlf-*
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:sdlf-*
               - Sid: DynamoDBAccess
                 Effect: Allow
                 Action:
@@ -302,8 +295,6 @@ Resources:
   ####### Access Logging Bucket ######
   rS3AccessLogsBucket:
     Type: AWS::S3::Bucket
-    UpdateReplacePolicy: Retain
-    DeletionPolicy: Retain
     Metadata:
       cfn_nag:
         rules_to_suppress:
@@ -367,6 +358,11 @@ Resources:
   ####### S3 Buckets #########
   rLakeFormationDataAccessRolePolicy:
     Type: AWS::IAM::Policy
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W12
+            reason: Condition Applied to restrict access, and the KMS keys do not exist at this stage
     Properties:
       PolicyName: sdlf-lakeformation
       PolicyDocument:
@@ -1002,6 +998,11 @@ Resources:
   ######## DYNAMODB #########
   rDynamoOctagonObjectMetadata:
     Type: AWS::DynamoDB::Table
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W28
+            reason: DynamoDB tables require specific names to be compatible with Octagon
     Properties:
       AttributeDefinitions:
         - AttributeName: id
@@ -1024,6 +1025,11 @@ Resources:
 
   rDynamoOctagonDatasets:
     Type: AWS::DynamoDB::Table
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W28
+            reason: DynamoDB tables require specific names to be compatible with Octagon
     Properties:
       KeySchema:
         - AttributeName: name
@@ -1044,6 +1050,11 @@ Resources:
 
   rDynamoOctagonArtifacts:
     Type: AWS::DynamoDB::Table
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W28
+            reason: DynamoDB tables require specific names to be compatible with Octagon
     Properties:
       KeySchema:
         - AttributeName: id
@@ -1116,6 +1127,11 @@ Resources:
 
   rDynamoOctagonMetrics:
     Type: AWS::DynamoDB::Table
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W28
+            reason: DynamoDB tables require specific names to be compatible with Octagon
     Properties:
       KeySchema:
         - AttributeName: root
@@ -1172,6 +1188,11 @@ Resources:
 
   rDynamoOctagonConfiguration:
     Type: AWS::DynamoDB::Table
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W28
+            reason: DynamoDB tables require specific names to be compatible with Octagon
     Properties:
       KeySchema:
         - AttributeName: key
@@ -1201,6 +1222,11 @@ Resources:
 
   rDynamoOctagonTeams:
     Type: AWS::DynamoDB::Table
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W28
+            reason: DynamoDB tables require specific names to be compatible with Octagon
     Properties:
       KeySchema:
         - AttributeName: team
@@ -1221,6 +1247,11 @@ Resources:
 
   rDynamoOctagonPipelines:
     Type: AWS::DynamoDB::Table
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W28
+            reason: DynamoDB tables require specific names to be compatible with Octagon
     Properties:
       KeySchema:
         - AttributeName: name
@@ -1241,6 +1272,11 @@ Resources:
 
   rDynamoOctagonEvents:
     Type: AWS::DynamoDB::Table
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W28
+            reason: DynamoDB tables require specific names to be compatible with Octagon
     Properties:
       KeySchema:
         - AttributeName: id
@@ -1297,6 +1333,11 @@ Resources:
 
   rDynamoOctagonExecutionHistory:
     Type: AWS::DynamoDB::Table
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W28
+            reason: DynamoDB tables require specific names to be compatible with Octagon
     Properties:
       KeySchema:
         - AttributeName: id
@@ -1389,6 +1430,11 @@ Resources:
 
   rDynamoOctagonSchemas:
     Type: AWS::DynamoDB::Table
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W28
+            reason: DynamoDB tables require specific names to be compatible with Octagon
     Properties:
       KeySchema:
         - AttributeName: name
@@ -1412,6 +1458,11 @@ Resources:
 
   rDynamoOctagonManifests:
     Type: AWS::DynamoDB::Table
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W28
+            reason: DynamoDB tables require specific names to be compatible with Octagon
     Properties:
       KeySchema:
         - AttributeName: dataset_name

--- a/sdlf-foundations/template.yaml
+++ b/sdlf-foundations/template.yaml
@@ -299,6 +299,71 @@ Resources:
       Description: Lake Formation Data Access Role
 
   ######## S3 #########
+  ####### Access Logging Bucket ######
+  rS3AccessLogsBucket:
+    Type: AWS::S3::Bucket
+    UpdateReplacePolicy: Retain
+    DeletionPolicy: Retain
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W35
+            reason: Access logs bucket should not have logging enabled https://docs.aws.amazon.com/AmazonS3/latest/userguide/enable-server-access-logging.html
+    Properties:
+      BucketName:
+        !If [
+          UseCustomBucketPrefix,
+          !Sub "${pCustomBucketPrefix}-s3-access-logs",
+          !Sub "${pOrganizationName}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}-s3-access-logs",
+        ]
+      LifecycleConfiguration:
+        Rules:
+          - Id: InfrequentAccess
+            Status: Enabled
+            Transitions:
+              - TransitionInDays: 30
+                StorageClass: STANDARD_IA
+          - Id: DeepArchive
+            Status: Enabled
+            Transitions:
+              - TransitionInDays: 60
+                StorageClass: DEEP_ARCHIVE
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: AES256
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: True
+        BlockPublicPolicy: True
+        IgnorePublicAcls: True
+        RestrictPublicBuckets: True
+
+  rS3AccessLogsBucketPolicy:
+    Type: AWS::S3::BucketPolicy
+    Properties:
+      Bucket: !Ref rS3AccessLogsBucket
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Action:
+              - s3:PutObject
+            Effect: Allow
+            Principal:
+              Service: logging.s3.amazonaws.com
+            Resource:
+              - !Sub arn:${AWS::Partition}:s3:::${rS3AccessLogsBucket}/*
+              - !Sub arn:${AWS::Partition}:s3:::${rS3AccessLogsBucket}
+            Condition:
+              ArnLike:
+                "aws:SourceArn":
+                  !If [
+                    UseCustomBucketPrefix,
+                    !Sub "arn:${AWS::Partition}:s3:::${pCustomBucketPrefix}*",
+                    !Sub "arn:${AWS::Partition}:s3:::${pOrganizationName}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}*",
+                  ]
+              StringEquals:
+                "aws:SourceAccount": !Sub ${AWS::AccountId}
+
   ####### S3 Buckets #########
   rLakeFormationDataAccessRolePolicy:
     Type: AWS::IAM::Policy
@@ -360,6 +425,14 @@ Resources:
           !Sub "${pCustomBucketPrefix}-artifactory",
           !Sub "${pOrganizationName}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}-artifactory",
         ]
+      LoggingConfiguration:
+        DestinationBucketName: !Ref rS3AccessLogsBucket
+        LogFilePrefix:
+          !If [
+            UseCustomBucketPrefix,
+            !Sub "${pCustomBucketPrefix}-artifactory",
+            !Sub "${pOrganizationName}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}-artifactory",
+          ]
       BucketEncryption:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:
@@ -400,6 +473,14 @@ Resources:
           !Ref pCustomBucketPrefix,
           !Sub "${pOrganizationName}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}",
         ]
+      LoggingConfiguration:
+        DestinationBucketName: !Ref rS3AccessLogsBucket
+        LogFilePrefix:
+          !If [
+            UseCustomBucketPrefix,
+            !Ref pCustomBucketPrefix,
+            !Sub "${pOrganizationName}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}",
+          ]
       BucketEncryption:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:
@@ -454,6 +535,14 @@ Resources:
           !Sub "${pCustomBucketPrefix}-raw",
           !Sub "${pOrganizationName}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}-raw",
         ]
+      LoggingConfiguration:
+        DestinationBucketName: !Ref rS3AccessLogsBucket
+        LogFilePrefix:
+          !If [
+            UseCustomBucketPrefix,
+            !Sub "${pCustomBucketPrefix}-raw",
+            !Sub "${pOrganizationName}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}-raw",
+          ]
       BucketEncryption:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:
@@ -508,6 +597,14 @@ Resources:
           !Sub "${pCustomBucketPrefix}-stage",
           !Sub "${pOrganizationName}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}-stage",
         ]
+      LoggingConfiguration:
+        DestinationBucketName: !Ref rS3AccessLogsBucket
+        LogFilePrefix:
+          !If [
+            UseCustomBucketPrefix,
+            !Sub "${pCustomBucketPrefix}-stage",
+            !Sub "${pOrganizationName}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}-stage",
+          ]
       BucketEncryption:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:
@@ -562,6 +659,14 @@ Resources:
           !Sub "${pCustomBucketPrefix}-analytics",
           !Sub "${pOrganizationName}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}-analytics",
         ]
+      LoggingConfiguration:
+        DestinationBucketName: !Ref rS3AccessLogsBucket
+        LogFilePrefix:
+          !If [
+            UseCustomBucketPrefix,
+            !Sub "${pCustomBucketPrefix}-analytics",
+            !Sub "${pOrganizationName}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}-analytics",
+          ]
       BucketEncryption:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:
@@ -614,6 +719,14 @@ Resources:
           !Sub "${pCustomBucketPrefix}-athena",
           !Sub "${pOrganizationName}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}-athena",
         ]
+      LoggingConfiguration:
+        DestinationBucketName: !Ref rS3AccessLogsBucket
+        LogFilePrefix:
+          !If [
+            UseCustomBucketPrefix,
+            !Sub "${pCustomBucketPrefix}-athena",
+            !Sub "${pOrganizationName}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}-athena",
+          ]
       BucketEncryption:
         ServerSideEncryptionConfiguration:
           - ServerSideEncryptionByDefault:


### PR DESCRIPTION
*Description of changes:*

W12 IAM policy should not allow * resource
suppressed - Condition Applied to restrict access, and the KMS keys do not exist at this stage

W28 Resource found with an explicit name
suppressed for Octagon tables - these names are required for compatibility with Octagon
rDataLakeAdminRole no longer has an explicit name defined - although we should reassess if the role is needed at all really

W58 Lambda functions require permission to write CloudWatch Logs
fixed by reorganising the permissions

W35 S3 access logging
added access-logs bucket


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
