### PR TITLE
Python 3.11 as default for CodeBuild runtimes. Also update Codebuild image to latest AmazonLinux2

### DIFF
--- a/sdlf-cicd/nested-stacks/template-cicd-cfn-module.yaml
+++ b/sdlf-cicd/nested-stacks/template-cicd-cfn-module.yaml
@@ -158,7 +158,7 @@ Resources:
             Type: PLAINTEXT
             Value: !Ref pArtifactsBucket
         ComputeType: BUILD_GENERAL1_SMALL
-        Image: aws/codebuild/amazonlinux2-x86_64-standard:4.0
+        Image: aws/codebuild/amazonlinux2-x86_64-standard:5.0
         Type: LINUX_CONTAINER
       QueuedTimeoutInMinutes: 60
       ServiceRole: !Ref rBuildCloudformationModuleRole
@@ -168,7 +168,7 @@ Resources:
           phases:
             install:
               runtime-versions:
-                python: 3.9
+                python: 3.11
               commands:
                 - |-
                     pip3 uninstall -y aws-sam-cli

--- a/sdlf-cicd/nested-stacks/template-cicd-lambda-layer.yaml
+++ b/sdlf-cicd/nested-stacks/template-cicd-lambda-layer.yaml
@@ -79,7 +79,7 @@ Resources:
             Type: PLAINTEXT
             Value: !Ref AWS::Partition
         ComputeType: BUILD_GENERAL1_SMALL
-        Image: aws/codebuild/amazonlinux2-x86_64-standard:4.0
+        Image: aws/codebuild/amazonlinux2-x86_64-standard:5.0
         Type: LINUX_CONTAINER
       QueuedTimeoutInMinutes: 60
       ServiceRole: !GetAtt rLambdaLayersCodeBuildServiceRole.Arn
@@ -92,7 +92,7 @@ Resources:
           phases:
             install:
               runtime-versions:
-                  python: 3.9
+                  python: 3.11
               commands:
                 - |-
                     aws --version # version 1 installed using pip by codebuild

--- a/sdlf-cicd/template-cicd-sdlf-repositories.yaml
+++ b/sdlf-cicd/template-cicd-sdlf-repositories.yaml
@@ -1072,7 +1072,7 @@ Resources:
       EncryptionKey: !Ref pKMSKey
       Environment:
         ComputeType: BUILD_GENERAL1_SMALL
-        Image: aws/codebuild/amazonlinux2-x86_64-standard:4.0
+        Image: aws/codebuild/amazonlinux2-x86_64-standard:5.0
         Type: LINUX_CONTAINER
         EnvironmentVariables:
           - Name: ARTIFACTS_BUCKET
@@ -1164,7 +1164,7 @@ Resources:
             Type: PLAINTEXT
             Value: !Ref pDatalakeLibsLambdaLayerName
         ComputeType: BUILD_GENERAL1_SMALL
-        Image: aws/codebuild/amazonlinux2-x86_64-standard:4.0
+        Image: aws/codebuild/amazonlinux2-x86_64-standard:5.0
         Type: LINUX_CONTAINER
       QueuedTimeoutInMinutes: 60
       ServiceRole: !GetAtt rLambdaLayersCodeBuildServiceRole.Arn
@@ -1174,7 +1174,7 @@ Resources:
           phases:
             install:
               runtime-versions:
-                python: 3.9
+                python: 3.11
             build:
               commands:
                 - ls && echo "-----> making artifactory directory"

--- a/sdlf-cicd/template-codecommit-pr-check.yaml
+++ b/sdlf-cicd/template-codecommit-pr-check.yaml
@@ -191,7 +191,7 @@ Resources:
       EncryptionKey: !Ref pKMSKeyArn
       Environment:
         ComputeType: BUILD_GENERAL1_SMALL
-        Image: aws/codebuild/amazonlinux2-x86_64-standard:4.0
+        Image: aws/codebuild/amazonlinux2-x86_64-standard:5.0
         Type: LINUX_CONTAINER
       ServiceRole: !GetAtt rCodeBuildRole.Arn
       Source:
@@ -202,7 +202,7 @@ Resources:
           phases:
             install:
               runtime-versions:
-                  python: 3.9
+                  python: 3.11
             pre_build:
               on-failure: ABORT
               commands:


### PR DESCRIPTION
Python 3.11 as default for CodeBuild runtimes. Also update Codebuild image to latest AmazonLinux2

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
