### PR TITLE
Optional VPC support for SDLF

### DIFF
--- a/sdlf-cicd/lambda/domain-cicd/src/lambda_function.py
+++ b/sdlf-cicd/lambda/domain-cicd/src/lambda_function.py
@@ -13,9 +13,12 @@ logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
 s3 = boto3.client("s3", config=Config(signature_version="s3v4"))
-ssm = boto3.client("ssm")
-codepipeline = boto3.client("codepipeline")
-cloudformation = boto3.client("cloudformation")
+ssm_endpoint_url = "https://ssm." + os.getenv("AWS_REGION") + ".amazonaws.com"
+ssm = boto3.client("ssm", endpoint_url=ssm_endpoint_url)
+codepipeline_endpoint_url = "https://codepipeline." + os.getenv("AWS_REGION") + ".amazonaws.com"
+codepipeline = boto3.client("codepipeline", endpoint_url=codepipeline_endpoint_url)
+cloudformation_endpoint_url = "https://cloudformation." + os.getenv("AWS_REGION") + ".amazonaws.com"
+cloudformation = boto3.client("cloudformation", endpoint_url=cloudformation_endpoint_url)
 
 
 def delete_domain_cicd_stack(domain, environment, cloudformation_role):

--- a/sdlf-cicd/lambda/stagesrepositories-cicd/src/lambda_function.py
+++ b/sdlf-cicd/lambda/stagesrepositories-cicd/src/lambda_function.py
@@ -6,8 +6,10 @@ import boto3
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
-codecommit = boto3.client("codecommit")
-codepipeline = boto3.client("codepipeline")
+codecommit_endpoint_url = "https://codecommit." + os.getenv("AWS_REGION") + ".amazonaws.com"
+codecommit = boto3.client("codecommit", endpoint_url=codecommit_endpoint_url)
+codepipeline_endpoint_url = "https://codepipeline." + os.getenv("AWS_REGION") + ".amazonaws.com"
+codepipeline = boto3.client("codepipeline", endpoint_url=codepipeline_endpoint_url)
 
 
 def lambda_handler(event, context):

--- a/sdlf-cicd/lambda/team-cicd/src/lambda_function.py
+++ b/sdlf-cicd/lambda/team-cicd/src/lambda_function.py
@@ -13,10 +13,14 @@ logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 
 s3 = boto3.client("s3", config=Config(signature_version="s3v4"))
-codecommit = boto3.client("codecommit")
-codepipeline = boto3.client("codepipeline")
-cloudformation = boto3.client("cloudformation")
-kms = boto3.client("kms")
+codecommit_endpoint_url = "https://codecommit." + os.getenv("AWS_REGION") + ".amazonaws.com"
+codecommit = boto3.client("codecommit", endpoint_url=codecommit_endpoint_url)
+codepipeline_endpoint_url = "https://codepipeline." + os.getenv("AWS_REGION") + ".amazonaws.com"
+codepipeline = boto3.client("codepipeline", endpoint_url=codepipeline_endpoint_url)
+cloudformation_endpoint_url = "https://cloudformation." + os.getenv("AWS_REGION") + ".amazonaws.com"
+cloudformation = boto3.client("cloudformation", endpoint_url=cloudformation_endpoint_url)
+kms_endpoint_url = "https://kms." + os.getenv("AWS_REGION") + ".amazonaws.com"
+kms = boto3.client("kms", endpoint_url=kms_endpoint_url)
 
 
 def delete_domain_team_role_stack(team, cloudformation_role):

--- a/sdlf-cicd/nested-stacks/template-cicd-cfn-module.yaml
+++ b/sdlf-cicd/nested-stacks/template-cicd-cfn-module.yaml
@@ -14,6 +14,13 @@ Parameters:
     Description: Prefix of the repositories containing SDLF stages
     Type: String
     Default: sdlf-stage-
+  pEnableVpc:
+    Description: Deploy SDLF resources in a VPC
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: /SDLF/VPC/Enabled
+
+Conditions:
+  RunInVpc: !Equals [!Ref pEnableVpc, true]
 
 Resources:
   rBuildCloudformationModuleRole:
@@ -70,6 +77,38 @@ Resources:
               - Effect: Allow
                 Action: sts:AssumeRole
                 Resource: !Sub arn:${AWS::Partition}:iam::*:role/sdlf-cicd-domain-crossaccount-cfn-modules
+              - !If
+                - RunInVpc
+                - Effect: Allow
+                  Action:
+                    - ec2:DescribeSecurityGroups # W11 exception
+                    - ec2:DescribeSubnets # W11 exception
+                    - ec2:DescribeVpcs # W11 exception
+                    - ec2:DescribeNetworkInterfaces # W11 exception
+                    - ec2:DescribeDhcpOptions # W11 exception
+                    - ec2:CreateNetworkInterface # W11 condition applied
+                    - ec2:DeleteNetworkInterface # W11 condition applied
+                  Resource:
+                    - "*"
+                  Condition:
+                    ArnEqualsIfExists:
+                      "ec2:Vpc":
+                        - !Sub "arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:vpc/{{resolve:ssm:/SDLF/VPC/VpcId}}"
+                - !Ref "AWS::NoValue"
+              - !If
+                - RunInVpc
+                - Effect: Allow
+                  Action:
+                    - ec2:CreateNetworkInterfacePermission
+                  Resource:
+                    - !Sub "arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:network-interface/*"
+                  Condition:
+                    StringEquals:
+                      "ec2:AuthorizedService": codebuild.amazonaws.com
+                    ArnEquals:
+                      "ec2:Vpc":
+                        - !Sub "arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:vpc/{{resolve:ssm:/SDLF/VPC/VpcId}}"
+                - !Ref "AWS::NoValue"
         - PolicyName: sdlf-cicd-build-stages-cfn-modules
           PolicyDocument:
             Version: "2012-10-17"
@@ -98,6 +137,12 @@ Resources:
         Type: CODEPIPELINE
       Description: Build a CloudFormation module from Serverless templates
       EncryptionKey: !Ref pKMSKey
+      VpcConfig: !If
+        - RunInVpc
+        - SecurityGroupIds: !Split [",", !ImportValue sdlf-cicd-prerequisites-vpc-security-groups]
+          Subnets: !Split [",", !ImportValue sdlf-cicd-prerequisites-vpc-subnets]
+          VpcId: "{{resolve:ssm:/SDLF/VPC/VpcId}}"
+        - !Ref "AWS::NoValue"
       Environment:
         EnvironmentVariables:
           - Name: ARTIFACTS_BUCKET
@@ -129,11 +174,14 @@ Resources:
                 - sam package --template-file ./template.yaml --s3-bucket "$ARTIFACTS_BUCKET" --s3-prefix sdlf --output-template-file template.yaml
                 - python3 sam-translate.py --template-file=template.yaml --output-template=translated-template.json
                 - |-
+                    CLOUDFORMATION_ENDPOINT_URL="https://cloudformation.$AWS_REGION.amazonaws.com"
+                    SSM_ENDPOINT_URL="https://ssm.$AWS_REGION.amazonaws.com"
+                    STS_ENDPOINT_URL="https://sts.$AWS_REGION.amazonaws.com"
                     aws s3api put-object --bucket "$ARTIFACTS_BUCKET" \
                       --key "modules/$DOMAIN_NAME/$ENVIRONMENT/$TEAM_NAME/translated-template.json" \
                       --body translated-template.json
                     TEMPLATE_URL=$(aws s3 presign "s3://$ARTIFACTS_BUCKET/modules/$DOMAIN_NAME/$ENVIRONMENT/$TEAM_NAME/translated-template.json" --expires-in 300)
-                    aws cloudformation validate-template --template-url "$TEMPLATE_URL"
+                    aws cloudformation --endpoint-url "$CLOUDFORMATION_ENDPOINT_URL" validate-template --template-url "$TEMPLATE_URL"
                 - |-
                     mkdir module
                     cd module || exit
@@ -147,14 +195,14 @@ Resources:
                                           --key "modules/$DOMAIN_NAME/$ENVIRONMENT/$TEAM_NAME/$MODULE_NAME-$NEW_MODULE.zip" \
                                           --body "../$MODULE_NAME.zip"
                 - |-
-                    temp_role=$(aws sts assume-role --role-arn "arn:${AWS::Partition}:iam::$DOMAIN_ACCOUNT_ID:role/sdlf-cicd-domain-crossaccount-cfn-modules" --role-session-name "codebuild-cfn-module")
+                    temp_role=$(aws sts --endpoint-url "$STS_ENDPOINT_URL" assume-role --role-arn "arn:${AWS::Partition}:iam::$DOMAIN_ACCOUNT_ID:role/sdlf-cicd-domain-crossaccount-cfn-modules" --role-session-name "codebuild-cfn-module")
                     AWS_ACCESS_KEY_ID=$(echo "$temp_role" | jq .Credentials.AccessKeyId | xargs)
                     AWS_SECRET_ACCESS_KEY=$(echo "$temp_role" | jq .Credentials.SecretAccessKey | xargs)
                     AWS_SESSION_TOKEN=$(echo "$temp_role" | jq .Credentials.SessionToken | xargs)
                     export AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
 
                     # compare hashes to avoid creating a new module version when there is no change
-                    if CURRENT_MODULE=$(aws ssm get-parameter --name "/SDLF/CFN/$DOMAIN_NAME-$TEAM_NAME-$MODULE_NAME-MODULE" --query "Parameter.Value" --output text); then
+                    if CURRENT_MODULE=$(aws ssm --endpoint-url "$SSM_ENDPOINT_URL" get-parameter --name "/SDLF/CFN/$DOMAIN_NAME-$TEAM_NAME-$MODULE_NAME-MODULE" --query "Parameter.Value" --output text); then
                       echo "Current module version commit id: $CURRENT_MODULE"
                       echo "New module version commit id: $NEW_MODULE"
                       if [ "$NEW_MODULE" == "$CURRENT_MODULE" ]; then
@@ -164,7 +212,7 @@ Resources:
                     fi
 
                     STACK_NAME="sdlf-cfn-module-$TEAM_NAME-$MODULE_NAME"
-                    aws cloudformation deploy \
+                    aws cloudformation --endpoint-url "$CLOUDFORMATION_ENDPOINT_URL" deploy \
                         --stack-name "$STACK_NAME" \
                         --template-file "$CODEBUILD_SRC_DIR_SourceCicdArtifact"/template-cfn-module.yaml \
                         --parameter-overrides \
@@ -194,6 +242,12 @@ Resources:
         Type: CODEPIPELINE
       Description: Build CloudFormation modules from Serverless templates for SDLF stages
       EncryptionKey: !Ref pKMSKey
+      VpcConfig: !If
+        - RunInVpc
+        - SecurityGroupIds: !Split [",", !ImportValue sdlf-cicd-prerequisites-vpc-security-groups]
+          Subnets: !Split [",", !ImportValue sdlf-cicd-prerequisites-vpc-subnets]
+          VpcId: "{{resolve:ssm:/SDLF/VPC/VpcId}}"
+        - !Ref "AWS::NoValue"
       Environment:
         EnvironmentVariables:
           - Name: ARTIFACTS_BUCKET
@@ -223,10 +277,14 @@ Resources:
             build:
               commands:
                 - |-
+                    CLOUDFORMATION_ENDPOINT_URL="https://cloudformation.$AWS_REGION.amazonaws.com"
+                    CODECOMMIT_ENDPOINT_URL="https://codecommit.$AWS_REGION.amazonaws.com"
+                    SSM_ENDPOINT_URL="https://ssm.$AWS_REGION.amazonaws.com"
+                    STS_ENDPOINT_URL="https://sts.$AWS_REGION.amazonaws.com"
                     # clone all this team's stages repositories
-                    STAGES_REPOSITORIES=$(aws codecommit list-repositories --query "repositories[?starts_with(repositoryName, 'sdlf-stage-$DOMAIN_NAME-$TEAM_NAME-')].repositoryName" --output text)
+                    STAGES_REPOSITORIES=$(aws codecommit --endpoint-url "$CODECOMMIT_ENDPOINT_URL" list-repositories --query "repositories[?starts_with(repositoryName, 'sdlf-stage-$DOMAIN_NAME-$TEAM_NAME-')].repositoryName" --output text)
                     echo "STAGES_REPOSITORIES FOUND: $STAGES_REPOSITORIES"
-                    git config --global credential.helper '!aws codecommit credential-helper $@'
+                    git config --global credential.helper '!aws codecommit --endpoint-url "$CODECOMMIT_ENDPOINT_URL" credential-helper $@'
                     git config --global credential.UseHttpPath true
                     for STAGE_REPOSITORY in $STAGES_REPOSITORIES; do
                       git clone --single-branch --branch "$BRANCH_NAME" "https://git-codecommit.$AWS_REGION.amazonaws.com/v1/repos/$STAGE_REPOSITORY.git"
@@ -239,7 +297,7 @@ Resources:
                         --key "modules/$DOMAIN_NAME/$ENVIRONMENT/$TEAM_NAME/$MODULE_NAME/translated-template.json" \
                         --body translated-template.json
                       TEMPLATE_URL=$(aws s3 presign "s3://$ARTIFACTS_BUCKET/modules/$DOMAIN_NAME/$ENVIRONMENT/$TEAM_NAME/$MODULE_NAME/translated-template.json" --expires-in 300)
-                      aws cloudformation validate-template --template-url "$TEMPLATE_URL" || exit 1
+                      aws cloudformation --endpoint-url "$CLOUDFORMATION_ENDPOINT_URL" validate-template --template-url "$TEMPLATE_URL" || exit 1
                       popd || exit
                     done
                 - |-
@@ -263,7 +321,7 @@ Resources:
                       popd || exit
                     done
                 - |-
-                    temp_role=$(aws sts assume-role --role-arn "arn:${AWS::Partition}:iam::$DOMAIN_ACCOUNT_ID:role/sdlf-cicd-domain-crossaccount-cfn-modules" --role-session-name "codebuild-cfn-module")
+                    temp_role=$(aws sts --endpoint-url "$STS_ENDPOINT_URL" assume-role --role-arn "arn:${AWS::Partition}:iam::$DOMAIN_ACCOUNT_ID:role/sdlf-cicd-domain-crossaccount-cfn-modules" --role-session-name "codebuild-cfn-module")
                     AWS_ACCESS_KEY_ID=$(echo "$temp_role" | jq .Credentials.AccessKeyId | xargs)
                     AWS_SECRET_ACCESS_KEY=$(echo "$temp_role" | jq .Credentials.SecretAccessKey | xargs)
                     AWS_SESSION_TOKEN=$(echo "$temp_role" | jq .Credentials.SessionToken | xargs)
@@ -272,7 +330,7 @@ Resources:
                     for STAGE_REPOSITORY in $STAGES_REPOSITORIES; do
                       MODULE_NAME=${!STAGE_REPOSITORY##*-}
                       # compare hashes to avoid creating a new module version when there is no change
-                      if CURRENT_MODULE=$(aws ssm get-parameter --name "/SDLF/CFN/$DOMAIN_NAME-$TEAM_NAME-$MODULE_NAME-MODULE" --query "Parameter.Value" --output text); then
+                      if CURRENT_MODULE=$(aws ssm --endpoint-url "$SSM_ENDPOINT_URL" get-parameter --name "/SDLF/CFN/$DOMAIN_NAME-$TEAM_NAME-$MODULE_NAME-MODULE" --query "Parameter.Value" --output text); then
                         echo "Current module version commit id: $CURRENT_MODULE"
                         echo "New module version commit id: $NEW_MODULE"
                         if [ "$NEW_MODULE" == "$CURRENT_MODULE" ]; then
@@ -282,7 +340,7 @@ Resources:
                       fi
 
                       STACK_NAME="sdlf-cfn-module-$TEAM_NAME-$MODULE_NAME"
-                      aws cloudformation deploy \
+                      aws cloudformation --endpoint-url "$CLOUDFORMATION_ENDPOINT_URL" deploy \
                           --stack-name "$STACK_NAME" \
                           --template-file ./template-cfn-module.yaml \
                           --parameter-overrides \

--- a/sdlf-cicd/nested-stacks/template-cicd-glue-job.yaml
+++ b/sdlf-cicd/nested-stacks/template-cicd-glue-job.yaml
@@ -10,6 +10,13 @@ Parameters:
     Description: The KMS key used by CodeBuild and CodePipeline
     Type: AWS::SSM::Parameter::Value<String>
     Default: /SDLF/KMS/CICDKeyId
+  pEnableVpc:
+    Description: Deploy SDLF resources in a VPC
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: /SDLF/VPC/Enabled
+
+Conditions:
+  RunInVpc: !Equals [!Ref pEnableVpc, true]
 
 Resources:
   rGlueJobCodeBuildServiceRole:
@@ -58,6 +65,38 @@ Resources:
                   - kms:ReEncrypt*
                 Resource:
                   - !Ref pKMSKey
+              - !If
+                - RunInVpc
+                - Effect: Allow
+                  Action:
+                    - ec2:DescribeSecurityGroups # W11 exception
+                    - ec2:DescribeSubnets # W11 exception
+                    - ec2:DescribeVpcs # W11 exception
+                    - ec2:DescribeNetworkInterfaces # W11 exception
+                    - ec2:DescribeDhcpOptions # W11 exception
+                    - ec2:CreateNetworkInterface # W11 condition applied
+                    - ec2:DeleteNetworkInterface # W11 condition applied
+                  Resource:
+                    - "*"
+                  Condition:
+                    ArnEqualsIfExists:
+                      "ec2:Vpc":
+                        - !Sub "arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:vpc/{{resolve:ssm:/SDLF/VPC/VpcId}}"
+                - !Ref "AWS::NoValue"
+              - !If
+                - RunInVpc
+                - Effect: Allow
+                  Action:
+                    - ec2:CreateNetworkInterfacePermission
+                  Resource:
+                    - !Sub "arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:network-interface/*"
+                  Condition:
+                    StringEquals:
+                      "ec2:AuthorizedService": codebuild.amazonaws.com
+                    ArnEquals:
+                      "ec2:Vpc":
+                        - !Sub "arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:vpc/{{resolve:ssm:/SDLF/VPC/VpcId}}"
+                - !Ref "AWS::NoValue"
 
   rGlueJobPackage:
     Type: AWS::CodeBuild::Project
@@ -67,6 +106,12 @@ Resources:
       Name: sdlf-cicd-build-glue-jobs
       Description: Prepares Glue jobs for deployment
       EncryptionKey: !Ref pKMSKey
+      VpcConfig: !If
+        - RunInVpc
+        - SecurityGroupIds: !Split [",", !ImportValue sdlf-cicd-prerequisites-vpc-security-groups]
+          Subnets: !Split [",", !ImportValue sdlf-cicd-prerequisites-vpc-subnets]
+          VpcId: "{{resolve:ssm:/SDLF/VPC/VpcId}}"
+        - !Ref "AWS::NoValue"
       Environment:
         EnvironmentVariables:
           - Name: ARTIFACTS_BUCKET

--- a/sdlf-cicd/nested-stacks/template-cicd-lambda-layer.yaml
+++ b/sdlf-cicd/nested-stacks/template-cicd-lambda-layer.yaml
@@ -10,6 +10,13 @@ Parameters:
     Description: The KMS key used by CodeBuild and CodePipeline
     Type: AWS::SSM::Parameter::Value<String>
     Default: /SDLF/KMS/CICDKeyId
+  pEnableVpc:
+    Description: Deploy SDLF resources in a VPC
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: /SDLF/VPC/Enabled
+
+Conditions:
+  RunInVpc: !Equals [!Ref pEnableVpc, true]
 
 Resources:
   rLambdaLayersCodeBuildServiceRole:
@@ -58,6 +65,38 @@ Resources:
                   - kms:ReEncrypt*
                 Resource:
                   - !Ref pKMSKey
+              - !If
+                - RunInVpc
+                - Effect: Allow
+                  Action:
+                    - ec2:DescribeSecurityGroups # W11 exception
+                    - ec2:DescribeSubnets # W11 exception
+                    - ec2:DescribeVpcs # W11 exception
+                    - ec2:DescribeNetworkInterfaces # W11 exception
+                    - ec2:DescribeDhcpOptions # W11 exception
+                    - ec2:CreateNetworkInterface # W11 condition applied
+                    - ec2:DeleteNetworkInterface # W11 condition applied
+                  Resource:
+                    - "*"
+                  Condition:
+                    ArnEqualsIfExists:
+                      "ec2:Vpc":
+                        - !Sub "arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:vpc/{{resolve:ssm:/SDLF/VPC/VpcId}}"
+                - !Ref "AWS::NoValue"
+              - !If
+                - RunInVpc
+                - Effect: Allow
+                  Action:
+                    - ec2:CreateNetworkInterfacePermission
+                  Resource:
+                    - !Sub "arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:network-interface/*"
+                  Condition:
+                    StringEquals:
+                      "ec2:AuthorizedService": codebuild.amazonaws.com
+                    ArnEquals:
+                      "ec2:Vpc":
+                        - !Sub "arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:vpc/{{resolve:ssm:/SDLF/VPC/VpcId}}"
+                - !Ref "AWS::NoValue"
 
   rBuildLambdaLayersPackage:
     Type: AWS::CodeBuild::Project
@@ -67,6 +106,12 @@ Resources:
       Name: sdlf-cicd-build-lambda-layers
       Description: Creates a Lambda Layer containing the libraries and version numbers listed in the requirements.txt file in the repository provided
       EncryptionKey: !Ref pKMSKey
+      VpcConfig: !If
+        - RunInVpc
+        - SecurityGroupIds: !Split [",", !ImportValue sdlf-cicd-prerequisites-vpc-security-groups]
+          Subnets: !Split [",", !ImportValue sdlf-cicd-prerequisites-vpc-subnets]
+          VpcId: "{{resolve:ssm:/SDLF/VPC/VpcId}}"
+        - !Ref "AWS::NoValue"
       Environment:
         EnvironmentVariables:
           - Name: ARTIFACTS_BUCKET

--- a/sdlf-cicd/template-cicd-domain-roles.yaml
+++ b/sdlf-cicd/template-cicd-domain-roles.yaml
@@ -13,8 +13,24 @@ Parameters:
   pDevOpsKMSKey:
     Description: DevOps KMS key alias
     Type: String
+  pEnableVpc:
+    Description: Deploy SDLF resources in a VPC
+    Type: String
+    Default: false
+
+Conditions:
+  RunInVpc: !Equals [!Ref pEnableVpc, true]
 
 Resources:
+  ######## OPTIONAL SDLF FEATURES #########
+  rVpcFeatureSsm:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: /SDLF/VPC/Enabled
+      Type: String
+      Value: !Ref pEnableVpc
+      Description: Deploy SDLF resources in a VPC
+
   rBuildModuleActionCodePipelineRole:
     Type: AWS::IAM::Role
     Metadata:
@@ -385,9 +401,19 @@ Resources:
                 Resource: "*"
               - Effect: Allow
                 Action:
+                  - lambda:CreateFunction
+                  - lambda:UpdateFunctionConfiguration
+                Resource: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:sdlf-*
+                Condition: !If
+                  - RunInVpc
+                  - StringEquals:
+                      "lambda:VpcIds":
+                        - "{{resolve:ssm:/SDLF/VPC/VpcId}}"
+                  - !Ref "AWS::NoValue"
+              - Effect: Allow
+                Action:
                   - lambda:AddPermission
                   - lambda:CreateAlias
-                  - lambda:CreateFunction
                   - lambda:DeleteFunction
                   - lambda:DeleteFunctionConcurrency
                   - lambda:GetFunction
@@ -401,8 +427,6 @@ Resources:
                   - lambda:UntagResource
                   - lambda:UpdateAlias
                   - lambda:UpdateFunctionCode
-                  - lambda:UpdateFunctionConfiguration
-                  - lambda:UpdateFunctionConfiguration
                   - lambda:AddPermission
                   - lambda:RemovePermission
                 Resource: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:sdlf-*
@@ -581,6 +605,16 @@ Resources:
                   - athena:TagResource
                   - athena:UntagResource
                 Resource: !Sub arn:${AWS::Partition}:athena:${AWS::Region}:${AWS::AccountId}:workgroup/sdlf-*
+              - !If
+                - RunInVpc
+                - Effect: Allow
+                  Action:
+                    - ec2:DescribeSecurityGroups # W11 exception
+                    - ec2:DescribeSubnets # W11 exception
+                    - ec2:DescribeVpcs # W11 exception
+                  Resource:
+                    - "*"
+                - !Ref "AWS::NoValue"
 
   rTeamCodePipelineRole:
     Type: AWS::IAM::Role
@@ -710,6 +744,7 @@ Resources:
                 - ssm:GetParametersByPath
               Resource:
                 - !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/Misc/*
+                - !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/VPC/*
             - Effect: Allow
               Action:
                 - iam:GetRole
@@ -745,3 +780,23 @@ Resources:
                 StringEquals:
                   "iam:PassedToService":
                     - cloudformation.amazonaws.com
+
+Outputs:
+  # workaround {{resolve:ssm:}} not returning an array that can be used directly in VpcConfig blocks
+  oVpcFeatureSecurityGroupIds:
+    Description: List of security group ids that will be attached to Lambda functions and CodeBuild projects
+    Value: !If
+      - RunInVpc
+      - "{{resolve:ssm:/SDLF/VPC/SecurityGroupIds}}"
+      - "-"
+    Export:
+      Name: !Join ["-", [!Ref "AWS::StackName", "vpc-security-groups"]]
+
+  oVpcFeatureSubnetIds:
+    Description: List of subnet ids that will be attached to Lambda functions and CodeBuild projects
+    Value: !If
+      - RunInVpc
+      - "{{resolve:ssm:/SDLF/VPC/SubnetIds}}"
+      - "-"
+    Export:
+      Name: !Join ["-", [!Ref "AWS::StackName", "vpc-subnets"]]

--- a/sdlf-cicd/template-cicd-domain-team-role.yaml
+++ b/sdlf-cicd/template-cicd-domain-team-role.yaml
@@ -24,10 +24,15 @@ Parameters:
     Description: Environment name
     Type: String
     AllowedValues: [dev, test, prod]
+  pEnableVpc:
+    Description: Deploy SDLF resources in a VPC
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: /SDLF/VPC/Enabled
 
 Conditions:
   EnableLambdaLayerBuilder: !Equals [!Ref pEnableLambdaLayerBuilder, true]
   EnableGlueJobDeployer: !Equals [!Ref pEnableGlueJobDeployer, true]
+  RunInVpc: !Equals [!Ref pEnableVpc, true]
 
 Resources:
   rTeamCloudFormationRole:
@@ -274,9 +279,19 @@ Resources:
             Resource: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:layer:sdlf-* # there are sdlf-wide layers (datalake-lib-layer)
           - Effect: Allow
             Action:
+              - lambda:CreateFunction
+              - lambda:UpdateFunctionConfiguration
+            Resource: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:sdlf-${pTeamName}-*
+            Condition: !If
+              - RunInVpc
+              - StringEquals:
+                  "lambda:VpcIds":
+                    - "{{resolve:ssm:/SDLF/VPC/VpcId}}"
+              - !Ref "AWS::NoValue"
+          - Effect: Allow
+            Action:
               - lambda:AddPermission
               - lambda:CreateAlias
-              - lambda:CreateFunction
               - lambda:DeleteFunction
               - lambda:DeleteFunctionConcurrency
               - lambda:GetFunction
@@ -290,8 +305,6 @@ Resources:
               - lambda:UntagResource
               - lambda:UpdateAlias
               - lambda:UpdateFunctionCode
-              - lambda:UpdateFunctionConfiguration
-              - lambda:UpdateFunctionConfiguration
               - lambda:AddPermission
               - lambda:RemovePermission
             Resource: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:sdlf-${pTeamName}-*
@@ -316,6 +329,16 @@ Resources:
             Resource:
               - !Sub arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:stateMachine:sdlf-${pTeamName}-*
               - !Sub arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:activity:sdlf-${pTeamName}-*
+          - !If
+            - RunInVpc
+            - Effect: Allow
+              Action:
+                - ec2:DescribeSecurityGroups # W11 exception
+                - ec2:DescribeSubnets # W11 exception
+                - ec2:DescribeVpcs # W11 exception
+              Resource:
+                - "*"
+            - !Ref "AWS::NoValue"
       Roles:
         - !Ref rTeamCloudFormationRole
 
@@ -373,9 +396,13 @@ Resources:
             Resource:
               - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/sdlf-${pTeamName}/sdlf-${pTeamName}-*
             Condition:
-              ArnEquals:
+              ArnLike:
                 "iam:PolicyARN":
                   - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:policy/sdlf-${pTeamName}/sdlf-${pTeamName}-*
+                  - !If
+                    - RunInVpc
+                    - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
+                    - !Ref "AWS::NoValue"
           - Effect: Allow
             Action:
               - iam:DeleteRole
@@ -434,6 +461,7 @@ Resources:
               - ssm:GetParametersByPath
             Resource:
               - !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/KMS/KeyArn
+              - !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/VPC/*
           - Effect: Allow
             Action:
               - iam:AttachRolePolicy
@@ -454,10 +482,21 @@ Resources:
               - glue:UntagResource
             Resource:
               - !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:job/sdlf-${pTeamName}-*
+          - !If
+            - RunInVpc
+            - Effect: Allow
+              Action:
+                - glue:CreateConnection
+                - glue:DeleteConnection
+              Resource:
+                - !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:catalog
+                - !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:connection/sdlf-${pTeamName}-glue-conn
+            - !Ref "AWS::NoValue"
           - Effect: Allow
             Action:
               - iam:PassRole
             Resource:
+              - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/sdlf-${pTeamName}-* # cfn bug?
               - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/sdlf-${pTeamName}/sdlf-${pTeamName}-*
             Condition:
               StringEquals:

--- a/sdlf-cicd/template-cicd-prerequisites.yaml
+++ b/sdlf-cicd/template-cicd-prerequisites.yaml
@@ -9,11 +9,27 @@ Parameters:
   pDomainAccounts:
     Description: S3 Bucket Prefix if different from default. Must be a valid S3 Bucket name
     Type: CommaDelimitedList
+  pEnableVpc:
+    Description: Deploy SDLF resources in a VPC
+    Type: String
+    Default: false
 
 Conditions:
   UseCustomBucketPrefix: !Not [!Equals [!Ref pCustomBucketPrefix, sdlf]]
+  RunInVpc: !Equals [!Ref pEnableVpc, true]
 
 Resources:
+  ######## OPTIONAL SDLF FEATURES #########
+  # when enabling VPC support, /SDLF/VPC/SecurityGroupIds and /SDLF/VPC/SubnetIds are required too (see Outputs section)
+  # both for the devops account and child accounts.
+  rVpcFeatureSsm:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: /SDLF/VPC/Enabled
+      Type: String
+      Value: !Ref pEnableVpc
+      Description: Deploy SDLF resources in a VPC
+
   rBuildLambdaLayersFeatureSsm:
     Type: AWS::SSM::Parameter
     Properties:
@@ -307,3 +323,23 @@ Resources:
       Type: String
       Value: !Ref rArtifactsBucket
       Description: S3 DevOps Artifacts Bucket
+
+Outputs:
+  # workaround {{resolve:ssm:}} not returning an array that can be used directly in VpcConfig blocks
+  oVpcFeatureSecurityGroupIds:
+    Description: List of security group ids that will be attached to Lambda functions and CodeBuild projects
+    Value: !If
+      - RunInVpc
+      - "{{resolve:ssm:/SDLF/VPC/SecurityGroupIds}}"
+      - "-"
+    Export:
+      Name: !Join ["-", [!Ref "AWS::StackName", "vpc-security-groups"]]
+
+  oVpcFeatureSubnetIds:
+    Description: List of subnet ids that will be attached to Lambda functions and CodeBuild projects
+    Value: !If
+      - RunInVpc
+      - "{{resolve:ssm:/SDLF/VPC/SubnetIds}}"
+      - "-"
+    Export:
+      Name: !Join ["-", [!Ref "AWS::StackName", "vpc-subnets"]]

--- a/sdlf-cicd/template-cicd-sdlf-repositories.yaml
+++ b/sdlf-cicd/template-cicd-sdlf-repositories.yaml
@@ -48,6 +48,10 @@ Parameters:
     Type: String
     Default: DatalakeLibrary
     AllowedPattern: "^[a-zA-Z0-9]*$"
+  pEnableVpc:
+    Description: Deploy SDLF resources in a VPC
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: /SDLF/VPC/Enabled
   pEnableLambdaLayerBuilder:
     Description: Add Lambda layer builder infrastructure and pipeline stages
     Type: AWS::SSM::Parameter::Value<String>
@@ -60,6 +64,7 @@ Parameters:
 Conditions:
   EnableLambdaLayerBuilder: !Equals [!Ref pEnableLambdaLayerBuilder, true]
   EnableGlueJobDeployer: !Equals [!Ref pEnableGlueJobDeployer, true]
+  RunInVpc: !Equals [!Ref pEnableVpc, true]
 
 Resources:
   ######## CODECOMMIT #########
@@ -339,6 +344,11 @@ Resources:
                 - lambda.amazonaws.com
             Action:
               - sts:AssumeRole
+      ManagedPolicyArns:
+        - !If
+          - RunInVpc
+          - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
+          - !Ref "AWS::NoValue"
       Policies:
         - PolicyName: root
           PolicyDocument:
@@ -452,6 +462,12 @@ Resources:
       Handler: lambda_function.lambda_handler
       MemorySize: 128
       Role: !GetAtt rStagesRepositoriesLambdaRole.Arn
+      KmsKeyArn: !Ref pKMSKey
+      VpcConfig: !If
+        - RunInVpc
+        - SecurityGroupIds: !Split [",", !ImportValue sdlf-cicd-prerequisites-vpc-security-groups]
+          SubnetIds: !Split [",", !ImportValue sdlf-cicd-prerequisites-vpc-subnets]
+        - !Ref "AWS::NoValue"
       Runtime: python3.11
       Timeout: 300
       Environment:
@@ -469,13 +485,18 @@ Resources:
             reason: The actions with "*" are all ones that only support the all resources wildcard
     Properties:
       AssumeRolePolicyDocument:
+        Version: "2012-10-17"
         Statement:
           - Action: sts:AssumeRole
             Effect: Allow
             Principal:
               Service:
                 - lambda.amazonaws.com
-        Version: 2012-10-17
+      ManagedPolicyArns:
+        - !If
+          - RunInVpc
+          - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
+          - !Ref "AWS::NoValue"
       Policies:
         - PolicyName: root
           PolicyDocument:
@@ -699,6 +720,12 @@ Resources:
       Handler: lambda_function.lambda_handler
       MemorySize: 256
       Role: !GetAtt rMainRepositoryLambdaRole.Arn
+      KmsKeyArn: !Ref pKMSKey
+      VpcConfig: !If
+        - RunInVpc
+        - SecurityGroupIds: !Split [",", !ImportValue sdlf-cicd-prerequisites-vpc-security-groups]
+          SubnetIds: !Split [",", !ImportValue sdlf-cicd-prerequisites-vpc-subnets]
+        - !Ref "AWS::NoValue"
       Runtime: python3.11
       Timeout: 450
       Environment:
@@ -713,6 +740,12 @@ Resources:
       Handler: lambda_function.lambda_handler
       MemorySize: 256
       Role: !GetAtt rMainRepositoryLambdaRole.Arn
+      KmsKeyArn: !Ref pKMSKey
+      VpcConfig: !If
+        - RunInVpc
+        - SecurityGroupIds: !Split [",", !ImportValue sdlf-cicd-prerequisites-vpc-security-groups]
+          SubnetIds: !Split [",", !ImportValue sdlf-cicd-prerequisites-vpc-subnets]
+        - !Ref "AWS::NoValue"
       Runtime: python3.11
       Timeout: 450
       Environment:
@@ -730,6 +763,12 @@ Resources:
       Handler: lambda_function.lambda_handler
       MemorySize: 256
       Role: !GetAtt rMainRepositoryLambdaRole.Arn
+      KmsKeyArn: !Ref pKMSKey
+      VpcConfig: !If
+        - RunInVpc
+        - SecurityGroupIds: !Split [",", !ImportValue sdlf-cicd-prerequisites-vpc-security-groups]
+          SubnetIds: !Split [",", !ImportValue sdlf-cicd-prerequisites-vpc-subnets]
+        - !Ref "AWS::NoValue"
       Runtime: python3.11
       Timeout: 450
       Environment:
@@ -785,6 +824,38 @@ Resources:
               - Effect: Allow
                 Action: sts:AssumeRole
                 Resource: !Sub arn:${AWS::Partition}:iam::*:role/sdlf-cicd-team-crossaccount-cloudformation-package
+              - !If
+                - RunInVpc
+                - Effect: Allow
+                  Action:
+                    - ec2:DescribeSecurityGroups # W11 exception
+                    - ec2:DescribeSubnets # W11 exception
+                    - ec2:DescribeVpcs # W11 exception
+                    - ec2:DescribeNetworkInterfaces # W11 exception
+                    - ec2:DescribeDhcpOptions # W11 exception
+                    - ec2:CreateNetworkInterface # W11 condition applied
+                    - ec2:DeleteNetworkInterface # W11 condition applied
+                  Resource:
+                    - "*"
+                  Condition:
+                    ArnEqualsIfExists:
+                      "ec2:Vpc":
+                        - !Sub "arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:vpc/{{resolve:ssm:/SDLF/VPC/VpcId}}"
+                - !Ref "AWS::NoValue"
+              - !If
+                - RunInVpc
+                - Effect: Allow
+                  Action:
+                    - ec2:CreateNetworkInterfacePermission
+                  Resource:
+                    - !Sub "arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:network-interface/*"
+                  Condition:
+                    StringEquals:
+                      "ec2:AuthorizedService": codebuild.amazonaws.com
+                    ArnEquals:
+                      "ec2:Vpc":
+                        - !Sub "arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:vpc/{{resolve:ssm:/SDLF/VPC/VpcId}}"
+                - !Ref "AWS::NoValue"
 
   rCloudFormationPackageCodeBuildProject:
     Type: AWS::CodeBuild::Project
@@ -793,6 +864,12 @@ Resources:
       Artifacts:
         Type: CODEPIPELINE
       EncryptionKey: !Ref pKMSKey
+      VpcConfig: !If
+        - RunInVpc
+        - SecurityGroupIds: !Split [",", !ImportValue sdlf-cicd-prerequisites-vpc-security-groups]
+          Subnets: !Split [",", !ImportValue sdlf-cicd-prerequisites-vpc-subnets]
+          VpcId: "{{resolve:ssm:/SDLF/VPC/VpcId}}"
+        - !Ref "AWS::NoValue"
       Environment:
         ComputeType: BUILD_GENERAL1_SMALL
         Image: aws/codebuild/amazonlinux2-x86_64-standard:5.0
@@ -818,7 +895,9 @@ Resources:
                     aws --version # version 2
             build:
               commands:
-                - aws cloudformation package --template "$TEMPLATE" --s3-bucket "$ARTIFACTS_BUCKET" --s3-prefix codebuild --output-template-file packaged-template.yaml
+                - |-
+                    CLOUDFORMATION_ENDPOINT_URL="https://cloudformation.$AWS_REGION.amazonaws.com"
+                    aws cloudformation --endpoint-url "$CLOUDFORMATION_ENDPOINT_URL" package --template "$TEMPLATE" --s3-bucket "$ARTIFACTS_BUCKET" --s3-prefix codebuild --output-template-file packaged-template.yaml
           artifacts:
             files:
               - packaged-template.yaml
@@ -868,6 +947,39 @@ Resources:
               - Effect: Allow
                 Action: sts:AssumeRole
                 Resource: !Sub arn:${AWS::Partition}:iam::*:role/sdlf-cicd-domain-crossaccount-cfn-modules
+              - !If
+                - RunInVpc
+                - Effect: Allow
+                  Action:
+                    - ec2:DescribeSecurityGroups # W11 exception
+                    - ec2:DescribeSubnets # W11 exception
+                    - ec2:DescribeVpcs # W11 exception
+                    - ec2:DescribeNetworkInterfaces # W11 exception
+                    - ec2:DescribeDhcpOptions # W11 exception
+                    - ec2:CreateNetworkInterface # W11 condition applied
+                    - ec2:DeleteNetworkInterface # W11 condition applied
+                  Resource:
+                    - "*"
+                  Condition:
+                    ArnEqualsIfExists:
+                      "ec2:Vpc":
+                        - !Sub "arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:vpc/{{resolve:ssm:/SDLF/VPC/VpcId}}"
+                - !Ref "AWS::NoValue"
+              - !If
+                - RunInVpc
+                - Effect: Allow
+                  Action:
+                    - ec2:CreateNetworkInterfacePermission
+                  Resource:
+                    - !Sub "arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:network-interface/*"
+                  Condition:
+                    StringEquals:
+                      "ec2:AuthorizedService": codebuild.amazonaws.com
+                    ArnEquals:
+                      "ec2:Vpc":
+                        - !Sub "arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:vpc/{{resolve:ssm:/SDLF/VPC/VpcId}}"
+                - !Ref "AWS::NoValue"
+
 
   rBuildDeployDatalakeLibraryLayer:
     Type: AWS::CodeBuild::Project
@@ -877,6 +989,12 @@ Resources:
       Name: !Sub sdlf-cicd-${pDatalakeLibsLambdaLayerName}
       Description: Creates a Lambda Layer with the repository provided
       EncryptionKey: !Ref pKMSKey
+      VpcConfig: !If
+        - RunInVpc
+        - SecurityGroupIds: !Split [",", !ImportValue sdlf-cicd-prerequisites-vpc-security-groups]
+          Subnets: !Split [",", !ImportValue sdlf-cicd-prerequisites-vpc-subnets]
+          VpcId: "{{resolve:ssm:/SDLF/VPC/VpcId}}"
+        - !Ref "AWS::NoValue"
       Environment:
         EnvironmentVariables:
           - Name: ARTIFACTS_BUCKET
@@ -907,14 +1025,16 @@ Resources:
                      --key "layers/$DOMAIN_NAME/$ENVIRONMENT/$TEAM_NAME/$LAYER_NAME-$CODEBUILD_RESOLVED_SOURCE_VERSION.zip" \
                      --body artifacts/datalake_library.zip
                 - |-
-                    temp_role=$(aws sts assume-role --role-arn "arn:${AWS::Partition}:iam::$DOMAIN_ACCOUNT_ID:role/sdlf-cicd-domain-crossaccount-cfn-modules" --role-session-name "codebuild-lambda-layer")
+                    CLOUDFORMATION_ENDPOINT_URL="https://cloudformation.$AWS_REGION.amazonaws.com"
+                    STS_ENDPOINT_URL="https://sts.$AWS_REGION.amazonaws.com"
+                    temp_role=$(aws sts --endpoint-url "$STS_ENDPOINT_URL" assume-role --role-arn "arn:${AWS::Partition}:iam::$DOMAIN_ACCOUNT_ID:role/sdlf-cicd-domain-crossaccount-cfn-modules" --role-session-name "codebuild-lambda-layer")
                     AWS_ACCESS_KEY_ID=$(echo "$temp_role" | jq .Credentials.AccessKeyId | xargs)
                     AWS_SECRET_ACCESS_KEY=$(echo "$temp_role" | jq .Credentials.SecretAccessKey | xargs)
                     AWS_SESSION_TOKEN=$(echo "$temp_role" | jq .Credentials.SessionToken | xargs)
                     export AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
 
                     STACK_NAME="sdlf-lambdalayers-$LAYER_NAME"
-                    aws cloudformation deploy \
+                    aws cloudformation --endpoint-url "$CLOUDFORMATION_ENDPOINT_URL" deploy \
                         --stack-name "$STACK_NAME" \
                         --template-file "$CODEBUILD_SRC_DIR_SourceCicdArtifact"/template-lambda-layer.yaml \
                         --parameter-overrides \

--- a/sdlf-cicd/template-glue-job.yaml
+++ b/sdlf-cicd/template-glue-job.yaml
@@ -24,12 +24,17 @@ Parameters:
   pGitRef:
     Description: Git reference (commit id) with the sources of these glue jobs
     Type: String
+  pEnableVpc:
+    Description: Deploy SDLF resources in a VPC
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: /SDLF/VPC/Enabled
 
 Conditions:
   GlueJobsNotEmpty: !Not
     - !Equals
       - !Join ["", !Ref pGlueJobs]
       - ""
+  RunInVpc: !Equals [!Ref pEnableVpc, true]
 
 Resources:
   rGlueRole:
@@ -67,6 +72,28 @@ Resources:
                   - !Sub "{{resolve:ssm:/SDLF/KMS/${pTeamName}/InfraKeyId}}"
                   - !Sub "{{resolve:ssm:/SDLF/KMS/${pTeamName}/DataKeyId}}"
                   - "{{resolve:ssm:/SDLF/KMS/KeyArn}}"
+
+  rGlueConnection:
+    Type: AWS::Glue::Connection
+    Condition: RunInVpc
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - W3010
+    Properties:
+      CatalogId: !Ref AWS::AccountId
+      ConnectionInput:
+        ConnectionProperties: {}
+        ConnectionType: NETWORK
+        Description: "Network connected to the VPC data source"
+        Name: !Sub sdlf-${pTeamName}-glue-conn
+        PhysicalConnectionRequirements:
+          AvailabilityZone: us-east-1a # this is not taking into account at all, but the property needs to be present anyway
+          SecurityGroupIdList: !Split [",", !ImportValue sdlf-cicd-domain-roles-vpc-security-groups]
+          SubnetId: !Select
+            - "1"
+            - !Split [",", !ImportValue sdlf-cicd-domain-roles-vpc-subnets]
 
   "Fn::ForEach::GlueJobResources":
   - GlueJobName

--- a/sdlf-datalakeLibrary/python/datalake_library/configuration/event_configs.py
+++ b/sdlf-datalakeLibrary/python/datalake_library/configuration/event_configs.py
@@ -14,7 +14,8 @@ class EventConfig:
         :param event: event JSON object
         """
         self._event = event
-        self._ssm_interface = ssm_interface or boto3.client("ssm")
+        ssm_endpoint_url = "https://ssm." + os.getenv("AWS_REGION") + ".amazonaws.com"
+        self._ssm_interface = ssm_interface or boto3.client("ssm", endpoint_url=ssm_endpoint_url)
 
         self.log_level = os.getenv("LOG_LEVEL", "INFO")
         self._logger = init_logger(__name__, self.log_level)

--- a/sdlf-datalakeLibrary/python/datalake_library/configuration/resource_configs.py
+++ b/sdlf-datalakeLibrary/python/datalake_library/configuration/resource_configs.py
@@ -15,7 +15,8 @@ class S3Configuration(BaseConfig):
         """
         self.log_level = log_level or os.getenv("LOG_LEVEL", "INFO")
         self._logger = init_logger(__name__, self.log_level)
-        self._ssm = ssm_interface or boto3.client("ssm")
+        ssm_endpoint_url = "https://ssm." + os.getenv("AWS_REGION") + ".amazonaws.com"
+        self._ssm = ssm_interface or boto3.client("ssm", endpoint_url=ssm_endpoint_url)
         super().__init__(self.log_level, self._ssm)
 
         self._fetch_from_environment()
@@ -94,7 +95,8 @@ class DynamoConfiguration(BaseConfig):
         """
         self.log_level = log_level or os.getenv("LOG_LEVEL", "INFO")
         self._logger = init_logger(__name__, self.log_level)
-        self._ssm = ssm_interface or boto3.client("ssm")
+        ssm_endpoint_url = "https://ssm." + os.getenv("AWS_REGION") + ".amazonaws.com"
+        self._ssm = ssm_interface or boto3.client("ssm", endpoint_url=ssm_endpoint_url)
         super().__init__(self.log_level, self._ssm)
 
         self._fetch_from_ssm()
@@ -132,7 +134,8 @@ class SQSConfiguration(BaseConfig):
         """
         self.log_level = log_level or os.getenv("LOG_LEVEL", "INFO")
         self._logger = init_logger(__name__, self.log_level)
-        self._ssm = ssm_interface or boto3.client("ssm")
+        ssm_endpoint_url = "https://ssm." + os.getenv("AWS_REGION") + ".amazonaws.com"
+        self._ssm = ssm_interface or boto3.client("ssm", endpoint_url=ssm_endpoint_url)
         self._team = team
         self._prefix = prefix
         self._stage = stage
@@ -170,7 +173,8 @@ class StateMachineConfiguration(BaseConfig):
         """
         self.log_level = log_level or os.getenv("LOG_LEVEL", "INFO")
         self._logger = init_logger(__name__, self.log_level)
-        self._ssm = ssm_interface or boto3.client("ssm")
+        ssm_endpoint_url = "https://ssm." + os.getenv("AWS_REGION") + ".amazonaws.com"
+        self._ssm = ssm_interface or boto3.client("ssm", endpoint_url=ssm_endpoint_url)
         self._team = team
         self._pipeline = pipeline
         self._stage = stage
@@ -199,7 +203,8 @@ class KMSConfiguration(BaseConfig):
         """
         self.log_level = log_level or os.getenv("LOG_LEVEL", "INFO")
         self._logger = init_logger(__name__, self.log_level)
-        self._ssm = ssm_interface or boto3.client("ssm")
+        ssm_endpoint_url = "https://ssm." + os.getenv("AWS_REGION") + ".amazonaws.com"
+        self._ssm = ssm_interface or boto3.client("ssm", endpoint_url=ssm_endpoint_url)
         self._team = team
         super().__init__(self.log_level, self._ssm)
 

--- a/sdlf-datalakeLibrary/python/datalake_library/data_quality/schema_validator.py
+++ b/sdlf-datalakeLibrary/python/datalake_library/data_quality/schema_validator.py
@@ -2,6 +2,7 @@ from abc import ABC, abstractmethod
 
 import awswrangler as wr  # Ensure Lambda has an AWS Wrangler Layer configured
 import boto3
+import os
 
 from ..commons import init_logger
 
@@ -22,7 +23,8 @@ class GlueSchemaValidator(ABC):
         """
         self.boto3_session = boto3_session
         # Reuse session or create a default one
-        self.glue_client = boto3_session.client("glue") if boto3_session else boto3.client("glue")
+        glue_endpoint_url = "https://glue." + os.getenv("AWS_REGION") + ".amazonaws.com"
+        self.glue_client = boto3_session.client("glue", endpoint_url=glue_endpoint_url) if boto3_session else boto3.client("glue", endpoint_url=glue_endpoint_url)
 
     def _get_table_parameters(self, database_name, table_name):
         """

--- a/sdlf-datalakeLibrary/python/datalake_library/interfaces/sqs_interface.py
+++ b/sdlf-datalakeLibrary/python/datalake_library/interfaces/sqs_interface.py
@@ -12,7 +12,8 @@ class SQSInterface:
     def __init__(self, queue_name, log_level=None, sqs_resource=None):
         self.log_level = log_level or os.getenv("LOG_LEVEL", "INFO")
         self._logger = init_logger(__name__, self.log_level)
-        self._sqs_resource = sqs_resource or boto3.resource("sqs")
+        sqs_endpoint_url = "https://sqs." + os.getenv("AWS_REGION") + ".amazonaws.com"
+        self._sqs_resource = sqs_resource or boto3.resource("sqs", endpoint_url=sqs_endpoint_url)
 
         self._message_queue = self._sqs_resource.get_queue_by_name(QueueName=queue_name)
 

--- a/sdlf-datalakeLibrary/python/datalake_library/interfaces/states_interface.py
+++ b/sdlf-datalakeLibrary/python/datalake_library/interfaces/states_interface.py
@@ -11,7 +11,8 @@ class StatesInterface:
     def __init__(self, log_level=None, states_client=None):
         self.log_level = log_level or os.getenv("LOG_LEVEL", "INFO")
         self._logger = init_logger(__name__, self.log_level)
-        self._states_client = states_client or boto3.client("stepfunctions")
+        stepfunctions_endpoint_url = "https://states." + os.getenv("AWS_REGION") + ".amazonaws.com"
+        self._states_client = states_client or boto3.client("stepfunctions", endpoint_url=stepfunctions_endpoint_url)
 
     @staticmethod
     def json_serial(obj):

--- a/sdlf-datalakeLibrary/python/datalake_library/octagon/client.py
+++ b/sdlf-datalakeLibrary/python/datalake_library/octagon/client.py
@@ -148,10 +148,12 @@ class OctagonClient:
         else:
             boto3.setup_default_session(profile_name=self.profile, region_name=self.region)
 
-        self.account_id = boto3.client("sts").get_caller_identity().get("Account")
+        sts_endpoint_url = "https://sts." + os.getenv("AWS_REGION") + ".amazonaws.com"
+        self.account_id = boto3.client("sts", endpoint_url=sts_endpoint_url).get_caller_identity().get("Account")
 
         self.dynamodb = boto3.resource("dynamodb")
-        self.sns = boto3.client("sns")
+        sns_endpoint_url = "https://sns." + os.getenv("AWS_REGION") + ".amazonaws.com"
+        self.sns = boto3.client("sns", endpoint_url=sns_endpoint_url)
         self.config = ConfigParser(self.configuration_file, self.configuration_instance)
         self.meta = OctagonMetadata(self.metadata_file)
         self.initialized = True

--- a/sdlf-foundations/lambda/catalog-redrive/src/lambda_function.py
+++ b/sdlf-foundations/lambda/catalog-redrive/src/lambda_function.py
@@ -7,7 +7,8 @@ logger = logging.getLogger()
 logger.setLevel(logging.INFO)
 dlq_name = os.environ["DLQ"]
 queue_name = os.environ["QUEUE"]
-sqs = boto3.resource("sqs")
+sqs_endpoint_url = "https://sqs." + os.getenv("AWS_REGION") + ".amazonaws.com"
+sqs = boto3.resource("sqs", endpoint_url=sqs_endpoint_url)
 
 
 def lambda_handler(event, context):

--- a/sdlf-foundations/lambda/catalog/src/lambda_function.py
+++ b/sdlf-foundations/lambda/catalog/src/lambda_function.py
@@ -9,9 +9,8 @@ from botocore.exceptions import ClientError
 
 logger = logging.getLogger()
 logger.setLevel(logging.INFO)
-sqs = boto3.resource("sqs")
-dynamodb = boto3.resource("dynamodb")
-catalog_table = dynamodb.Table(f"octagon-ObjectMetadata-{os.environ['ENV']}")
+dynamodb = boto3.client("dynamodb")
+catalog_table = f"octagon-ObjectMetadata-{os.environ['ENV']}"
 
 
 def parse_s3_event(s3_event):
@@ -26,7 +25,8 @@ def parse_s3_event(s3_event):
 
 def put_item(table, item, key):
     try:
-        response = table.put_item(
+        response = dynamodb.put_item(
+            TableName=table,
             Item=item,
             ConditionExpression=f"attribute_not_exists({key})",
         )
@@ -41,7 +41,10 @@ def put_item(table, item, key):
 
 def delete_item(table, key):
     try:
-        response = table.delete_item(Key=key)
+        response = dynamodb.delete_item(
+            TableName=table,
+            Key=key
+        )
     except ClientError as e:
         logger.error("Fatal error", exc_info=True)
         raise e

--- a/sdlf-foundations/template.yaml
+++ b/sdlf-foundations/template.yaml
@@ -55,17 +55,41 @@ Parameters:
         1827,
         3653,
       ]
+  # the ideal would be to fetch ssm:/SDLF/VPC/Enabled and not ask the user to set this variable to true manually.
+  # however between AWS::SSM::Parameter::Value<String> not working in CloudFormation modules,
+  # Fn::ImportValue not being accepted in CloudFormation modules template fragments,
+  # {{resolve:}} being evaluated later than the Conditions block, options are limited.
+  pEnableVpc:
+    Description: Deploy SDLF resources in a VPC
+    Type: String
+    Default: false
+  # pVpcSecurityGroupIds and pVpcSubnetIds are passed explicitly (unlike in sdlf-cicd/template-cicd-sdlf-repositories.yaml for example)
+  # due to Fn::ImportValue not being accepted in CloudFormation modules template fragments
+  pVpcSecurityGroupIds:
+    Description: VPC Security Groups Ids
+    Type: String
+    Default: ""
+  pVpcSubnetIds:
+    Description: VPC Subnet Ids
+    Type: String
+    Default: ""
 
 Conditions:
   CreateMultipleBuckets: !Equals [!Ref pNumBuckets, "3"]
   CreateSingleBucket: !Equals [!Ref pNumBuckets, "1"]
   UseCustomBucketPrefix: !Not [!Equals [!Ref pCustomBucketPrefix, sdlf]]
+  RunInVpc: !Equals [!Ref pEnableVpc, true]
 
 Globals:
   Function:
     Runtime: python3.11
     Handler: lambda_function.lambda_handler
     KmsKeyArn: !GetAtt rKMSKey.Arn
+    VpcConfig: !If
+      - RunInVpc
+      - SecurityGroupIds: !Split [",", !Ref pVpcSecurityGroupIds]
+        SubnetIds: !Split [",", !Ref pVpcSubnetIds]
+      - !Ref "AWS::NoValue"
 
 Resources:
   # Role defined upstream due to Lake Formation PutDataLakeSettings constraints
@@ -86,6 +110,10 @@ Resources:
         - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSGlueServiceRole
         - !Sub arn:${AWS::Partition}:iam::aws:policy/AmazonS3FullAccess
         - !Sub arn:${AWS::Partition}:iam::aws:policy/AWSLakeFormationDataAdmin
+        - !If
+          - RunInVpc
+          - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
+          - !Ref "AWS::NoValue"
       Policies:
         - PolicyName: sdlf-lakeformation-admin
           PolicyDocument:
@@ -885,6 +913,11 @@ Resources:
             Principal:
               Service: lambda.amazonaws.com
             Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - !If
+          - RunInVpc
+          - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
+          - !Ref "AWS::NoValue"
       Policies:
         - PolicyName: sdlf-catalog
           PolicyDocument:

--- a/sdlf-stageA/template.yaml
+++ b/sdlf-stageA/template.yaml
@@ -94,10 +94,29 @@ Parameters:
   pEnableTracing:
     Description: Flag for whether XRay tracing is enabled
     Type: String
+  # the ideal would be to fetch ssm:/SDLF/VPC/Enabled and not ask the user to set this variable to true manually.
+  # however between AWS::SSM::Parameter::Value<String> not working in CloudFormation modules,
+  # Fn::ImportValue not being accepted in CloudFormation modules template fragments,
+  # {{resolve:}} being evaluated later than the Conditions block, options are limited.
+  pEnableVpc:
+    Description: Deploy SDLF resources in a VPC
+    Type: String
+    Default: false
+  # pVpcSecurityGroupIds and pVpcSubnetIds are passed explicitly (unlike in sdlf-cicd/template-cicd-sdlf-repositories.yaml for example)
+  # due to Fn::ImportValue not being accepted in CloudFormation modules template fragments
+  pVpcSecurityGroupIds:
+    Description: VPC Security Groups Ids
+    Type: String
+    Default: ""
+  pVpcSubnetIds:
+    Description: VPC Subnet Ids
+    Type: String
+    Default: ""
 
 Conditions:
   DeployElasticSearch: !Equals [!Ref pElasticSearchEnabled, "true"]
   EnableTracing: !Equals [!Ref pEnableTracing, "true"]
+  RunInVpc: !Equals [!Ref pEnableVpc, true]
 
 Globals:
   Function:
@@ -106,6 +125,12 @@ Globals:
     Layers:
       - "{{resolve:ssm:/SDLF/Lambda/LatestDatalakeLibraryLayer}}"
     KmsKeyArn: !Sub "{{resolve:ssm:/SDLF/KMS/${pTeamName}/InfraKeyId}}"
+    VpcConfig: !If
+      - RunInVpc
+      - SecurityGroupIds: !Split [",", !Ref pVpcSecurityGroupIds]
+        SubnetIds: !Split [",", !Ref pVpcSubnetIds]
+      - !Ref "AWS::NoValue"
+
 
 Resources:
   rPipelineInterface:
@@ -177,6 +202,10 @@ Resources:
       PermissionsBoundary: !Sub "{{resolve:ssm:/SDLF/IAM/${pTeamName}/TeamPermissionsBoundary}}"
       ManagedPolicyArns:
         - !Ref rLambdaCommonPolicy
+        - !If
+          - RunInVpc
+          - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
+          - !Ref "AWS::NoValue"
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -218,6 +247,10 @@ Resources:
       PermissionsBoundary: !Sub "{{resolve:ssm:/SDLF/IAM/${pTeamName}/TeamPermissionsBoundary}}"
       ManagedPolicyArns:
         - !Ref rLambdaCommonPolicy
+        - !If
+          - RunInVpc
+          - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
+          - !Ref "AWS::NoValue"
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -252,6 +285,10 @@ Resources:
       PermissionsBoundary: !Sub "{{resolve:ssm:/SDLF/IAM/${pTeamName}/TeamPermissionsBoundary}}"
       ManagedPolicyArns:
         - !Ref rLambdaCommonPolicy
+        - !If
+          - RunInVpc
+          - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
+          - !Ref "AWS::NoValue"
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -301,6 +338,10 @@ Resources:
       PermissionsBoundary: !Sub "{{resolve:ssm:/SDLF/IAM/${pTeamName}/TeamPermissionsBoundary}}"
       ManagedPolicyArns:
         - !Ref rLambdaCommonPolicy
+        - !If
+          - RunInVpc
+          - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
+          - !Ref "AWS::NoValue"
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -346,6 +387,10 @@ Resources:
       PermissionsBoundary: !Sub "{{resolve:ssm:/SDLF/IAM/${pTeamName}/TeamPermissionsBoundary}}"
       ManagedPolicyArns:
         - !Ref rLambdaCommonPolicy
+        - !If
+          - RunInVpc
+          - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
+          - !Ref "AWS::NoValue"
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:

--- a/sdlf-stageB/template.yaml
+++ b/sdlf-stageB/template.yaml
@@ -90,10 +90,29 @@ Parameters:
   pEnableTracing:
     Description: Flag for whether XRay tracing is enabled
     Type: String
+  # the ideal would be to fetch ssm:/SDLF/VPC/Enabled and not ask the user to set this variable to true manually.
+  # however between AWS::SSM::Parameter::Value<String> not working in CloudFormation modules,
+  # Fn::ImportValue not being accepted in CloudFormation modules template fragments,
+  # {{resolve:}} being evaluated later than the Conditions block, options are limited.
+  pEnableVpc:
+    Description: Deploy SDLF resources in a VPC
+    Type: String
+    Default: false
+  # pVpcSecurityGroupIds and pVpcSubnetIds are passed explicitly (unlike in sdlf-cicd/template-cicd-sdlf-repositories.yaml for example)
+  # due to Fn::ImportValue not being accepted in CloudFormation modules template fragments
+  pVpcSecurityGroupIds:
+    Description: VPC Security Groups Ids
+    Type: String
+    Default: ""
+  pVpcSubnetIds:
+    Description: VPC Subnet Ids
+    Type: String
+    Default: ""
 
 Conditions:
   DeployElasticSearch: !Equals [!Ref pElasticSearchEnabled, "true"]
   EnableTracing: !Equals [!Ref pEnableTracing, "true"]
+  RunInVpc: !Equals [!Ref pEnableVpc, true]
 
 Globals:
   Function:
@@ -102,6 +121,11 @@ Globals:
     Layers:
       - "{{resolve:ssm:/SDLF/Lambda/LatestDatalakeLibraryLayer}}"
     KmsKeyArn: !Sub "{{resolve:ssm:/SDLF/KMS/${pTeamName}/InfraKeyId}}"
+    VpcConfig: !If
+      - RunInVpc
+      - SecurityGroupIds: !Split [",", !Ref pVpcSecurityGroupIds]
+        SubnetIds: !Split [",", !Ref pVpcSubnetIds]
+      - !Ref "AWS::NoValue"
 
 Resources:
   rPipelineInterface:
@@ -174,6 +198,10 @@ Resources:
       PermissionsBoundary: !Sub "{{resolve:ssm:/SDLF/IAM/${pTeamName}/TeamPermissionsBoundary}}"
       ManagedPolicyArns:
         - !Ref rLambdaCommonPolicy
+        - !If
+          - RunInVpc
+          - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
+          - !Ref "AWS::NoValue"
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -214,6 +242,10 @@ Resources:
       PermissionsBoundary: !Sub "{{resolve:ssm:/SDLF/IAM/${pTeamName}/TeamPermissionsBoundary}}"
       ManagedPolicyArns:
         - !Ref rLambdaCommonPolicy
+        - !If
+          - RunInVpc
+          - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
+          - !Ref "AWS::NoValue"
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -230,6 +262,10 @@ Resources:
       PermissionsBoundary: !Sub "{{resolve:ssm:/SDLF/IAM/${pTeamName}/TeamPermissionsBoundary}}"
       ManagedPolicyArns:
         - !Ref rLambdaCommonPolicy
+        - !If
+          - RunInVpc
+          - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
+          - !Ref "AWS::NoValue"
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -265,6 +301,10 @@ Resources:
       PermissionsBoundary: !Sub "{{resolve:ssm:/SDLF/IAM/${pTeamName}/TeamPermissionsBoundary}}"
       ManagedPolicyArns:
         - !Ref rLambdaCommonPolicy
+        - !If
+          - RunInVpc
+          - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
+          - !Ref "AWS::NoValue"
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:

--- a/sdlf-team/lambda/datasets-dynamodb/src/lambda_function.py
+++ b/sdlf-team/lambda/datasets-dynamodb/src/lambda_function.py
@@ -1,0 +1,76 @@
+import logging
+import os
+
+import boto3
+import json
+
+from boto3.dynamodb.types import TypeSerializer
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+dynamodb = boto3.client("dynamodb")
+ssm_endpoint_url = "https://ssm." + os.getenv("AWS_REGION") + ".amazonaws.com"
+ssm = boto3.client("ssm", endpoint_url=ssm_endpoint_url)
+
+def delete_dynamodb_dataset_entry(table_name, team_name, dataset_name):
+    response = dynamodb.delete_item(
+        TableName=table_name,
+        Key={"name": {"S": f"{team_name}-{dataset_name}"}},
+    )
+    return response
+
+def create_dynamodb_dataset_entry(table_name, team_name, dataset_name, pipeline_details):
+    pipeline_details_dynamodb_json = TypeSerializer().serialize(pipeline_details)
+    logger.info("PIPELINE DETAILS DYNAMODB JSON: %s", pipeline_details_dynamodb_json)
+    response = dynamodb.update_item(
+        TableName=table_name,
+        Key={"name": {"S": f"{team_name}-{dataset_name}"}},
+        ExpressionAttributeNames={
+            "#P": "pipeline",
+            "#MXIP": "max_items_process",
+            "#MIP": "min_items_process",
+            "#V": "version",
+        },
+        ExpressionAttributeValues={
+            ":p": pipeline_details_dynamodb_json,
+            ":mxip": {"M":{"stage_b": {"N": "100"},"stage_c": {"N": "100"}}}, # todo replace with a nested "pipeline_modifiers" field (half done)
+            ":mip": {"M":{"stage_b": {"N": "1"},"stage_c": {"N": "1"}}},
+            ":v": {"N": "1"},
+        },
+        UpdateExpression="SET #P = :p, #MXIP = :mxip, #MIP = :mip, #V = :v",
+        ReturnValues="UPDATED_NEW",
+    )
+    return response
+
+
+def lambda_handler(event, context):
+    try:
+        environment = os.getenv("ENVIRONMENT")
+        team_name = os.getenv("TEAM_NAME")
+        table = f"octagon-Datasets-{environment}"
+
+        paginator = ssm.get_paginator("get_parameters_by_path")
+        datasets_pages = paginator.paginate(
+            Path=f"/SDLF/Datasets/{team_name}",
+            PaginationConfig={"MaxItems": 30},
+        )
+
+        for datasets_page in datasets_pages:
+            for dataset in datasets_page["Parameters"]:
+                dataset_name = dataset["Name"].split("/")[-1]
+                logger.info("DATASET SSM CONTENT: %s", dataset["Value"])
+                dataset_pipeline_details = json.loads(dataset["Value"])
+                create_dynamodb_dataset_entry(table, team_name, dataset_name, dataset_pipeline_details)
+                logger.info(
+                    f"{team_name}-{dataset_name} DynamoDB Dataset entry created"
+                )
+
+        logger.info(
+            "INFO: Entries for datasets that no longer exist are not removed from DynamoDB"
+        )
+    except Exception as e:
+        message = "Function exception: " + str(e)
+        raise
+
+    return "Success"

--- a/sdlf-team/lambda/pipelines-dynamodb/src/lambda_function.py
+++ b/sdlf-team/lambda/pipelines-dynamodb/src/lambda_function.py
@@ -1,0 +1,75 @@
+import logging
+import os
+
+import boto3
+
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+dynamodb = boto3.client("dynamodb")
+ssm_endpoint_url = "https://ssm." + os.getenv("AWS_REGION") + ".amazonaws.com"
+ssm = boto3.client("ssm", endpoint_url=ssm_endpoint_url)
+
+def delete_dynamodb_pipeline_entry(table_name, team_name, pipeline_name, stage_name):
+    response = dynamodb.delete_item(
+        TableName=table_name,
+        Key={"name": {"S": f"{team_name}-{pipeline_name}-{stage_name}"}},
+    )
+    return response
+
+
+def create_dynamodb_pipeline_entry(
+    table_name, team_name, pipeline_name, stage_name
+):
+    response = dynamodb.update_item(
+        TableName=table_name,
+        Key={"name": {"S": f"{team_name}-{pipeline_name}-{stage_name}"}},
+        ExpressionAttributeNames={
+            "#T": "type",
+            "#S": "status",
+            "#V": "version",
+        },
+        ExpressionAttributeValues={
+            ":t": {
+                "S": "TRANSFORMATION",
+            },
+            ":s": {"S": "ACTIVE"},
+            ":v": {"N": "1"},
+        },
+        UpdateExpression="SET #T = :t, #S = :s, #V = :v",
+        ReturnValues="UPDATED_NEW",
+    )
+    return response
+
+
+def lambda_handler(event, context):
+    try:
+        environment = os.getenv("ENVIRONMENT")
+        team_name = os.getenv("TEAM_NAME")
+        table = f"octagon-Pipelines-{environment}"
+
+        paginator = ssm.get_paginator("get_parameters_by_path")
+        stages_pages = paginator.paginate(
+            Path=f"/SDLF/Pipelines/{team_name}",
+            Recursive=True,
+            PaginationConfig={"MaxItems": 30},
+        )
+        for stages_page in stages_pages:
+            for stage in stages_page["Parameters"]:
+                pipeline_name = stage["Name"].split("/")[-2]
+                stage_name = stage["Name"].split("/")[-1]
+                create_dynamodb_pipeline_entry(
+                    table, team_name, pipeline_name, stage_name
+                )
+                logger.info(
+                    f"{team_name}-{pipeline_name}-{stage_name} DynamoDB Pipeline entry created"
+                )
+
+        logger.info(
+            "INFO: Entries for stages that no longer exist are *not* removed from DynamoDB"
+        )
+    except Exception as e:
+        message = "Function exception: " + str(e)
+        raise
+
+    return "Success"

--- a/sdlf-team/template.yaml
+++ b/sdlf-team/template.yaml
@@ -1,4 +1,5 @@
 AWSTemplateFormatVersion: "2010-09-09"
+Transform: AWS::Serverless-2016-10-31
 Description: Resources to be created to manage a team
 
 Parameters:
@@ -48,10 +49,39 @@ Parameters:
   pLakeFormationDataAccessRole:
     Type: String
     Default: "{{resolve:ssm:/SDLF/IAM/LakeFormationDataAccessRoleArn}}"
+  # the ideal would be to fetch ssm:/SDLF/VPC/Enabled and not ask the user to set this variable to true manually.
+  # however between AWS::SSM::Parameter::Value<String> not working in CloudFormation modules,
+  # Fn::ImportValue not being accepted in CloudFormation modules template fragments,
+  # {{resolve:}} being evaluated later than the Conditions block, options are limited.
+  pEnableVpc:
+    Description: Deploy SDLF resources in a VPC
+    Type: String
+    Default: false
+  # pVpcSecurityGroupIds and pVpcSubnetIds are passed explicitly (unlike in sdlf-cicd/template-cicd-sdlf-repositories.yaml for example)
+  # due to Fn::ImportValue not being accepted in CloudFormation modules template fragments
+  pVpcSecurityGroupIds:
+    Description: VPC Security Groups Ids
+    Type: String
+    Default: ""
+  pVpcSubnetIds:
+    Description: VPC Subnet Ids
+    Type: String
+    Default: ""
 
 Conditions:
-  CreateMultipleBuckets:
-    !Not [!Equals [!Ref pCentralBucket, !Ref pAnalyticsBucket]]
+  CreateMultipleBuckets: !Not [!Equals [!Ref pCentralBucket, !Ref pAnalyticsBucket]]
+  RunInVpc: !Equals [!Ref pEnableVpc, true]
+
+Globals:
+  Function:
+    Runtime: python3.11
+    Handler: lambda_function.lambda_handler
+    KmsKeyArn: !GetAtt rKMSInfraKey.Arn
+    VpcConfig: !If
+      - RunInVpc
+      - SecurityGroupIds: !Split [",", !Ref pVpcSecurityGroupIds]
+        SubnetIds: !Split [",", !Ref pVpcSubnetIds]
+      - !Ref "AWS::NoValue"
 
 Resources:
   ######## KMS #########
@@ -240,8 +270,10 @@ Resources:
     Metadata:
       cfn_nag:
         rules_to_suppress:
-          - id: F5
-            reason: Condition Applied
+          - id: W13
+            reason: |-
+              Condition applied to restrict access, and the KMS keys do not exist at this stage
+              The other actions with "*" are all ones that only support the all resources wildcard
     Properties:
       Path: !Sub /sdlf/${pTeamName}/ # keep this path for the team's permissions boundary policy only
       Description: Team Permissions Boundary IAM policy. Add/remove permissions based on company policy and associate it to federated role
@@ -290,7 +322,29 @@ Resources:
           - Sid: AllowFullCodeCommitOnTeamRepositories
             Effect: Allow
             Action:
-              - codecommit:*
+              - codecommit:AssociateApprovalRuleTemplateWithRepository
+              - codecommit:BatchAssociateApprovalRuleTemplateWithRepositories
+              - codecommit:BatchDisassociateApprovalRuleTemplateFromRepositories
+              - codecommit:BatchGet*
+              - codecommit:BatchDescribe*
+              - codecommit:Create*
+              - codecommit:DeleteBranch
+              - codecommit:DeleteFile
+              - codecommit:Describe*
+              - codecommit:DisassociateApprovalRuleTemplateFromRepository
+              - codecommit:EvaluatePullRequestApprovalRules
+              - codecommit:Get*
+              - codecommit:List*
+              - codecommit:Merge*
+              - codecommit:OverridePullRequestApprovalRules
+              - codecommit:Put*
+              - codecommit:Post*
+              - codecommit:TagResource
+              - codecommit:Test*
+              - codecommit:UntagResource
+              - codecommit:Update*
+              - codecommit:GitPull
+              - codecommit:GitPush
             Resource:
               - !Sub arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
           - Sid: AllowTeamKMSDataKeyUsage
@@ -388,6 +442,22 @@ Resources:
               - lambda:InvokeFunction
             Resource:
               - !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:sdlf-${pTeamName}-*
+          - !If
+            - RunInVpc
+            - Effect: Allow
+              Action:
+                - ec2:CreateNetworkInterface # W13 condition applied
+                - ec2:DescribeNetworkInterfaces # W13 exception
+                - ec2:DeleteNetworkInterface # W13 condition applied
+                - ec2:AssignPrivateIpAddresses # W13 condition applied
+                - ec2:UnassignPrivateIpAddresses # W13 condition applied
+              Resource:
+                - "*"
+              Condition:
+                ArnEqualsIfExists:
+                  "ec2:Vpc":
+                    - !Sub "arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:vpc/{{resolve:ssm:/SDLF/VPC/VpcId}}"
+            - !Ref "AWS::NoValue"
 
   rDatalakeCrawlerRole:
     Type: AWS::IAM::Role
@@ -511,6 +581,11 @@ Resources:
                 - lambda.amazonaws.com
             Action:
               - sts:AssumeRole
+      ManagedPolicyArns:
+        - !If
+          - RunInVpc
+          - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
+          - !Ref "AWS::NoValue"
       Policies:
         - PolicyName: !Sub sdlf-${pTeamName}-dynamodb-lambda
           PolicyDocument:
@@ -555,97 +630,18 @@ Resources:
                   - !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/Datasets/${pTeamName}
 
   rDatasetsDynamodbLambda:
-    Type: AWS::Lambda::Function
+    Type: AWS::Serverless::Function
     Properties:
       Description: !Sub Creates/updates DynamoDB entries for ${pTeamName} datasets
       FunctionName: !Sub sdlf-${pTeamName}-datasets-dynamodb
-      Handler: index.lambda_handler
       MemorySize: 192
       Role: !GetAtt rDatasetsDynamodbLambdaRole.Arn
-      Runtime: python3.11
       Timeout: 300
       Environment:
         Variables:
           TEAM_NAME: !Ref pTeamName
           ENVIRONMENT: !Ref pEnvironment
-      Code:
-        ZipFile: |
-          import logging
-          import os
-
-          import boto3
-          import json
-
-          from boto3.dynamodb.types import TypeSerializer
-
-          logger = logging.getLogger()
-          logger.setLevel(logging.INFO)
-
-          dynamodb = boto3.client("dynamodb")
-          ssm = boto3.client("ssm")
-          codepipeline = boto3.client("codepipeline")
-
-          def delete_dynamodb_dataset_entry(table_name, team_name, dataset_name):
-              response = dynamodb.delete_item(
-                  TableName=table_name,
-                  Key={"name": {"S": f"{team_name}-{dataset_name}"}},
-              )
-              return response
-
-          def create_dynamodb_dataset_entry(table_name, team_name, dataset_name, pipeline_details):
-              pipeline_details_dynamodb_json = TypeSerializer().serialize(pipeline_details)
-              logger.info("PIPELINE DETAILS DYNAMODB JSON: %s", pipeline_details_dynamodb_json)
-              response = dynamodb.update_item(
-                  TableName=table_name,
-                  Key={"name": {"S": f"{team_name}-{dataset_name}"}},
-                  ExpressionAttributeNames={
-                      "#P": "pipeline",
-                      "#MXIP": "max_items_process",
-                      "#MIP": "min_items_process",
-                      "#V": "version",
-                  },
-                  ExpressionAttributeValues={
-                      ":p": pipeline_details_dynamodb_json,
-                      ":mxip": {"M":{"stage_b": {"N": "100"},"stage_c": {"N": "100"}}}, # todo replace with a nested "pipeline_modifiers" field (half done)
-                      ":mip": {"M":{"stage_b": {"N": "1"},"stage_c": {"N": "1"}}},
-                      ":v": {"N": "1"},
-                  },
-                  UpdateExpression="SET #P = :p, #MXIP = :mxip, #MIP = :mip, #V = :v",
-                  ReturnValues="UPDATED_NEW",
-              )
-              return response
-
-
-          def lambda_handler(event, context):
-              try:
-                  environment = os.getenv("ENVIRONMENT")
-                  team_name = os.getenv("TEAM_NAME")
-                  table = f"octagon-Datasets-{environment}"
-
-                  paginator = ssm.get_paginator("get_parameters_by_path")
-                  datasets_pages = paginator.paginate(
-                      Path=f"/SDLF/Datasets/{team_name}",
-                      PaginationConfig={"MaxItems": 30},
-                  )
-
-                  for datasets_page in datasets_pages:
-                    for dataset in datasets_page["Parameters"]:
-                        dataset_name = dataset["Name"].split("/")[-1]
-                        logger.info("DATASET SSM CONTENT: %s", dataset["Value"])
-                        dataset_pipeline_details = json.loads(dataset["Value"])
-                        create_dynamodb_dataset_entry(table, team_name, dataset_name, dataset_pipeline_details)
-                        logger.info(
-                            f"{team_name}-{dataset_name} DynamoDB Dataset entry created"
-                        )
-
-                  logger.info(
-                      "INFO: Entries for datasets that no longer exist are not removed from DynamoDB"
-                  )
-              except Exception as e:
-                  message = "Function exception: " + str(e)
-                  raise
-
-              return "Success"
+      CodeUri: ./lambda/datasets-dynamodb/src
 
   rPermissionForDatasetsEventsToInvokeLambda:
     Type: AWS::Lambda::Permission
@@ -689,6 +685,11 @@ Resources:
                 - lambda.amazonaws.com
             Action:
               - sts:AssumeRole
+      ManagedPolicyArns:
+        - !If
+          - RunInVpc
+          - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
+          - !Ref "AWS::NoValue"
       Policies:
         - PolicyName: !Sub sdlf-${pTeamName}-dynamodb-lambda
           PolicyDocument:
@@ -733,96 +734,18 @@ Resources:
                   - !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/Datasets/${pTeamName}
 
   rPipelinesDynamodbLambda:
-    Type: AWS::Lambda::Function
+    Type: AWS::Serverless::Function
     Properties:
       Description: !Sub Creates/updates DynamoDB entries for ${pTeamName} pipelines
       FunctionName: !Sub sdlf-${pTeamName}-pipelines-dynamodb
-      Handler: index.lambda_handler
       MemorySize: 192
       Role: !GetAtt rPipelinesDynamodbLambdaRole.Arn
-      Runtime: python3.11
       Timeout: 300
       Environment:
         Variables:
           TEAM_NAME: !Ref pTeamName
           ENVIRONMENT: !Ref pEnvironment
-      Code:
-        ZipFile: |
-          import logging
-          import os
-
-          import boto3
-
-          logger = logging.getLogger()
-          logger.setLevel(logging.INFO)
-
-          dynamodb = boto3.client("dynamodb")
-          ssm = boto3.client("ssm")
-          codepipeline = boto3.client("codepipeline")
-
-          def delete_dynamodb_pipeline_entry(table_name, team_name, pipeline_name, stage_name):
-              response = dynamodb.delete_item(
-                  TableName=table_name,
-                  Key={"name": {"S": f"{team_name}-{pipeline_name}-{stage_name}"}},
-              )
-              return response
-
-
-          def create_dynamodb_pipeline_entry(
-              table_name, team_name, pipeline_name, stage_name
-          ):
-              response = dynamodb.update_item(
-                  TableName=table_name,
-                  Key={"name": {"S": f"{team_name}-{pipeline_name}-{stage_name}"}},
-                  ExpressionAttributeNames={
-                      "#T": "type",
-                      "#S": "status",
-                      "#V": "version",
-                  },
-                  ExpressionAttributeValues={
-                      ":t": {
-                          "S": "TRANSFORMATION",
-                      },
-                      ":s": {"S": "ACTIVE"},
-                      ":v": {"N": "1"},
-                  },
-                  UpdateExpression="SET #T = :t, #S = :s, #V = :v",
-                  ReturnValues="UPDATED_NEW",
-              )
-              return response
-
-
-          def lambda_handler(event, context):
-              try:
-                  environment = os.getenv("ENVIRONMENT")
-                  team_name = os.getenv("TEAM_NAME")
-                  table = f"octagon-Pipelines-{environment}"
-
-                  paginator = ssm.get_paginator("get_parameters_by_path")
-                  stages_pages = paginator.paginate(
-                      Path=f"/SDLF/Pipelines/{team_name}",
-                      Recursive=True,
-                      PaginationConfig={"MaxItems": 30},
-                  )
-                  for stages_page in stages_pages:
-                    for stage in stages_page["Parameters"]:
-                        pipeline_name = stage["Name"].split("/")[-2]
-                        stage_name = stage["Name"].split("/")[-1]
-                        create_dynamodb_pipeline_entry(
-                            table, team_name, pipeline_name, stage_name
-                        )
-                        logger.info(
-                            f"{team_name}-{pipeline_name}-{stage_name} DynamoDB Pipeline entry created"
-                        )
-
-                  logger.info(
-                      "INFO: Entries for stages that no longer exist are *not* removed from DynamoDB"
-                  )
-              except Exception as e:
-                  message = "Function exception: " + str(e)
-                  raise
-
-              return "Success"
+      CodeUri: ./lambda/pipelines-dynamodb/src
 
   rPermissionForPipelinesEventsToInvokeLambda:
     Type: AWS::Lambda::Permission


### PR DESCRIPTION
*Issue #, if available:*
#153 

*Description of changes:*
* vpcs, subnets, vpc endpoints (etc.) deployment is not covered by SDLF - they need provisioning ahead of any SDLF deployment
* regional endpoint urls are passed explicitly in SDLF (boto3 client calls) - `Enable DNS hostnames` and `Enable DNS support`, two VPC attributes, have to be enabled
* `Enable DNS name` has to be enabled on VPC endpoints

Set pEnableVpc to true in both:
* `sdlf-cicd/template-cicd-prerequisites.yaml`
* `sdlf-cicd/template-cicd-domain-roles.yaml`

This will populate the SSM Parameter `/SDLF/VPC/Enabled`. Make sure to provide the following parameters as well (their creation is not handled by SDLF):
* `/SDLF/VPC/VpcId`
* `/SDLF/VPC/SubnetIds`
* `/SDLF/VPC/SecurityGroupIds`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
