### PR TITLE
store the aws-sam-cli zip in s3 when setting up sdlf

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -185,6 +185,8 @@ devops_account () {
     done
 
     aws --region "$REGION" --profile "$DEVOPS_AWS_PROFILE" s3api put-object --bucket "$ARTIFACTS_BUCKET" --key sam-translate.py --body "$DIRNAME"/sdlf-cicd/sam-translate.py
+    curl -L -O --output-dir "$DIRNAME"/sdlf-cicd/ https://github.com/aws/aws-sam-cli/releases/latest/download/aws-sam-cli-linux-x86_64.zip
+    aws --region "$REGION" --profile "$DEVOPS_AWS_PROFILE" s3api put-object --bucket "$ARTIFACTS_BUCKET" --key aws-sam-cli-linux-x86_64.zip --body "$DIRNAME"/sdlf-cicd/aws-sam-cli-linux-x86_64.zip
 
     exit
 }

--- a/sdlf-cicd/nested-stacks/template-cicd-cfn-module.yaml
+++ b/sdlf-cicd/nested-stacks/template-cicd-cfn-module.yaml
@@ -168,7 +168,7 @@ Resources:
               commands:
                 - |-
                     pip3 uninstall -y aws-sam-cli
-                    curl -L -O https://github.com/aws/aws-sam-cli/releases/latest/download/aws-sam-cli-linux-x86_64.zip \
+                    aws s3api get-object --bucket "$ARTIFACTS_BUCKET" --key aws-sam-cli-linux-x86_64.zip aws-sam-cli-linux-x86_64.zip \
                     && unzip -q aws-sam-cli-linux-x86_64.zip -d sam-installation
                     ./sam-installation/install \
                     && sam --version


### PR DESCRIPTION
*Description of changes:*
Store the aws-sam-cli zip in s3 when initially setting up SDLF.

This is to avoid hitting GitHub way too many times when building CloudFormation modules. It's not perfect, as new versions of the SAM cli won't be picked up without re-running `deploy.sh`.

CodeArtifact may also be a better fit for this now that it allows uploading generic files such as zip archives. This may happen in the near future.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
