### PR TITLE
update GlueVersion from 2.0 to 4.0

### DIFF
--- a/sdlf-stage-dataquality/template.yaml
+++ b/sdlf-stage-dataquality/template.yaml
@@ -422,7 +422,7 @@ Resources:
         "--targetBucketName": !Sub "s3://${pDataQualityBucket}"
       ExecutionProperty:
         MaxConcurrentRuns: 10
-      GlueVersion: "2.0"
+      GlueVersion: "3.0"
       Timeout: 65
       Name: sdlf-data-quality-controller
       Role: !Ref pDataLakeAdminRoleArn
@@ -452,7 +452,7 @@ Resources:
         "--targetBucketName": !Sub "s3://${pDataQualityBucket}"
       ExecutionProperty:
         MaxConcurrentRuns: 10
-      GlueVersion: "2.0"
+      GlueVersion: "4.0"
       MaxCapacity: 3
       MaxRetries: 0
       Timeout: 60
@@ -486,7 +486,7 @@ Resources:
         MaxConcurrentRuns: 10
       MaxRetries: 0
       Timeout: 60
-      GlueVersion: "2.0"
+      GlueVersion: "4.0"
       MaxCapacity: 3
       Name: sdlf-data-quality-analysis-verification-runner
       Role: !Ref pDataLakeAdminRoleArn
@@ -516,7 +516,7 @@ Resources:
         MaxConcurrentRuns: 10
       MaxRetries: 0
       Timeout: 60
-      GlueVersion: "2.0"
+      GlueVersion: "4.0"
       MaxCapacity: 3
       Name: sdlf-data-quality-profile-runner
       Role: !Ref pDataLakeAdminRoleArn

--- a/sdlf-utils/ingestion-examples/cdc/dms-task/template.yaml
+++ b/sdlf-utils/ingestion-examples/cdc/dms-task/template.yaml
@@ -185,8 +185,8 @@ Resources:
       Role: !Sub "{{resolve:ssm:/SDLF/IAM/${pTeamName}/DMSExecutionRoleArn:1}}"
       ExecutionProperty:
         MaxConcurrentRuns: 20
-      AllocatedCapacity: 3
-      GlueVersion: "2.0"
+      MaxCapacity: 3
+      GlueVersion: "4.0"
       Command:
         Name: glueetl
         PythonVersion: "3"
@@ -204,8 +204,8 @@ Resources:
       Role: !Sub "{{resolve:ssm:/SDLF/IAM/${pTeamName}/DMSExecutionRoleArn:1}}"
       ExecutionProperty:
         MaxConcurrentRuns: 20
-      AllocatedCapacity: 3
-      GlueVersion: "2.0"
+      MaxCapacity: 3
+      GlueVersion: "4.0"
       Command:
         Name: glueetl
         PythonVersion: "3"
@@ -222,7 +222,7 @@ Resources:
       Role: !Sub "{{resolve:ssm:/SDLF/IAM/${pTeamName}/DMSExecutionRoleArn:1}}"
       ExecutionProperty:
         MaxConcurrentRuns: 1
-      GlueVersion: "2.0"
+      GlueVersion: "3.0"
       Command:
         Name: "pythonshell"
         PythonVersion: "3.9"

--- a/sdlf-utils/pipeline-examples/datalake-workload-management/sdlf-wlm-integration/demo/scripts/legislators-glue-job.yaml
+++ b/sdlf-utils/pipeline-examples/datalake-workload-management/sdlf-wlm-integration/demo/scripts/legislators-glue-job.yaml
@@ -65,7 +65,7 @@ Resources:
         MaxConcurrentRuns: 3
       MaxRetries: 0
       AllocatedCapacity: 2
-      GlueVersion: "2.0"
+      GlueVersion: "4.0"
       Name: !Sub sdlf-${pTeamName}-${pDatasetName}-glue-job
       SecurityConfiguration: !Sub sdlf-${pTeamName}-glue-security-config
       Role: !Ref rGlueRole

--- a/sdlf-utils/pipeline-examples/glue-jobs-deployer/glue-job.yaml
+++ b/sdlf-utils/pipeline-examples/glue-jobs-deployer/glue-job.yaml
@@ -90,7 +90,7 @@ Resources:
         MaxConcurrentRuns: 10
       MaxRetries: 0
       AllocatedCapacity: !Sub ${pAllocatedCapacity}
-      GlueVersion: '2.0'
+      GlueVersion: "4.0"
       Connections:
         Connections:
         - !Sub 'sdlf-${pTeam}-glue-conn'

--- a/sdlf-utils/pipeline-examples/legislators/scripts/legislators-glue-job.yaml
+++ b/sdlf-utils/pipeline-examples/legislators/scripts/legislators-glue-job.yaml
@@ -66,7 +66,7 @@ Resources:
         MaxConcurrentRuns: 3
       MaxRetries: 0
       MaxCapacity: 2.0
-      GlueVersion: "2.0"
+      GlueVersion: "4.0"
       Name: !Sub sdlf-${pTeamName}-${pDatasetName}-glue-job
       SecurityConfiguration: !Sub sdlf-${pTeamName}-glue-security-config
       Role: !Ref rGlueRole

--- a/sdlf-utils/pipeline-examples/manifests/scripts/weather-glue-job.yaml
+++ b/sdlf-utils/pipeline-examples/manifests/scripts/weather-glue-job.yaml
@@ -64,8 +64,8 @@ Resources:
       ExecutionProperty:
         MaxConcurrentRuns: 3
       MaxRetries: 0
-      AllocatedCapacity: 2
-      GlueVersion: "2.0"
+      MaxCapacity: 2
+      GlueVersion: "4.0"
       Name: !Sub sdlf-${pTeamName}-${pDatasetName}-glue-job
       SecurityConfiguration: !Sub sdlf-${pTeamName}-glue-security-config
       Role: !Ref rGlueRole


### PR DESCRIPTION
*Description of changes:*
Update GlueVersion from 2.0 to 4.0, except for pythonshell jobs (upgraded to 3.0) as 4.0 is not supported yet

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
