### PR TITLE
use sdlf-main-{domain}-{team} naming scheme instead of sdlf-{domain}-{team}-main

### DIFF
--- a/sdlf-cicd/template-cicd-sdlf-repositories.yaml
+++ b/sdlf-cicd/template-cicd-sdlf-repositories.yaml
@@ -917,7 +917,7 @@ Resources:
                   - codecommit:UploadArchive
                   - codecommit:AssociateApprovalRuleTemplateWithRepository
                   - codecommit:CreateApprovalRuleTemplate
-              - Resource: !Sub arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-*-main
+              - Resource: !Sub arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-main-*
                 Effect: Allow
                 Action:
                   - codecommit:CreateRepository

--- a/sdlf-cicd/template-cicd-team.yaml
+++ b/sdlf-cicd/template-cicd-team.yaml
@@ -64,7 +64,7 @@ Resources:
       #     Bucket:
       #     Key: zip
       RepositoryDescription: !Sub ${pDomain} ${pTeamName} main repository
-      RepositoryName: !Sub sdlf-${pDomain}-${pTeamName}-main
+      RepositoryName: !Sub sdlf-main-${pDomain}-${pTeamName}
 
   rTeamMainCodePipelineRole:
     Type: AWS::IAM::Role


### PR DESCRIPTION
*Description of changes:*
Team repository naming scheme

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
