### PR TITLE
Codebuild awscli version

### DIFF
--- a/sdlf-cicd/template-cicd-sdlf-repositories.yaml
+++ b/sdlf-cicd/template-cicd-sdlf-repositories.yaml
@@ -1286,6 +1286,12 @@ Resources:
         BuildSpec: |
           version: 0.2
           phases:
+            install:
+              commands:
+                - |-
+                    aws --version # version 1 installed using pip by codebuild
+                    pip3 uninstall -y awscli
+                    aws --version # version 2
             build:
               commands:
                 - aws cloudformation package --template "$TEMPLATE" --s3-bucket $ARTIFACTS_BUCKET --s3-prefix codebuild --output-template-file packaged-template.yaml


### PR DESCRIPTION
CodeBuild images have both awscli 1 and awscli 2 - remove awscli 1 (via pip) to make sure version 2 is used


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
