### PR TITLE
restore min/max_items_process feature at the pipeline level

### DIFF
--- a/sdlf-datalakeLibrary/python/datalake_library/configuration/resource_configs.py
+++ b/sdlf-datalakeLibrary/python/datalake_library/configuration/resource_configs.py
@@ -104,6 +104,7 @@ class DynamoConfiguration(BaseConfig):
     def _fetch_from_ssm(self):
         self._object_metadata_table = None
         self._transform_mapping_table = None
+        self._pipelines_table = None
         self._manifests_control_table = None
 
     @property
@@ -117,6 +118,12 @@ class DynamoConfiguration(BaseConfig):
         if not self._transform_mapping_table:
             self._transform_mapping_table = self._get_ssm_param("/SDLF/Dynamo/TransformMapping")
         return self._transform_mapping_table
+
+    @property
+    def pipelines_table(self):
+        if not self._pipelines_table:
+            self._pipelines_table = self._get_ssm_param("/SDLF/Dynamo/Pipelines")
+        return self._pipelines_table
 
     @property
     def manifests_control_table(self):

--- a/sdlf-datalakeLibrary/python/datalake_library/interfaces/dynamo_interface.py
+++ b/sdlf-datalakeLibrary/python/datalake_library/interfaces/dynamo_interface.py
@@ -18,10 +18,12 @@ class DynamoInterface:
 
         self.object_metadata_table = None
         self.transform_mapping_table = None
+        self.pipelines_table = None
         self.manifests_control_table = None
 
         self._get_object_metadata_table()
         self._get_transform_mapping_table()
+        self._get_pipelines_table()
         self._get_manifests_control_table()
 
     def _get_object_metadata_table(self):
@@ -33,6 +35,11 @@ class DynamoInterface:
         if not self.transform_mapping_table:
             self.transform_mapping_table = self.dynamodb_resource.Table(self._config.transform_mapping_table)
         return self.transform_mapping_table
+
+    def _get_pipelines_table(self):
+        if not self.pipelines_table:
+            self.pipelines_table = self.dynamodb_resource.Table(self._config.pipelines_table)
+        return self.pipelines_table
 
     def _get_manifests_control_table(self):
         if not self.manifests_control_table:
@@ -68,6 +75,9 @@ class DynamoInterface:
 
     def get_transform_table_item(self, dataset):
         return self.get_item(self.transform_mapping_table, {"name": dataset})
+
+    def get_pipelines_table_item(self, pipeline):
+        return self.get_item(self.pipelines_table, {"name": pipeline})
 
     def update_object_metadata_catalog(self, item):
         item["id"] = self.build_id(item["bucket"], item["key"])

--- a/sdlf-foundations/template.yaml
+++ b/sdlf-foundations/template.yaml
@@ -1549,6 +1549,13 @@ Resources:
       Type: String
       Value: !Ref rDynamoOctagonDatasets
       Description: Name of the DynamoDB used to store mappings to transformation
+  rDynamoPipelinesSsm:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: /SDLF/Dynamo/Pipelines
+      Type: String
+      Value: !Ref rDynamoOctagonPipelines
+      Description: Name of the DynamoDB used to store pipelines metadata
   rDynamoTeamMetadataSsm:
     Type: AWS::SSM::Parameter
     Properties:

--- a/sdlf-team/lambda/datasets-dynamodb/src/lambda_function.py
+++ b/sdlf-team/lambda/datasets-dynamodb/src/lambda_function.py
@@ -28,17 +28,13 @@ def create_dynamodb_dataset_entry(table_name, team_name, dataset_name, pipeline_
         Key={"name": {"S": f"{team_name}-{dataset_name}"}},
         ExpressionAttributeNames={
             "#P": "pipeline",
-            "#MXIP": "max_items_process",
-            "#MIP": "min_items_process",
             "#V": "version",
         },
         ExpressionAttributeValues={
             ":p": pipeline_details_dynamodb_json,
-            ":mxip": {"M":{"stage_b": {"N": "100"},"stage_c": {"N": "100"}}}, # todo replace with a nested "pipeline_modifiers" field (half done)
-            ":mip": {"M":{"stage_b": {"N": "1"},"stage_c": {"N": "1"}}},
             ":v": {"N": "1"},
         },
-        UpdateExpression="SET #P = :p, #MXIP = :mxip, #MIP = :mip, #V = :v",
+        UpdateExpression="SET #P = :p, #V = :v",
         ReturnValues="UPDATED_NEW",
     )
     return response

--- a/sdlf-team/lambda/pipelines-dynamodb/src/lambda_function.py
+++ b/sdlf-team/lambda/pipelines-dynamodb/src/lambda_function.py
@@ -27,6 +27,7 @@ def create_dynamodb_pipeline_entry(
         ExpressionAttributeNames={
             "#T": "type",
             "#S": "status",
+            "#P": "pipeline",
             "#V": "version",
         },
         ExpressionAttributeValues={
@@ -34,9 +35,10 @@ def create_dynamodb_pipeline_entry(
                 "S": "TRANSFORMATION",
             },
             ":s": {"S": "ACTIVE"},
+            ":p": {"M": {"max_items_process": {"N": "100"},"min_items_process": {"N": "1"}}},
             ":v": {"N": "1"},
         },
-        UpdateExpression="SET #T = :t, #S = :s, #V = :v",
+        UpdateExpression="SET #T = :t, #S = :s, #P = :p, #V = :v",
         ReturnValues="UPDATED_NEW",
     )
     return response


### PR DESCRIPTION
*Description of changes:*
Restore min/max_items_process feature at the pipeline level.

This used to be at the [dataset level in SDLFv1](https://github.com/awslabs/aws-serverless-data-lake-framework/blob/main/sdlf-stageB/lambda/stage-b-routing/src/lambda_function.py#L37-L38). In SDLFv2 the routing lambda doesn't know the dataset - the SQS queue is shared. This is why it has been moved to the pipeline table.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
