### PR TITLE
add optional glue job deployer feature

### DIFF
--- a/sdlf-cicd/lambda/crossaccountteam-cicd/src/lambda_function.py
+++ b/sdlf-cicd/lambda/crossaccountteam-cicd/src/lambda_function.py
@@ -57,6 +57,11 @@ def create_domain_team_role_stack(
                     "ParameterValue": os.getenv("ENABLE_LAMBDA_LAYER_BUILDER"),
                     "UsePreviousValue": False,
                 },
+                {
+                    "ParameterKey": "pEnableGlueJobDeployer",
+                    "ParameterValue": os.getenv("ENABLE_GLUE_JOB_DEPLOYER"),
+                    "UsePreviousValue": False,
+                },
             ],
             Capabilities=[
                 "CAPABILITY_NAMED_IAM",
@@ -102,6 +107,11 @@ def create_domain_team_role_stack(
                     {
                         "ParameterKey": "pEnableLambdaLayerBuilder",
                         "ParameterValue": os.getenv("ENABLE_LAMBDA_LAYER_BUILDER"),
+                        "UsePreviousValue": False,
+                    },
+                    {
+                        "ParameterKey": "pEnableGlueJobDeployer",
+                        "ParameterValue": os.getenv("ENABLE_GLUE_JOB_DEPLOYER"),
                         "UsePreviousValue": False,
                     },
                 ],

--- a/sdlf-cicd/nested-stacks/template-cicd-glue-job.yaml
+++ b/sdlf-cicd/nested-stacks/template-cicd-glue-job.yaml
@@ -1,0 +1,144 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: CICD pipelines to automate SDLF workflows
+
+Parameters:
+  pArtifactsBucket:
+    Description: The artifacts bucket used by CodeBuild and CodePipeline
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: /SDLF/S3/DevOpsArtifactsBucket
+  pKMSKey:
+    Description: The KMS key used by CodeBuild and CodePipeline
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: /SDLF/KMS/CICDKeyId
+
+Resources:
+  rGlueJobCodeBuildServiceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: codebuild.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      Policies:
+        - PolicyName: sdlf-codebuild
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                Resource:
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/sdlf-*
+              - Effect: Allow
+                Action:
+                  - s3:GetBucketAcl
+                  - s3:GetBucketLocation
+                  - s3:GetObject
+                  - s3:GetObjectVersion
+                  - s3:PutObject
+                Resource:
+                  - !Sub arn:${AWS::Partition}:s3:::${pArtifactsBucket}/*
+              - Effect: Allow
+                Action: codecommit:GitPull
+                Resource:
+                  - !Sub arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-*
+              - Effect: Allow
+                Action:
+                  - kms:CreateGrant
+                  - kms:Decrypt
+                  - kms:DescribeKey
+                  - kms:Encrypt
+                  - kms:GenerateDataKey*
+                  - kms:ReEncrypt*
+                Resource:
+                  - !Ref pKMSKey
+
+  rGlueJobPackage:
+    Type: AWS::CodeBuild::Project
+    Properties:
+      Artifacts:
+        Type: CODEPIPELINE
+      Name: sdlf-cicd-build-glue-jobs
+      Description: Prepares Glue jobs for deployment
+      EncryptionKey: !Ref pKMSKey
+      Environment:
+        EnvironmentVariables:
+          - Name: ARTIFACTS_BUCKET
+            Type: PLAINTEXT
+            Value: !Ref pArtifactsBucket
+          - Name: KMS_KEY
+            Type: PLAINTEXT
+            Value: !Ref pKMSKey
+          - Name: AWS_PARTITION
+            Type: PLAINTEXT
+            Value: !Ref AWS::Partition
+        ComputeType: BUILD_GENERAL1_SMALL
+        Image: aws/codebuild/amazonlinux2-x86_64-standard:5.0
+        Type: LINUX_CONTAINER
+      QueuedTimeoutInMinutes: 60
+      ServiceRole: !GetAtt rGlueJobCodeBuildServiceRole.Arn
+      Source:
+        BuildSpec: |
+          version: 0.2
+          env:
+            exported-variables:
+              - TRANSFORMS_CDL
+              - CODEBUILD_RESOLVED_SOURCE_VERSION
+          phases:
+            install:
+              runtime-versions:
+                  python: 3.11
+              commands:
+                - |-
+                    aws --version # version 1 installed using pip by codebuild
+                    pip3 uninstall -y awscli
+                    aws --version # version 2
+                - pip3 install boto3
+            build:
+              commands:
+                - |-
+                    if [ -d "./transforms-$ENVIRONMENT/" ]; then
+                        cd "./transforms-$ENVIRONMENT/" || exit
+                        TRANSFORMS=()
+
+                        echo ">>>>> Beginning build of subdirectories >>>>>"
+                        for dir in ./*/
+                        do
+                            dir=${dir%*/}      # remove the trailing "/"
+                            TRANSFORM_NAME="${dir##*/}"    # print everything after the final "/"
+                            echo "---- Looking to move to: "
+
+                            pushd "$dir" || exit
+                            echo "Moving into dir..."
+                            echo "Current directory contents:"
+                            ls
+                            aws s3api put-object --bucket "$ARTIFACTS_BUCKET" \
+                                                  --key "transforms/$DOMAIN/$ENVIRONMENT/$TEAM/$TRANSFORM_NAME-$CODEBUILD_RESOLVED_SOURCE_VERSION.py" \
+                                                  --body "$TRANSFORM_NAME.py" || exit 1
+                            TRANSFORMS+=("$TRANSFORM_NAME")
+                            popd || exit
+                            echo "============= COMPLETED DIRECTORY BUILD ============="
+                        done
+
+                        # prepare the parameter that will be fed to the cloudformation template containing all glue jobs
+                        printf -v joined "%s," "${TRANSFORMS[@]}"
+                        TRANSFORMS_CDL="${joined%,}"
+                        echo "TRANSFORMS_CDL - $TRANSFORMS_CDL"
+                    fi
+        Type: CODEPIPELINE
+      TimeoutInMinutes: 20
+
+  ######## SSM OUTPUTS #########
+  rGlueJobPackageSsm:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: /SDLF/CodeBuild/PrepareGlueJobPackage
+      Type: String
+      Value: !Ref rGlueJobPackage
+      Description: Name of the CodeBuild job that prepares Glue jobs

--- a/sdlf-cicd/template-cicd-domain-roles.yaml
+++ b/sdlf-cicd/template-cicd-domain-roles.yaml
@@ -646,6 +646,7 @@ Resources:
                   - !Sub arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/sdlf-*-pipelines-*
                   - !Sub arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/sdlf-*-datasets-*
                   - !Sub arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/sdlf-*-lambdalayers-*
+                  - !Sub arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/sdlf-*-gluejobs-*
               - Effect: Allow
                 Action: iam:PassRole
                 Resource:

--- a/sdlf-cicd/template-cicd-domain-team-role.yaml
+++ b/sdlf-cicd/template-cicd-domain-team-role.yaml
@@ -14,6 +14,9 @@ Parameters:
   pEnableLambdaLayerBuilder:
     Description: Add Lambda layer builder infrastructure and pipeline stages
     Type: String
+  pEnableGlueJobDeployer:
+    Description: Add Glue job deployer infrastructure and pipeline stages
+    Type: String
   pDomain:
     Description: Data domain name
     Type: String
@@ -24,6 +27,7 @@ Parameters:
 
 Conditions:
   EnableLambdaLayerBuilder: !Equals [!Ref pEnableLambdaLayerBuilder, true]
+  EnableGlueJobDeployer: !Equals [!Ref pEnableGlueJobDeployer, true]
 
 Resources:
   rTeamCloudFormationRole:
@@ -408,5 +412,55 @@ Resources:
               - lambda:DeleteLayerVersion
             Resource:
               - !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:layer:sdlf-${pTeamName}-*
+      Roles:
+        - !Ref rTeamCloudFormationRole
+
+  rTeamGlueJobsCloudFormationPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Condition: EnableGlueJobDeployer
+    Properties:
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Action:
+              - cloudformation:CreateChangeSet
+            Resource:
+              - !Sub arn:${AWS::Partition}:cloudformation:${AWS::Region}:aws:transform/LanguageExtensions
+          - Effect: Allow
+            Action:
+              - ssm:GetParameter
+              - ssm:GetParameters
+              - ssm:GetParametersByPath
+            Resource:
+              - !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/KMS/KeyArn
+          - Effect: Allow
+            Action:
+              - iam:AttachRolePolicy
+              - iam:DetachRolePolicy
+            Resource:
+              - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/sdlf-${pTeamName}/sdlf-${pTeamName}-*
+            Condition:
+              ArnEquals:
+                "iam:PolicyARN":
+                  - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSGlueServiceRole
+                  - !Sub arn:${AWS::Partition}:iam::aws:policy/AmazonS3FullAccess
+                  - !Sub arn:${AWS::Partition}:iam::aws:policy/CloudWatchLogsFullAccess
+          - Effect: Allow
+            Action:
+              - glue:CreateJob
+              - glue:DeleteJob
+              - glue:TagResource
+              - glue:UntagResource
+            Resource:
+              - !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:job/sdlf-${pTeamName}-*
+          - Effect: Allow
+            Action:
+              - iam:PassRole
+            Resource:
+              - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/sdlf-${pTeamName}/sdlf-${pTeamName}-*
+            Condition:
+              StringEquals:
+                "iam:PassedToService": glue.amazonaws.com
       Roles:
         - !Ref rTeamCloudFormationRole

--- a/sdlf-cicd/template-cicd-prerequisites.yaml
+++ b/sdlf-cicd/template-cicd-prerequisites.yaml
@@ -22,6 +22,14 @@ Resources:
       Value: false
       Description: Add Lambda layer builder infrastructure and pipeline stages
 
+  rGlueJobDeployerFeatureSsm:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: /SDLF/GlueJobDeployer/Enabled
+      Type: String
+      Value: false
+      Description: Add Glue job deployer infrastructure and pipeline stages
+
   ######## KMS #########
   rKMSKey:
     Type: AWS::KMS::Key

--- a/sdlf-cicd/template-cicd-sdlf-repositories.yaml
+++ b/sdlf-cicd/template-cicd-sdlf-repositories.yaml
@@ -52,9 +52,14 @@ Parameters:
     Description: Add Lambda layer builder infrastructure and pipeline stages
     Type: AWS::SSM::Parameter::Value<String>
     Default: /SDLF/LambdaLayerBuilder/Enabled
+  pEnableGlueJobDeployer:
+    Description: Add Glue job deployer infrastructure and pipeline stages
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: /SDLF/GlueJobDeployer/Enabled
 
 Conditions:
   EnableLambdaLayerBuilder: !Equals [!Ref pEnableLambdaLayerBuilder, true]
+  EnableGlueJobDeployer: !Equals [!Ref pEnableGlueJobDeployer, true]
 
 Resources:
   ######## CODECOMMIT #########
@@ -672,6 +677,7 @@ Resources:
                   - !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/CodePipeline/*
                   - !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/CodeBuild/*
                   - !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/LambdaLayerBuilder/Enabled
+                  - !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/GlueJobDeployer/Enabled
                   - !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/CodeCommit/*
               - Effect: Allow
                 Action:
@@ -714,6 +720,7 @@ Resources:
           AWS_PARTITION: !Ref AWS::Partition
           DEVOPS_KMS_KEY: !Ref pKMSKey
           ENABLE_LAMBDA_LAYER_BUILDER: !Ref pEnableLambdaLayerBuilder
+          ENABLE_GLUE_JOB_DEPLOYER: !Ref pEnableGlueJobDeployer
       Code: ./lambda/crossaccountteam-cicd/src
 
   rMainRepositoryTeamLambda:
@@ -946,3 +953,11 @@ Resources:
     DeletionPolicy: Delete
     Properties:
       TemplateURL: ./nested-stacks/template-cicd-lambda-layer.yaml
+
+  rGlueJobDeployerInfrastructure:
+    Type: AWS::CloudFormation::Stack
+    Condition: EnableGlueJobDeployer
+    UpdateReplacePolicy: Delete
+    DeletionPolicy: Delete
+    Properties:
+      TemplateURL: ./nested-stacks/template-cicd-glue-job.yaml

--- a/sdlf-cicd/template-cicd-team.yaml
+++ b/sdlf-cicd/template-cicd-team.yaml
@@ -50,6 +50,10 @@ Parameters:
     Description: Add Lambda layer builder infrastructure and pipeline stages
     Type: AWS::SSM::Parameter::Value<String>
     Default: /SDLF/LambdaLayerBuilder/Enabled
+  pEnableGlueJobDeployer:
+    Description: Add Glue job deployer infrastructure and pipeline stages
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: /SDLF/GlueJobDeployer/Enabled
   pCicdRepository:
     Description: Name of the Cicd repository
     Type: AWS::SSM::Parameter::Value<String>
@@ -89,6 +93,8 @@ Mappings:
 
 Conditions:
   EnableLambdaLayerBuilder: !Equals [!Ref pEnableLambdaLayerBuilder, true]
+  EnableGlueJobDeployer: !Equals [!Ref pEnableGlueJobDeployer, true]
+  EnableOptionalFeatures: !Or [!Condition EnableLambdaLayerBuilder, !Condition EnableGlueJobDeployer]
 
 Resources:
   rTeamMainCodeCommit:
@@ -164,6 +170,10 @@ Resources:
                   - !If
                     - EnableLambdaLayerBuilder
                     - !Sub "arn:${AWS::Partition}:codebuild:${AWS::Region}:${AWS::AccountId}:project/{{resolve:ssm:/SDLF/CodeBuild/BuildLambdaLayersPackage}}"
+                    - !Ref AWS::NoValue
+                  - !If
+                    - EnableGlueJobDeployer
+                    - !Sub "arn:${AWS::Partition}:codebuild:${AWS::Region}:${AWS::AccountId}:project/{{resolve:ssm:/SDLF/CodeBuild/PrepareGlueJobPackage}}"
                     - !Ref AWS::NoValue
         - PolicyName: sdlf-cicd-cloudformation
           PolicyDocument:
@@ -280,75 +290,112 @@ Resources:
                 BranchName: !FindInMap [pCodeCommitBranch, !Ref pEnvironment, branch]
                 PollForSourceChanges: false
               RunOrder: 1
-            - !If
-              - EnableLambdaLayerBuilder
-              - Name: CicdSource
-                ActionTypeId:
-                  Category: Source
-                  Owner: AWS
-                  Provider: CodeCommit
-                  Version: "1"
-                OutputArtifacts:
-                  - Name: CicdTemplateSource
-                Configuration:
-                  RepositoryName: !Ref pCicdRepository
-                  BranchName:
-                    !FindInMap [pCodeCommitBranch, !Ref pEnvironment, branch]
-                  PollForSourceChanges: false
-                RunOrder: 1
-              - !Ref AWS::NoValue
         - !If
-          - EnableLambdaLayerBuilder
-          - Name: BuildLambdaLayers
+          - EnableOptionalFeatures
+          - Name: BuildOptionalFeatures
             Actions:
-              - Name: Build
-                InputArtifacts:
-                  - Name: TemplateSource
-                Namespace: LambdaLayersVariables
-                ActionTypeId:
-                  Category: Build
-                  Owner: AWS
-                  Version: "1"
-                  Provider: CodeBuild
-                Configuration:
-                  ProjectName: "{{resolve:ssm:/SDLF/CodeBuild/BuildLambdaLayersPackage}}"
-                  EnvironmentVariables: !Sub >-
-                    [{"name":"ENVIRONMENT", "value":"${pEnvironment}", "type":"PLAINTEXT"},
-                    {"name":"DOMAIN", "value":"${pDomain}", "type":"PLAINTEXT"},
-                    {"name":"TEAM", "value":"${pTeamName}", "type":"PLAINTEXT"}]
-                RunOrder: 1
+              - !If
+                - EnableLambdaLayerBuilder
+                - Name: BuildLambdaLayers
+                  InputArtifacts:
+                    - Name: TemplateSource
+                  Namespace: LambdaLayersVariables
+                  ActionTypeId:
+                    Category: Build
+                    Owner: AWS
+                    Version: "1"
+                    Provider: CodeBuild
+                  Configuration:
+                    ProjectName: "{{resolve:ssm:/SDLF/CodeBuild/BuildLambdaLayersPackage}}"
+                    EnvironmentVariables: !Sub >-
+                      [{"name":"ENVIRONMENT", "value":"${pEnvironment}", "type":"PLAINTEXT"},
+                      {"name":"DOMAIN", "value":"${pDomain}", "type":"PLAINTEXT"},
+                      {"name":"TEAM", "value":"${pTeamName}", "type":"PLAINTEXT"}]
+                  RunOrder: 1
+                - !Ref AWS::NoValue
+              - !If
+                - EnableGlueJobDeployer
+                - Name: BuildGlueJobs
+                  InputArtifacts:
+                    - Name: TemplateSource
+                  Namespace: GlueJobVariables
+                  ActionTypeId:
+                    Category: Build
+                    Owner: AWS
+                    Version: "1"
+                    Provider: CodeBuild
+                  Configuration:
+                    ProjectName: "{{resolve:ssm:/SDLF/CodeBuild/PrepareGlueJobPackage}}"
+                    EnvironmentVariables: !Sub >-
+                      [{"name":"ENVIRONMENT", "value":"${pEnvironment}", "type":"PLAINTEXT"},
+                      {"name":"DOMAIN", "value":"${pDomain}", "type":"PLAINTEXT"},
+                      {"name":"TEAM", "value":"${pTeamName}", "type":"PLAINTEXT"}]
+                  RunOrder: 1
+                - !Ref AWS::NoValue
           - !Ref AWS::NoValue
         - !If
-          - EnableLambdaLayerBuilder
-          - Name: DeployLambdaLayers
+          - EnableOptionalFeatures
+          - Name: DeployOptionalFeatures
             Actions:
-              - Name: CreateStack
-                RoleArn: !Sub arn:${AWS::Partition}:iam::${pChildAccountId}:role/sdlf-cicd-team-crossaccount-pipeline
-                ActionTypeId:
-                  Category: Deploy
-                  Owner: AWS
-                  Provider: CloudFormation
-                  Version: '1'
-                InputArtifacts:
-                  - Name: TemplateSource
-                  - Name: CicdTemplateSource
-                Configuration:
-                  ActionMode: CREATE_UPDATE
-                  RoleArn: !Ref pCrossAccountTeamRole
-                  StackName: !Sub sdlf-${pTeamName}-lambdalayers-${pEnvironment}
-                  TemplatePath: "CicdTemplateSource::template-lambda-layer.yaml"
-                  TemplateConfiguration: "TemplateSource::tags.json"
-                  Capabilities: CAPABILITY_NAMED_IAM,CAPABILITY_AUTO_EXPAND
-                  ParameterOverrides: !Sub |+
-                    {
-                      "pArtifactsBucket": "${pArtifactsBucket}",
-                      "pDomain": "${pDomain}",
-                      "pEnvironment": "${pEnvironment}",
-                      "pTeamName": "${pTeamName}",
-                      "pLayers": "#{LambdaLayersVariables.LAYERS_CDL}",
-                      "pGitRef": "#{LambdaLayersVariables.CODEBUILD_RESOLVED_SOURCE_VERSION}"
-                    }
-                RunOrder: 1
+              - !If
+                - EnableLambdaLayerBuilder
+                - Name: CreateLambdaLayersStack
+                  RoleArn: !Sub arn:${AWS::Partition}:iam::${pChildAccountId}:role/sdlf-cicd-team-crossaccount-pipeline
+                  ActionTypeId:
+                    Category: Deploy
+                    Owner: AWS
+                    Provider: CloudFormation
+                    Version: "1"
+                  InputArtifacts:
+                    - Name: TemplateSource
+                    - Name: SourceCicdArtifact
+                  Configuration:
+                    ActionMode: CREATE_UPDATE
+                    RoleArn: !Ref pCrossAccountTeamRole
+                    StackName: !Sub sdlf-${pTeamName}-lambdalayers-${pEnvironment}
+                    TemplatePath: "SourceCicdArtifact::template-lambda-layer.yaml"
+                    TemplateConfiguration: "TemplateSource::tags.json"
+                    Capabilities: CAPABILITY_NAMED_IAM,CAPABILITY_AUTO_EXPAND
+                    ParameterOverrides: !Sub |+
+                      {
+                        "pArtifactsBucket": "${pArtifactsBucket}",
+                        "pDomain": "${pDomain}",
+                        "pEnvironment": "${pEnvironment}",
+                        "pTeamName": "${pTeamName}",
+                        "pLayers": "#{LambdaLayersVariables.LAYERS_CDL}",
+                        "pGitRef": "#{LambdaLayersVariables.CODEBUILD_RESOLVED_SOURCE_VERSION}"
+                      }
+                  RunOrder: 1
+                - !Ref AWS::NoValue
+              - !If
+                - EnableGlueJobDeployer
+                - Name: CreateGlueJobsStack
+                  RoleArn: !Sub arn:${AWS::Partition}:iam::${pChildAccountId}:role/sdlf-cicd-team-crossaccount-pipeline
+                  ActionTypeId:
+                    Category: Deploy
+                    Owner: AWS
+                    Provider: CloudFormation
+                    Version: "1"
+                  InputArtifacts:
+                    - Name: TemplateSource
+                    - Name: SourceCicdArtifact
+                  Configuration:
+                    ActionMode: CREATE_UPDATE
+                    RoleArn: !Ref pCrossAccountTeamRole
+                    StackName: !Sub sdlf-${pTeamName}-gluejobs-${pEnvironment}
+                    TemplatePath: "SourceCicdArtifact::template-glue-job.yaml"
+                    TemplateConfiguration: "TemplateSource::tags.json"
+                    Capabilities: CAPABILITY_NAMED_IAM,CAPABILITY_AUTO_EXPAND
+                    ParameterOverrides: !Sub |+
+                      {
+                        "pArtifactsBucket": "${pArtifactsBucket}",
+                        "pEnvironment": "${pEnvironment}",
+                        "pTeamName": "${pTeamName}",
+                        "pGlueJobs": "#{GlueJobVariables.TRANSFORMS_CDL}",
+                        "pGitRef": "#{GlueJobVariables.CODEBUILD_RESOLVED_SOURCE_VERSION}"
+                      }
+                  RunOrder: 1
+                - !Ref AWS::NoValue
           - !Ref AWS::NoValue
         -
           Name: BuildPipelineDataset

--- a/sdlf-cicd/template-glue-job.yaml
+++ b/sdlf-cicd/template-glue-job.yaml
@@ -1,0 +1,95 @@
+AWSTemplateFormatVersion: 2010-09-09
+Transform: AWS::LanguageExtensions
+Description: Deploy Glue jobs
+
+Parameters:
+  pArtifactsBucket:
+    Description: The artifactory bucket used by CodeBuild and CodePipeline
+    Type: String
+  pDomain:
+    Description: Name of the data domain (all lowercase, no symbols or spaces)
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: /SDLF/Misc/pDomain
+  pEnvironment:
+    Description: Environment name
+    Type: String
+    AllowedValues: [dev, test, prod]
+  pTeamName:
+    Description: Name of the team (all lowercase, no symbols or spaces)
+    Type: String
+  pGlueJobs:
+    Description: List of glue job names
+    Type: CommaDelimitedList
+    AllowedPattern: "^[a-zA-Z0-9]*$"
+  pGitRef:
+    Description: Git reference (commit id) with the sources of these glue jobs
+    Type: String
+
+Conditions:
+  GlueJobsNotEmpty: !Not
+    - !Equals
+      - !Join ["", !Ref pGlueJobs]
+      - ""
+
+Resources:
+  rGlueRole:
+    Type: AWS::IAM::Role
+    Properties:
+      Path: !Sub /sdlf-${pTeamName}/
+      PermissionsBoundary: !Sub "{{resolve:ssm:/SDLF/IAM/${pTeamName}/TeamPermissionsBoundary}}"
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - glue.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      ManagedPolicyArns:
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSGlueServiceRole
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/AmazonS3FullAccess
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/CloudWatchLogsFullAccess
+      Policies:
+        - PolicyName: !Sub sdlf-${pTeamName}-glue-job
+          PolicyDocument:
+            Version: 2012-10-17
+            Statement:
+              - Effect: Allow
+                Action:
+                  - kms:CreateGrant
+                  - kms:Decrypt
+                  - kms:DescribeKey
+                  - kms:Encrypt
+                  - kms:GenerateDataKey*
+                  - kms:ReEncrypt*
+                Resource:
+                  - !Sub "{{resolve:ssm:/SDLF/KMS/${pTeamName}/InfraKeyId}}"
+                  - !Sub "{{resolve:ssm:/SDLF/KMS/${pTeamName}/DataKeyId}}"
+                  - "{{resolve:ssm:/SDLF/KMS/KeyArn}}"
+
+  "Fn::ForEach::GlueJobResources":
+  - GlueJobName
+  - !Ref pGlueJobs
+  - "r${GlueJobName}GlueJob":
+      Type: AWS::Glue::Job
+      Condition: GlueJobsNotEmpty
+      Properties:
+        Command:
+          Name: glueetl
+          PythonVersion: "3"
+          ScriptLocation: !Sub s3://${pArtifactsBucket}/transforms/${pDomain}/${pEnvironment}/${pTeamName}/${GlueJobName}-${pGitRef}.py
+        DefaultArguments:
+          "--job-bookmark-option": job-bookmark-disable
+          "--enable-glue-datacatalog": "true"
+          "--enable-continuous-cloudwatch-log": "true"
+          "--enable-continuous-log-filter": "true"
+          "--enable-metrics": "true"
+        ExecutionProperty:
+          MaxConcurrentRuns: 10
+        MaxRetries: 0
+        MaxCapacity: 2.0
+        GlueVersion: "4.0"
+        Name: !Sub sdlf-${pTeamName}-${GlueJobName}
+        SecurityConfiguration: !Sub "{{resolve:ssm:/SDLF/Glue/${pTeamName}/SecurityConfigurationId}}"
+        Role: !Ref rGlueRole

--- a/sdlf-cicd/template-lambda-layer.yaml
+++ b/sdlf-cicd/template-lambda-layer.yaml
@@ -9,16 +9,17 @@ Parameters:
   pDomain:
     Description: Name of the data domain (all lowercase, no symbols or spaces)
     Type: String
-  pTeamName:
-    Description: Name of the team (all lowercase, no symbols or spaces)
-    Type: String
   pEnvironment:
     Description: Environment name
     Type: String
     AllowedValues: [dev, test, prod]
+  pTeamName:
+    Description: Name of the team (all lowercase, no symbols or spaces)
+    Type: String
   pLayers:
     Description: List of folder names from layers/ directory
     Type: CommaDelimitedList
+    AllowedPattern: "^[a-zA-Z0-9]*$"
   pGitRef:
     Description: Git reference (commit id) with the sources of these layers
     Type: String

--- a/sdlf-team/template.yaml
+++ b/sdlf-team/template.yaml
@@ -23,8 +23,8 @@ Parameters:
     Default: "{{resolve:ssm:/SDLF/S3/CentralBucket}}"
   pAthenaBucket:
     Description: S3 Athena bucket
-    Type: AWS::SSM::Parameter::Value<String>
-    Default: /SDLF/S3/AthenaBucket
+    Type: String
+    Default: "{{resolve:ssm:/SDLF/S3/AthenaBucket}}"
   pEnvironment:
     Description: Environment name
     Type: String
@@ -224,6 +224,14 @@ Resources:
       Type: String
       Value: !Ref rScheduleGroup
       Description: !Sub Name of the ${pTeamName} schedule group
+
+  rGlueSecurityConfigurationSsm:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub /SDLF/Glue/${pTeamName}/SecurityConfigurationId
+      Type: String
+      Value: !Sub sdlf-${pTeamName}-glue-security-config # unfortunately AWS::Glue::SecurityConfiguration doesn't provide any return value
+      Description: !Sub Name of the ${pTeamName} Glue security configuration
   #### END KMS STACK
 
   ######## IAM #########
@@ -936,7 +944,7 @@ Resources:
           EncryptionConfiguration:
             EncryptionOption: SSE_KMS
             KmsKey: !GetAtt rKMSDataKey.Arn
-          OutputLocation: !Sub s3://${pAthenaBucket}/${pTeamName}
+          OutputLocation: !Sub s3://${pAthenaBucket}/${pTeamName}/
 
   rAthenaWorkgroupSsm:
     Type: AWS::SSM::Parameter


### PR DESCRIPTION
*Description of changes:*
Set `/SDLF/GlueJobDeployer/Enabled` to true then add python files to `sdlf-main-{domain}-{team}` repository under `transforms-{environment}/{glue_job_name}/{glue_job_name}.py` for it to be automatically deployed.

This is a simplified version of the glue jobs deployer available in sdlf-utils. It may be extended in the future to better match users' use cases.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
