### PR TITLE
Python 3.11 as default for Lambda functions

### DIFF
--- a/.github/workflows/static-checking.yml
+++ b/.github/workflows/static-checking.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python 3.9
+      - name: Set up Python 3.11
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: 3.11
       - name: install requirements
         run: |
           python -m pip install --upgrade pip

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,2 @@
-sphinx==5.2.3
+sphinx==5.3.0
 sphinx_bootstrap_theme==0.8.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.black]
-target-version = ["py39", "py310"]
+target-version = ["py311"]
 line-length = 120
 extend-exclude = '''
 (
@@ -14,10 +14,10 @@ ignore = ["PLR0912", "PLR0913", "PLR0915"]
 fixable = ["I001"]
 extend-exclude = ["sdlf-stage-dataquality/scripts/deequ", "sdlf-utils"]
 line-length = 120
-target-version = "py39"
+target-version = "py311"
 
 [tool.pylint.main]
-py-version = "3.9"
+py-version = "3.11"
 ignore-paths = ["^/sdlf-stage-dataquality/scripts/deequ/", "^/sdlf-utils/"]
 jobs = 0
 

--- a/sdlf-cicd/template-cicd-sdlf-repositories.yaml
+++ b/sdlf-cicd/template-cicd-sdlf-repositories.yaml
@@ -470,7 +470,7 @@ Resources:
       Handler: lambda_function.lambda_handler
       MemorySize: 128
       Role: !GetAtt rStagesRepositoriesLambdaRole.Arn
-      Runtime: python3.9
+      Runtime: python3.11
       Timeout: 300
       Environment:
         Variables:
@@ -977,7 +977,7 @@ Resources:
       Handler: lambda_function.lambda_handler
       MemorySize: 256
       Role: !GetAtt rMainRepositoryLambdaRole.Arn
-      Runtime: python3.9
+      Runtime: python3.11
       Timeout: 450
       Environment:
         Variables:
@@ -991,7 +991,7 @@ Resources:
       Handler: lambda_function.lambda_handler
       MemorySize: 256
       Role: !GetAtt rMainRepositoryLambdaRole.Arn
-      Runtime: python3.9
+      Runtime: python3.11
       Timeout: 450
       Environment:
         Variables:
@@ -1007,7 +1007,7 @@ Resources:
       Handler: lambda_function.lambda_handler
       MemorySize: 256
       Role: !GetAtt rMainRepositoryLambdaRole.Arn
-      Runtime: python3.9
+      Runtime: python3.11
       Timeout: 450
       Environment:
         Variables:
@@ -1190,7 +1190,7 @@ Resources:
                         AWS_SESSION_TOKEN=$(echo "$temp_role" | jq .Credentials.SessionToken | xargs)
                         export AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
 
-                        layer=$(aws lambda publish-layer-version --layer-name sdlf-$LAYER_NAME --description "Contains the latest version of datalake_library" --compatible-runtimes "python3.9" --zip-file fileb://./artifacts/datalake_library.zip)
+                        layer=$(aws lambda publish-layer-version --layer-name sdlf-$LAYER_NAME --description "Contains the latest version of datalake_library" --compatible-runtimes "python3.11" --zip-file fileb://./artifacts/datalake_library.zip)
                         latest_layer_version=$(echo $layer | jq -r .LayerVersionArn)
                         aws ssm put-parameter --name "/SDLF/Lambda/LatestDatalakeLibraryLayer" --value $latest_layer_version --type String --overwrite
                     done

--- a/sdlf-cicd/template-codecommit-pr-check.yaml
+++ b/sdlf-cicd/template-codecommit-pr-check.yaml
@@ -110,7 +110,7 @@ Resources:
       Role: !GetAtt rPullRequestLambdaRole.Arn
       TracingConfig:
         Mode: Active
-      Runtime: "python3.9"
+      Runtime: python3.11
       Timeout: 10
       Code:
         ZipFile: |
@@ -361,7 +361,7 @@ Resources:
       Role: !GetAtt rCodeBuildResultFunctionLambdaRole.Arn
       TracingConfig:
         Mode: Active
-      Runtime: "python3.9"
+      Runtime: python3.11
       Timeout: 10
       Code:
         ZipFile: |

--- a/sdlf-cicd/template-lambda-layer.yaml
+++ b/sdlf-cicd/template-lambda-layer.yaml
@@ -29,7 +29,7 @@ Resources:
       Type: AWS::Lambda::LayerVersion
       Properties:
         CompatibleRuntimes:
-          - python3.9
+          - python3.11
         Content:
           S3Bucket: !Ref pArtifactsBucket
           S3Key: !Sub layers/${pDomain}/${pEnvironment}/${pTeamName}/${LayerName}.zip

--- a/sdlf-datalakeLibrary/python/datalake_library/requirements.txt
+++ b/sdlf-datalakeLibrary/python/datalake_library/requirements.txt
@@ -1,8 +1,8 @@
-boto3==1.24.84
-botocore==1.27.84
-pytest==7.1.3
-pytest-mock==3.9.0
+boto3==1.28.19
+botocore==1.31.19
+pytest==7.4.0
+pytest-mock==3.11.1
 python-dateutil==2.8.2
-pytest-cov==4.0.0
-mock==4.0.3
-coverage==6.5.0
+pytest-cov==4.1.0
+mock==5.1.0
+coverage==7.2.0

--- a/sdlf-foundations/template.yaml
+++ b/sdlf-foundations/template.yaml
@@ -63,7 +63,7 @@ Conditions:
 
 Globals:
   Function:
-    Runtime: python3.9
+    Runtime: python3.11
     Handler: lambda_function.lambda_handler
     KmsKeyArn: !GetAtt rKMSKey.Arn
 

--- a/sdlf-monitoring/template.yaml
+++ b/sdlf-monitoring/template.yaml
@@ -146,7 +146,7 @@ Resources:
   rSNSTopicSubscriptionLambda:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: python3.9
+      Runtime: python3.11
       Handler: lambda_function.lambda_handler
       KmsKeyArn: !Ref KMSKeyId
       CodeUri: ./lambda/topic/src

--- a/sdlf-stage-dataquality/template.yaml
+++ b/sdlf-stage-dataquality/template.yaml
@@ -66,7 +66,7 @@ Conditions:
 
 Globals:
   Function:
-    Runtime: python3.9
+    Runtime: python3.11
     Handler: lambda_function.lambda_handler
     KmsKeyArn: !Ref pKMSKeyId
 

--- a/sdlf-stageA/template.yaml
+++ b/sdlf-stageA/template.yaml
@@ -101,7 +101,7 @@ Conditions:
 
 Globals:
   Function:
-    Runtime: python3.9
+    Runtime: python3.11
     Handler: lambda_function.lambda_handler
     Layers:
       - "{{resolve:ssm:/SDLF/Lambda/LatestDatalakeLibraryLayer}}"

--- a/sdlf-stageB/template.yaml
+++ b/sdlf-stageB/template.yaml
@@ -97,7 +97,7 @@ Conditions:
 
 Globals:
   Function:
-    Runtime: python3.9
+    Runtime: python3.11
     Handler: lambda_function.lambda_handler
     Layers:
       - "{{resolve:ssm:/SDLF/Lambda/LatestDatalakeLibraryLayer}}"

--- a/sdlf-team/template.yaml
+++ b/sdlf-team/template.yaml
@@ -550,7 +550,7 @@ Resources:
       Handler: index.lambda_handler
       MemorySize: 192
       Role: !GetAtt rDatasetsDynamodbLambdaRole.Arn
-      Runtime: python3.9
+      Runtime: python3.11
       Timeout: 300
       Environment:
         Variables:
@@ -728,7 +728,7 @@ Resources:
       Handler: index.lambda_handler
       MemorySize: 192
       Role: !GetAtt rPipelinesDynamodbLambdaRole.Arn
-      Runtime: python3.9
+      Runtime: python3.11
       Timeout: 300
       Environment:
         Variables:

--- a/sdlf-utils/ingestion-examples/cdc/dms-replication/template.yaml
+++ b/sdlf-utils/ingestion-examples/cdc/dms-replication/template.yaml
@@ -191,7 +191,7 @@ Resources:
       Handler: index.handler
       Role:
         Fn::GetAtt: [rExecutionRole, Arn]
-      Runtime: python3.9
+      Runtime: python3.11
 
   rLambdaFunctionInitDMS:
     Type: AWS::Lambda::Function
@@ -310,7 +310,7 @@ Resources:
       Handler: index.handler
       Role:
         Fn::GetAtt: [rExecutionRole, Arn]
-      Runtime: python3.9
+      Runtime: python3.11
 
   ######## SSM #########
   rReplicationInstanceSsm:

--- a/sdlf-utils/pipeline-examples/cloudfront/template.yaml
+++ b/sdlf-utils/pipeline-examples/cloudfront/template.yaml
@@ -102,7 +102,7 @@ Conditions:
 
 Globals:
   Function:
-    Runtime: python3.9
+    Runtime: python3.11
     Handler: lambda_function.lambda_handler
     Layers:
       - !Ref pDatalakeLibLayer

--- a/sdlf-utils/pipeline-examples/dataset-dependency/stageA/template.yaml
+++ b/sdlf-utils/pipeline-examples/dataset-dependency/stageA/template.yaml
@@ -97,7 +97,7 @@ Conditions:
 
 Globals:
   Function:
-    Runtime: python3.9
+    Runtime: python3.11
     Handler: lambda_function.lambda_handler
     Layers:
       - !Ref pDatalakeLibLayer

--- a/sdlf-utils/pipeline-examples/manifests/stageA/template.yaml
+++ b/sdlf-utils/pipeline-examples/manifests/stageA/template.yaml
@@ -97,7 +97,7 @@ Conditions:
 
 Globals:
   Function:
-    Runtime: python3.9
+    Runtime: python3.11
     Handler: lambda_function.lambda_handler
     Layers:
       - !Ref pDatalakeLibLayer

--- a/sdlf-utils/pipeline-examples/manifests/stageB/template.yaml
+++ b/sdlf-utils/pipeline-examples/manifests/stageB/template.yaml
@@ -97,7 +97,7 @@ Conditions:
 
 Globals:
   Function:
-    Runtime: python3.9
+    Runtime: python3.11
     Handler: lambda_function.lambda_handler
     Layers:
       - !Ref pDatalakeLibLayer

--- a/sdlf-utils/pipeline-examples/topic-modelling/pipLibraries/LangDetect/requirements.txt
+++ b/sdlf-utils/pipeline-examples/topic-modelling/pipLibraries/LangDetect/requirements.txt
@@ -1,2 +1,2 @@
-langdetect==1.0.8
-six==1.15.0
+langdetect==1.0.9
+six==1.16.0

--- a/sdlf-utils/pipeline-examples/topic-modelling/stageA/template.yaml
+++ b/sdlf-utils/pipeline-examples/topic-modelling/stageA/template.yaml
@@ -100,7 +100,7 @@ Conditions:
 
 Globals:
   Function:
-    Runtime: python3.9
+    Runtime: python3.11
     Handler: lambda_function.lambda_handler
     Layers:
       - !Ref pDatalakeLibLayer

--- a/sdlf-utils/pipeline-examples/topic-modelling/stageB/template.yaml
+++ b/sdlf-utils/pipeline-examples/topic-modelling/stageB/template.yaml
@@ -100,7 +100,7 @@ Conditions:
 
 Globals:
   Function:
-    Runtime: python3.9
+    Runtime: python3.11
     Handler: lambda_function.lambda_handler
     Layers:
       - !Ref pDatalakeLibLayer


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Python 3.11 as default for Lambda functions


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
