### PR TITLE
StageB: configurable glue job name through dynamodb

### DIFF
--- a/sdlf-cicd/template-cicd-sdlf-repositories.yaml
+++ b/sdlf-cicd/template-cicd-sdlf-repositories.yaml
@@ -902,6 +902,7 @@ Resources:
                   - iam:PassRole
                 Resource:
                   - !Sub arn:${AWS::Partition}:iam::*:role/sdlf-cicd-team-*
+                  - !Sub arn:${AWS::Partition}:iam::*:role/sdlf-cicd-domain
               - Effect: Allow
                 Action:
                   - iam:AttachRolePolicy


### PR DESCRIPTION
*Description of changes:*
The glue job used in stageB is now configurable through dynamodb, using pPipelineDetails when deploying a dataset. See #199 for more details.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
