### PR TITLE
Enforce the use of aws-cli >= 2.13.0

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -208,6 +208,16 @@ do
 done
 
 # crossaccount-cicd-roles, devops-account
+# check aws-cli version is recent enough
+if (echo aws-cli/2.13.0; aws --version | cut -d' ' -f1) | sort -V | tail -1 | grep -Fv "aws-cli/2.13.0"
+then
+  echo "aws-cli >= 2.13.0, deployment can start"
+else
+  echo "SDLF requires aws-cli >= 2.13.0"
+  echo "https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html"
+  exit 1
+fi
+
 if [ "${1#-}" = "$1" ]
 then
     subcommand=$1


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Older versions do not handle AWS::CodeCommit::Repository Code property with aws cloudformation package.

Remove aws-sam-cli zip archive after upload to s3 to avoid making sdlf-cicd too big to be pushed to codecommit by cloudformation package this only happens in some circumstances, but might as well do this to never have the issue


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
