### PR TITLE
Configurable lambda stageA is now configurable through dynamodb

### DIFF
--- a/sdlf-stageA/lambda/stage-a-preupdate-metadata/src/lambda_function.py
+++ b/sdlf-stageA/lambda/stage-a-preupdate-metadata/src/lambda_function.py
@@ -1,9 +1,33 @@
+import os
+
 from datalake_library import octagon
 from datalake_library.commons import init_logger
 from datalake_library.configuration.resource_configs import DynamoConfiguration
 from datalake_library.interfaces.dynamo_interface import DynamoInterface
 
 logger = init_logger(__name__)
+
+
+def get_lambda_transform_details(team, dataset, pipeline, stage):
+    dynamo_config = DynamoConfiguration()
+    dynamo_interface = DynamoInterface(dynamo_config)
+    transform_info = dynamo_interface.get_transform_table_item(f"{team}-{dataset}")
+    lambda_arn = os.getenv("STAGE_TRANSFORM_LAMBDA")
+    logger.info(f"Pipeline is {pipeline}, stage is {stage}")
+    if pipeline in transform_info.get("pipeline", {}):
+        if stage in transform_info["pipeline"][pipeline]:
+            logger.info(
+                f"Details from DynamoDB: {transform_info['pipeline'][pipeline][stage]}"
+            )
+            lambda_arn = transform_info["pipeline"][pipeline][stage].get(
+                "lambda_arn", lambda_arn
+            )
+    #######################################################
+    # We assume a Lambda function has already been created based on
+    # customer needs.
+    #######################################################
+
+    return {"lambda_arn": lambda_arn}
 
 
 def lambda_handler(event, context):
@@ -18,18 +42,22 @@ def lambda_handler(event, context):
     """
     try:
         logger.info("Fetching event data from previous step")
+        team = event["team"]
+        pipeline = event["pipeline"]
         stage = event["pipeline_stage"]
+        dataset = event["dataset"]
 
         logger.info("Initializing Octagon client")
         component = context.function_name.split("-")[-2].title()
         octagon_client = (
-            octagon.OctagonClient().with_run_lambda(True).with_configuration_instance(event["env"]).build()
+            octagon.OctagonClient()
+            .with_run_lambda(True)
+            .with_configuration_instance(event["env"])
+            .build()
         )
         event["peh_id"] = octagon_client.start_pipeline_execution(
-            pipeline_name="{}-{}-{}".format(
-                event["team"], event["pipeline"], stage
-            ),
-            dataset_name="{}-{}".format(event["team"], event["dataset"]),
+            pipeline_name="{}-{}-{}".format(team, pipeline, stage),
+            dataset_name="{}-{}".format(team, dataset),
             comment=event,
         )
         # Add business metadata (e.g. event['project'] = 'xyz')
@@ -45,10 +73,15 @@ def lambda_handler(event, context):
         octagon_client.update_pipeline_execution(
             status="{} {} Processing".format(stage, component), component=component
         )
+
+        event["lambda"] = get_lambda_transform_details(
+            team, dataset, pipeline, stage
+        )  # custom user code called
     except Exception as e:
         logger.error("Fatal error", exc_info=True)
         octagon_client.end_pipeline_execution_failed(
-            component=component, issue_comment="{} {} Error: {}".format(stage, component, repr(e))
+            component=component,
+            issue_comment="{} {} Error: {}".format(stage, component, repr(e)),
         )
         raise e
     return {"statusCode": 200, "body": event}

--- a/sdlf-stageA/state-machine/stage-a.asl.json
+++ b/sdlf-stageA/state-machine/stage-a.asl.json
@@ -37,7 +37,7 @@
               "OutputPath": "$.Payload",
               "Parameters": {
                 "Payload.$": "$",
-                "FunctionName": "${lStep2}:$LATEST"
+                "FunctionName.$": "$.body.lambda.lambda_arn"
               },
               "Retry": [
                 {

--- a/sdlf-stageA/template.yaml
+++ b/sdlf-stageA/template.yaml
@@ -427,6 +427,9 @@ Resources:
       CodeUri: ./lambda/stage-a-preupdate-metadata/src
       FunctionName: !Sub sdlf-${pTeamName}-${pPipeline}-preupdate-a
       Description: Pre-Update the metadata in the DynamoDB Catalog table
+      Environment:
+        Variables:
+          STAGE_TRANSFORM_LAMBDA: !GetAtt rLambdaStep2.Arn
       MemorySize: 128
       Timeout: 300
       Role: !GetAtt rRoleLambdaExecutionStep1.Arn
@@ -667,7 +670,6 @@ Resources:
       DefinitionUri: ./state-machine/stage-a.asl.json
       DefinitionSubstitutions:
         lStep1: !GetAtt rLambdaStep1.Arn
-        lStep2: !GetAtt rLambdaStep2.Arn
         lStep3: !GetAtt rLambdaStep3.Arn
         lError: !GetAtt rLambdaErrorStep.Arn
       Role: !GetAtt rStatesExecutionRole.Arn


### PR DESCRIPTION
*Description of changes:*
The lambda used in stageA is now configurable through dynamodb using `pPipelineDetails` when deploying a dataset:
```
  rLegislators:
    Type: awslabs::sdlf::dataset::MODULE
    Properties:
      pPipelineReference: !Ref pPipelineReference
      pTeamName: engineering
      pDatasetName: legislators
      pPipelineDetails: >-
        {
          "main": {
            "A": {
              "lambda_arn": "arn:aws:lambda:us-west-1:111111111111:function:sdlf-engineering-main-custom-a"
            },
            "B": {
              "glue_capacity": {
                "NumberOfWorkers": 12,
                "WorkerType": "G.1X"
              },
              "glue_extra_arguments": {
                "--enable-auto-scaling": "true"
              }
            }
          }
        }
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
