### PR TITLE
Crossaccount roles simplification

### DIFF
--- a/sdlf-cicd/lambda/crossaccountteam-cicd/src/lambda_function.py
+++ b/sdlf-cicd/lambda/crossaccountteam-cicd/src/lambda_function.py
@@ -250,7 +250,7 @@ def lambda_handler(event, context):
 
             # assume role in child account to be able to deploy a cloudformation stack
             crossaccount_pipeline_role = (
-                f"arn:{partition}:iam::{child_account}:role/sdlf-cicd-team-crossaccount-pipeline"
+                f"arn:{partition}:iam::{child_account}:role/sdlf-cicd-devops-crossaccount-pipeline"
             )
             sts_endpoint_url = "https://sts." + os.getenv("AWS_REGION") + ".amazonaws.com"
             sts = boto3.client("sts", endpoint_url=sts_endpoint_url)

--- a/sdlf-cicd/nested-stacks/template-cicd-cfn-module.yaml
+++ b/sdlf-cicd/nested-stacks/template-cicd-cfn-module.yaml
@@ -76,7 +76,7 @@ Resources:
                   - !Ref pKMSKey
               - Effect: Allow
                 Action: sts:AssumeRole
-                Resource: !Sub arn:${AWS::Partition}:iam::*:role/sdlf-cicd-domain-crossaccount-cfn-modules
+                Resource: !Sub arn:${AWS::Partition}:iam::*:role/sdlf-cicd-devops-crossaccount-pipeline
               - !If
                 - RunInVpc
                 - Effect: Allow
@@ -195,7 +195,7 @@ Resources:
                                           --key "modules/$DOMAIN_NAME/$ENVIRONMENT/$TEAM_NAME/$MODULE_NAME-$NEW_MODULE.zip" \
                                           --body "../$MODULE_NAME.zip"
                 - |-
-                    temp_role=$(aws sts --endpoint-url "$STS_ENDPOINT_URL" assume-role --role-arn "arn:${AWS::Partition}:iam::$DOMAIN_ACCOUNT_ID:role/sdlf-cicd-domain-crossaccount-cfn-modules" --role-session-name "codebuild-cfn-module")
+                    temp_role=$(aws sts --endpoint-url "$STS_ENDPOINT_URL" assume-role --role-arn "arn:${AWS::Partition}:iam::$DOMAIN_ACCOUNT_ID:role/sdlf-cicd-devops-crossaccount-pipeline" --role-session-name "codebuild-cfn-module")
                     AWS_ACCESS_KEY_ID=$(echo "$temp_role" | jq .Credentials.AccessKeyId | xargs)
                     AWS_SECRET_ACCESS_KEY=$(echo "$temp_role" | jq .Credentials.SecretAccessKey | xargs)
                     AWS_SESSION_TOKEN=$(echo "$temp_role" | jq .Credentials.SessionToken | xargs)
@@ -321,7 +321,7 @@ Resources:
                       popd || exit
                     done
                 - |-
-                    temp_role=$(aws sts --endpoint-url "$STS_ENDPOINT_URL" assume-role --role-arn "arn:${AWS::Partition}:iam::$DOMAIN_ACCOUNT_ID:role/sdlf-cicd-domain-crossaccount-cfn-modules" --role-session-name "codebuild-cfn-module")
+                    temp_role=$(aws sts --endpoint-url "$STS_ENDPOINT_URL" assume-role --role-arn "arn:${AWS::Partition}:iam::$DOMAIN_ACCOUNT_ID:role/sdlf-cicd-devops-crossaccount-pipeline" --role-session-name "codebuild-cfn-module")
                     AWS_ACCESS_KEY_ID=$(echo "$temp_role" | jq .Credentials.AccessKeyId | xargs)
                     AWS_SECRET_ACCESS_KEY=$(echo "$temp_role" | jq .Credentials.SecretAccessKey | xargs)
                     AWS_SESSION_TOKEN=$(echo "$temp_role" | jq .Credentials.SessionToken | xargs)

--- a/sdlf-cicd/template-cicd-domain-roles.yaml
+++ b/sdlf-cicd/template-cicd-domain-roles.yaml
@@ -31,7 +31,7 @@ Resources:
       Value: !Ref pEnableVpc
       Description: Deploy SDLF resources in a VPC
 
-  rBuildModuleActionCodePipelineRole:
+  rDevopsCrossaccountCodePipelineRole:
     Type: AWS::IAM::Role
     Metadata:
       cfn_nag:
@@ -39,7 +39,7 @@ Resources:
           - id: W11
             reason: KMS permissions are controlled through kms:ResourceAliases, the team's KMS infra key has not been created yet and its ARN is not known
     Properties:
-      RoleName: sdlf-cicd-domain-crossaccount-cfn-modules
+      RoleName: sdlf-cicd-devops-crossaccount-pipeline
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
         Statement:
@@ -82,22 +82,40 @@ Resources:
                 Resource: !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/CFN/*
               - Effect: Allow
                 Action:
-                  - cloudformation:CreateStack
-                  - cloudformation:UpdateStack
-                  - cloudformation:DescribeStacks
-                  - cloudformation:DescribeChangeSet
                   - cloudformation:CreateChangeSet
+                  - cloudformation:CreateStack
+                  - cloudformation:DeleteChangeSet
+                  - cloudformation:DeleteStack
+                  - cloudformation:DescribeChangeSet
+                  - cloudformation:DescribeStacks
                   - cloudformation:ExecuteChangeSet
+                  - cloudformation:SetStackPolicy
+                  - cloudformation:UpdateStack
                   - cloudformation:GetTemplateSummary
                 Resource:
                   - !Sub "arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/sdlf-cfn-module-*"
                   - !Sub "arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/sdlf-lambdalayers-*"
+                  - !Sub arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/sdlf-domain-*
+                  - !Sub arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/sdlf-cicd-team-role-*
+                  - !Sub arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/sdlf-*-pipelines-*
+                  - !Sub arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/sdlf-*-datasets-*
+                  - !Sub arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/sdlf-*-lambdalayers-*
+                  - !Sub arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/sdlf-*-gluejobs-*
               - Effect: Allow
                 Action: iam:PassRole
-                Resource: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/sdlf-cicd-cfn-modules
+                Resource:
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/sdlf-cicd-cfn-modules
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/sdlf-cicd-domain
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/sdlf-cicd-team
+                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/sdlf-cicd-team-*
                 Condition:
                   StringEquals:
                     "iam:PassedToService": cloudformation.amazonaws.com
+              - Effect: Allow
+                Action:
+                  - cloudformation:DescribeStacks
+                Resource:
+                  - !Sub arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/sdlf-*
 
   rBuildModuleCloudFormationRole:
     Type: AWS::IAM::Role
@@ -199,74 +217,6 @@ Resources:
                   - ssm:DeleteParameter
                 Resource:
                   - !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/Lambda/LatestDatalakeLibraryLayer
-
-  rDomainCodePipelineRole:
-    Type: AWS::IAM::Role
-    Metadata:
-      cfn_nag:
-        rules_to_suppress:
-          - id: W11
-            reason: KMS permissions are controlled through kms:ResourceAliases, the team's KMS infra key has not been created yet and its ARN is not known
-    Properties:
-      RoleName: sdlf-cicd-domain-crossaccount-pipeline
-      AssumeRolePolicyDocument:
-        Version: "2012-10-17"
-        Statement:
-          - Effect: Allow
-            Principal:
-              AWS:
-                - !Sub arn:${AWS::Partition}:iam::${pDevOpsAccountId}:root
-            Action:
-              - sts:AssumeRole
-      Policies:
-        - PolicyName: sdlf-cicd-codepipeline
-          PolicyDocument:
-            Version: "2012-10-17"
-            Statement:
-              - Effect: Allow
-                Action:
-                  - s3:Get*
-                  - s3:ListBucket*
-                  - s3:Put*
-                Resource:
-                  - !Sub arn:${AWS::Partition}:s3:::${pDevOpsArtifactsBucket}
-                  - !Sub arn:${AWS::Partition}:s3:::${pDevOpsArtifactsBucket}/*
-              - Effect: Allow
-                Action:
-                  - kms:Decrypt
-                  - kms:Describe*
-                  - kms:Encrypt
-                  - kms:GenerateDataKey*
-                  - kms:List*
-                  - kms:ReEncrypt*
-                Resource: "*"
-                Condition:
-                  "ForAnyValue:StringLike":
-                    "kms:ResourceAliases": !Ref pDevOpsKMSKey
-              - Effect: Allow
-                Action:
-                  - cloudformation:DescribeStacks
-                Resource:
-                  - !Sub arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/sdlf-*
-              - Effect: Allow
-                Action:
-                  - cloudformation:CreateChangeSet
-                  - cloudformation:CreateStack
-                  - cloudformation:DeleteChangeSet
-                  - cloudformation:DeleteStack
-                  - cloudformation:DescribeChangeSet
-                  - cloudformation:DescribeStacks
-                  - cloudformation:ExecuteChangeSet
-                  - cloudformation:SetStackPolicy
-                  - cloudformation:UpdateStack
-                Resource:
-                  - !Sub arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/sdlf-domain-*
-              - Effect: Allow
-                Action: iam:PassRole
-                Resource: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/sdlf-cicd-domain
-                Condition:
-                  StringEquals:
-                    "iam:PassedToService": cloudformation.amazonaws.com
 
   rDomainCloudFormationRole:
     Type: AWS::IAM::Role
@@ -615,80 +565,6 @@ Resources:
                   Resource:
                     - "*"
                 - !Ref "AWS::NoValue"
-
-  rTeamCodePipelineRole:
-    Type: AWS::IAM::Role
-    Metadata:
-      cfn_nag:
-        rules_to_suppress:
-          - id: W11
-            reason: KMS permissions are controlled through kms:ResourceAliases, the team's KMS infra key has not been created yet and its ARN is not known
-    Properties:
-      RoleName: sdlf-cicd-team-crossaccount-pipeline
-      AssumeRolePolicyDocument:
-        Version: "2012-10-17"
-        Statement:
-          - Effect: Allow
-            Principal:
-              AWS:
-                - !Sub arn:${AWS::Partition}:iam::${pDevOpsAccountId}:root
-            Action:
-              - sts:AssumeRole
-      Policies:
-        - PolicyName: sdlf-cicd-team-codepipeline
-          PolicyDocument:
-            Version: "2012-10-17"
-            Statement:
-              - Effect: Allow
-                Action:
-                  - s3:Get*
-                  - s3:ListBucket*
-                  - s3:Put*
-                Resource:
-                  - !Sub arn:${AWS::Partition}:s3:::${pDevOpsArtifactsBucket}
-                  - !Sub arn:${AWS::Partition}:s3:::${pDevOpsArtifactsBucket}/*
-              - Effect: Allow
-                Action:
-                  - kms:Decrypt
-                  - kms:Describe*
-                  - kms:Encrypt
-                  - kms:GenerateDataKey*
-                  - kms:List*
-                  - kms:ReEncrypt*
-                Resource: "*"
-                Condition:
-                  "ForAnyValue:StringLike":
-                    "kms:ResourceAliases": !Ref pDevOpsKMSKey
-              - Effect: Allow
-                Action:
-                  - cloudformation:DescribeStacks
-                Resource:
-                  - !Sub arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/sdlf-*
-              - Effect: Allow
-                Action:
-                  - cloudformation:CreateChangeSet
-                  - cloudformation:CreateStack
-                  - cloudformation:DeleteChangeSet
-                  - cloudformation:DeleteStack
-                  - cloudformation:DescribeChangeSet
-                  - cloudformation:DescribeStacks
-                  - cloudformation:ExecuteChangeSet
-                  - cloudformation:SetStackPolicy
-                  - cloudformation:UpdateStack
-                Resource:
-                  - !Sub arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/sdlf-cicd-team-role-*
-                  - !Sub arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/sdlf-*-pipelines-*
-                  - !Sub arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/sdlf-*-datasets-*
-                  - !Sub arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/sdlf-*-lambdalayers-*
-                  - !Sub arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/sdlf-*-gluejobs-*
-              - Effect: Allow
-                Action: iam:PassRole
-                Resource:
-                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/sdlf-cicd-team
-                  - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/sdlf-cicd-team-*
-                Condition:
-                  StringEquals:
-                    "iam:PassedToService": cloudformation.amazonaws.com
 
   rTeamCloudFormationRole:
     Type: AWS::IAM::Role

--- a/sdlf-cicd/template-cicd-domain.yaml
+++ b/sdlf-cicd/template-cicd-domain.yaml
@@ -124,7 +124,7 @@ Resources:
               - Effect: Allow
                 Action: sts:AssumeRole
                 Resource:
-                  - !Sub arn:${AWS::Partition}:iam::${pChildAccountId}:role/sdlf-cicd-domain-crossaccount-pipeline
+                  - !Sub arn:${AWS::Partition}:iam::${pChildAccountId}:role/sdlf-cicd-devops-crossaccount-pipeline
 
   rDomainCodePipeline:
     Type: AWS::CodePipeline::Pipeline
@@ -250,7 +250,7 @@ Resources:
         - Name: DeployFoundationsAndTeamsInfrastructure
           Actions:
             - Name: CreateStack
-              RoleArn: !Sub arn:${AWS::Partition}:iam::${pChildAccountId}:role/sdlf-cicd-domain-crossaccount-pipeline
+              RoleArn: !Sub arn:${AWS::Partition}:iam::${pChildAccountId}:role/sdlf-cicd-devops-crossaccount-pipeline
               ActionTypeId:
                 Category: Deploy
                 Owner: AWS

--- a/sdlf-cicd/template-cicd-prerequisites.yaml
+++ b/sdlf-cicd/template-cicd-prerequisites.yaml
@@ -7,7 +7,7 @@ Parameters:
     Type: String
     Default: sdlf
   pDomainAccounts:
-    Description: S3 Bucket Prefix if different from default. Must be a valid S3 Bucket name
+    Description: List of AWS account ids bootstrapped with SDLF domain roles
     Type: CommaDelimitedList
   pEnableVpc:
     Description: Deploy SDLF resources in a VPC
@@ -17,6 +17,9 @@ Parameters:
 Conditions:
   UseCustomBucketPrefix: !Not [!Equals [!Ref pCustomBucketPrefix, sdlf]]
   RunInVpc: !Equals [!Ref pEnableVpc, true]
+  GovCloudPartition: !Equals
+    - !Sub ${AWS::Partition}
+    - aws-us-gov
 
 Resources:
   ######## OPTIONAL SDLF FEATURES #########
@@ -51,6 +54,11 @@ Resources:
     Type: AWS::KMS::Key
     UpdateReplacePolicy: Retain
     DeletionPolicy: Retain
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - I3042
     Properties:
       Description: KMS key for encryption of CodePipeline artifacts
       Enabled: true
@@ -75,33 +83,23 @@ Resources:
               - kms:GenerateDataKey*
               - kms:ReEncrypt*
             Resource: "*"
-          - Sid: CrossAccount Domain Pipelines
+          - Sid: CrossAccount Pipelines
             Effect: Allow
-            Principal:
-              AWS: !Split
+            Principal: !If
+              - GovCloudPartition
+              - AWS: !Split
                 - ","
                 - !Sub
-                  - "arn:${AWS::Partition}:iam::${inner}:role/sdlf-cicd-domain-crossaccount-pipeline"
+                  - "arn:${AWS::Partition}:iam::${inner}:role/sdlf-cicd-devops-crossaccount-pipeline"
                   - inner: !Join
-                    - ":role/sdlf-cicd-domain-crossaccount-pipeline,arn:${AWS::Partition}:iam::"
+                    - ":role/sdlf-cicd-devops-crossaccount-pipeline,arn:aws-us-gov:iam::"
                     - Ref: "pDomainAccounts"
-            Action:
-              - kms:Decrypt
-              - kms:Describe*
-              - kms:Encrypt
-              - kms:GenerateDataKey*
-              - kms:List*
-              - kms:ReEncrypt*
-            Resource: "*"
-          - Sid: CrossAccount Team Pipelines
-            Effect: Allow
-            Principal:
-              AWS: !Split
+              - AWS: !Split
                 - ","
                 - !Sub
-                  - "arn:${AWS::Partition}:iam::${inner}:role/sdlf-cicd-team-crossaccount-pipeline"
+                  - "arn:${AWS::Partition}:iam::${inner}:role/sdlf-cicd-devops-crossaccount-pipeline"
                   - inner: !Join
-                    - ":role/sdlf-cicd-team-crossaccount-pipeline,arn:${AWS::Partition}:iam::"
+                    - ":role/sdlf-cicd-devops-crossaccount-pipeline,arn:aws:iam::"
                     - Ref: "pDomainAccounts"
             Action:
               - kms:Decrypt
@@ -113,13 +111,21 @@ Resources:
             Resource: "*"
           - Sid: CrossAccount Domain Cfn
             Effect: Allow
-            Principal:
-              AWS: !Split
+            Principal: !If
+              - GovCloudPartition
+              - AWS: !Split
                 - ","
                 - !Sub
                   - "arn:${AWS::Partition}:iam::${inner}:role/sdlf-cicd-domain"
                   - inner: !Join
-                    - ":role/sdlf-cicd-domain,arn:${AWS::Partition}:iam::"
+                    - ":role/sdlf-cicd-domain,arn:aws-us-gov:iam::"
+                    - Ref: "pDomainAccounts"
+              - AWS: !Split
+                - ","
+                - !Sub
+                  - "arn:${AWS::Partition}:iam::${inner}:role/sdlf-cicd-domain"
+                  - inner: !Join
+                    - ":role/sdlf-cicd-domain,arn:aws:iam::"
                     - Ref: "pDomainAccounts"
             Action:
               - kms:Decrypt
@@ -131,13 +137,21 @@ Resources:
             Resource: "*"
           - Sid: CrossAccount Team Role Cfn
             Effect: Allow
-            Principal:
-              AWS: !Split
+            Principal: !If
+              - GovCloudPartition
+              - AWS: !Split
                 - ","
                 - !Sub
                   - "arn:${AWS::Partition}:iam::${inner}:role/sdlf-cicd-team"
                   - inner: !Join
-                    - ":role/sdlf-cicd-team,arn:${AWS::Partition}:iam::"
+                    - ":role/sdlf-cicd-team,arn:aws-us-gov:iam::"
+                    - Ref: "pDomainAccounts"
+              - AWS: !Split
+                - ","
+                - !Sub
+                  - "arn:${AWS::Partition}:iam::${inner}:role/sdlf-cicd-team"
+                  - inner: !Join
+                    - ":role/sdlf-cicd-team,arn:aws:iam::"
                     - Ref: "pDomainAccounts"
             Action:
               - kms:Decrypt
@@ -149,13 +163,21 @@ Resources:
             Resource: "*"
           - Sid: CrossAccount Module Cfn
             Effect: Allow
-            Principal:
-              AWS: !Split
+            Principal: !If
+              - GovCloudPartition
+              - AWS: !Split
                 - ","
                 - !Sub
                   - "arn:${AWS::Partition}:iam::${inner}:role/sdlf-cicd-cfn-modules"
                   - inner: !Join
-                    - ":role/sdlf-cicd-cfn-modules,arn:${AWS::Partition}:iam::"
+                    - ":role/sdlf-cicd-cfn-modules,arn:aws-us-gov:iam::"
+                    - Ref: "pDomainAccounts"
+              - AWS: !Split
+                - ","
+                - !Sub
+                  - "arn:${AWS::Partition}:iam::${inner}:role/sdlf-cicd-cfn-modules"
+                  - inner: !Join
+                    - ":role/sdlf-cicd-cfn-modules,arn:aws:iam::"
                     - Ref: "pDomainAccounts"
             Action:
               - kms:Decrypt
@@ -206,6 +228,11 @@ Resources:
 
   rArtifactsBucketPolicy:
     Type: AWS::S3::BucketPolicy
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - I3042
     Properties:
       Bucket: !Ref rArtifactsBucket
       PolicyDocument:
@@ -222,30 +249,23 @@ Resources:
                 aws:SecureTransport: False
               NumericLessThan:
                 s3:TlsVersion: "1.2"
-          - Sid: CrossAccount Domain Pipelines
+          - Sid: CrossAccount Pipelines
             Effect: Allow
-            Principal:
-              AWS: !Split
+            Principal: !If
+              - GovCloudPartition
+              - AWS: !Split
                 - ","
                 - !Sub
-                  - "arn:${AWS::Partition}:iam::${inner}:role/sdlf-cicd-domain-crossaccount-pipeline"
+                  - "arn:${AWS::Partition}:iam::${inner}:role/sdlf-cicd-devops-crossaccount-pipeline"
                   - inner: !Join
-                    - ":role/sdlf-cicd-domain-crossaccount-pipeline,arn:${AWS::Partition}:iam::"
+                    - ":role/sdlf-cicd-devops-crossaccount-pipeline,arn:aws-us-gov:iam::"
                     - Ref: "pDomainAccounts"
-            Action:
-              - s3:*
-            Resource:
-              - !GetAtt rArtifactsBucket.Arn
-              - !Sub ${rArtifactsBucket.Arn}/*
-          - Sid: CrossAccount Team Pipelines
-            Effect: Allow
-            Principal:
-              AWS: !Split
+              - AWS: !Split
                 - ","
                 - !Sub
-                  - "arn:${AWS::Partition}:iam::${inner}:role/sdlf-cicd-team-crossaccount-pipeline"
+                  - "arn:${AWS::Partition}:iam::${inner}:role/sdlf-cicd-devops-crossaccount-pipeline"
                   - inner: !Join
-                    - ":role/sdlf-cicd-team-crossaccount-pipeline,arn:${AWS::Partition}:iam::"
+                    - ":role/sdlf-cicd-devops-crossaccount-pipeline,arn:aws:iam::"
                     - Ref: "pDomainAccounts"
             Action:
               - s3:*
@@ -254,13 +274,21 @@ Resources:
               - !Sub ${rArtifactsBucket.Arn}/*
           - Sid: CrossAccount Domain Cfn
             Effect: Allow
-            Principal:
-              AWS: !Split
+            Principal: !If
+              - GovCloudPartition
+              - AWS: !Split
                 - ","
                 - !Sub
                   - "arn:${AWS::Partition}:iam::${inner}:role/sdlf-cicd-domain"
                   - inner: !Join
-                    - ":role/sdlf-cicd-domain,arn:${AWS::Partition}:iam::"
+                    - ":role/sdlf-cicd-domain,arn:aws-us-gov:iam::"
+                    - Ref: "pDomainAccounts"
+              - AWS: !Split
+                - ","
+                - !Sub
+                  - "arn:${AWS::Partition}:iam::${inner}:role/sdlf-cicd-domain"
+                  - inner: !Join
+                    - ":role/sdlf-cicd-domain,arn:aws:iam::"
                     - Ref: "pDomainAccounts"
             Action:
               - s3:*
@@ -269,28 +297,21 @@ Resources:
               - !Sub ${rArtifactsBucket.Arn}/*
           - Sid: CrossAccount Team Role Cfn
             Effect: Allow
-            Principal:
-              AWS: !Split
+            Principal: !If
+              - GovCloudPartition
+              - AWS: !Split
                 - ","
                 - !Sub
                   - "arn:${AWS::Partition}:iam::${inner}:role/sdlf-cicd-team"
                   - inner: !Join
-                    - ":role/sdlf-cicd-team,arn:${AWS::Partition}:iam::"
+                    - ":role/sdlf-cicd-team,arn:aws-us-gov:iam::"
                     - Ref: "pDomainAccounts"
-            Action:
-              - s3:*
-            Resource:
-              - !GetAtt rArtifactsBucket.Arn
-              - !Sub ${rArtifactsBucket.Arn}/*
-          - Sid: CrossAccount Module Cfn
-            Effect: Allow
-            Principal:
-              AWS: !Split
+              - AWS: !Split
                 - ","
                 - !Sub
-                  - "arn:${AWS::Partition}:iam::${inner}:role/sdlf-cicd-cfn-modules"
+                  - "arn:${AWS::Partition}:iam::${inner}:role/sdlf-cicd-team"
                   - inner: !Join
-                    - ":role/sdlf-cicd-cfn-modules,arn:${AWS::Partition}:iam::"
+                    - ":role/sdlf-cicd-team,arn:aws:iam::"
                     - Ref: "pDomainAccounts"
             Action:
               - s3:*
@@ -307,14 +328,45 @@ Resources:
               - !GetAtt rArtifactsBucket.Arn
               - !Sub ${rArtifactsBucket.Arn}/*
             Condition:
-              "ArnLike":
-                "aws:PrincipalArn": !Split
+              "ArnLike": !If
+                - GovCloudPartition
+                - "aws:PrincipalArn": !Split
+                  - ","
+                  - !Sub
+                    - "arn:${AWS::Partition}:iam::${inner}:role/sdlf-cicd-team-*"
+                    - inner: !Join
+                      - ":role/sdlf-cicd-team-*,arn:aws-us-gov:iam::"
+                      - Ref: "pDomainAccounts"
+                - "aws:PrincipalArn": !Split
+                  - ","
+                  - !Sub
+                    - "arn:${AWS::Partition}:iam::${inner}:role/sdlf-cicd-team-*"
+                    - inner: !Join
+                      - ":role/sdlf-cicd-team-*,arn:aws:iam::"
+                      - Ref: "pDomainAccounts"
+          - Sid: CrossAccount Module Cfn
+            Effect: Allow
+            Principal: !If
+              - GovCloudPartition
+              - AWS: !Split
                 - ","
                 - !Sub
-                  - "arn:${AWS::Partition}:iam::${inner}:role/sdlf-cicd-team-*"
+                  - "arn:${AWS::Partition}:iam::${inner}:role/sdlf-cicd-cfn-modules"
                   - inner: !Join
-                    - ":role/sdlf-cicd-team-*,arn:${AWS::Partition}:iam::"
+                    - ":role/sdlf-cicd-cfn-modules,arn:aws-us-gov:iam::"
                     - Ref: "pDomainAccounts"
+              - AWS: !Split
+                - ","
+                - !Sub
+                  - "arn:${AWS::Partition}:iam::${inner}:role/sdlf-cicd-cfn-modules"
+                  - inner: !Join
+                    - ":role/sdlf-cicd-cfn-modules,arn:aws:iam::"
+                    - Ref: "pDomainAccounts"
+            Action:
+              - s3:*
+            Resource:
+              - !GetAtt rArtifactsBucket.Arn
+              - !Sub ${rArtifactsBucket.Arn}/*
 
   rArtifactsBucketSsm:
     Type: AWS::SSM::Parameter

--- a/sdlf-cicd/template-cicd-sdlf-repositories.yaml
+++ b/sdlf-cicd/template-cicd-sdlf-repositories.yaml
@@ -582,7 +582,7 @@ Resources:
               - Effect: Allow
                 Action:
                   - sts:AssumeRole
-                Resource: !Sub arn:${AWS::Partition}:iam::*:role/sdlf-cicd-team-crossaccount-pipeline
+                Resource: !Sub arn:${AWS::Partition}:iam::*:role/sdlf-cicd-devops-crossaccount-pipeline
               - Effect: Allow
                 Action:
                   - kms:CreateGrant
@@ -627,14 +627,6 @@ Resources:
                 Action:
                   - iam:PassRole
                 Resource:
-                  - !Sub arn:${AWS::Partition}:iam::*:role/sdlf-cicd-team-crossaccount-pipeline
-                Condition:
-                  StringEquals:
-                    "iam:PassedToService": codepipeline.amazonaws.com
-              - Effect: Allow
-                Action:
-                  - iam:PassRole
-                Resource:
                   - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/sdlf-cicd-domain-*
                   - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/sdlf-cicd-teams-*
                 Condition:
@@ -646,7 +638,7 @@ Resources:
                 Action:
                   - iam:PassRole
                 Resource:
-                  - !Sub arn:${AWS::Partition}:iam::*:role/sdlf-cicd-domain-crossaccount-pipeline
+                  - !Sub arn:${AWS::Partition}:iam::*:role/sdlf-cicd-devops-crossaccount-pipeline
                 Condition:
                   StringEquals:
                     "iam:PassedToService": codepipeline.amazonaws.com
@@ -946,7 +938,7 @@ Resources:
                   - !Ref pKMSKey
               - Effect: Allow
                 Action: sts:AssumeRole
-                Resource: !Sub arn:${AWS::Partition}:iam::*:role/sdlf-cicd-domain-crossaccount-cfn-modules
+                Resource: !Sub arn:${AWS::Partition}:iam::*:role/sdlf-cicd-devops-crossaccount-pipeline
               - !If
                 - RunInVpc
                 - Effect: Allow
@@ -1027,7 +1019,7 @@ Resources:
                 - |-
                     CLOUDFORMATION_ENDPOINT_URL="https://cloudformation.$AWS_REGION.amazonaws.com"
                     STS_ENDPOINT_URL="https://sts.$AWS_REGION.amazonaws.com"
-                    temp_role=$(aws sts --endpoint-url "$STS_ENDPOINT_URL" assume-role --role-arn "arn:${AWS::Partition}:iam::$DOMAIN_ACCOUNT_ID:role/sdlf-cicd-domain-crossaccount-cfn-modules" --role-session-name "codebuild-lambda-layer")
+                    temp_role=$(aws sts --endpoint-url "$STS_ENDPOINT_URL" assume-role --role-arn "arn:${AWS::Partition}:iam::$DOMAIN_ACCOUNT_ID:role/sdlf-cicd-devops-crossaccount-pipeline" --role-session-name "codebuild-lambda-layer")
                     AWS_ACCESS_KEY_ID=$(echo "$temp_role" | jq .Credentials.AccessKeyId | xargs)
                     AWS_SECRET_ACCESS_KEY=$(echo "$temp_role" | jq .Credentials.SecretAccessKey | xargs)
                     AWS_SESSION_TOKEN=$(echo "$temp_role" | jq .Credentials.SessionToken | xargs)

--- a/sdlf-cicd/template-cicd-team.yaml
+++ b/sdlf-cicd/template-cicd-team.yaml
@@ -182,7 +182,7 @@ Resources:
               - Effect: Allow
                 Action: sts:AssumeRole
                 Resource:
-                  - !Sub arn:${AWS::Partition}:iam::${pChildAccountId}:role/sdlf-cicd-team-crossaccount-pipeline
+                  - !Sub arn:${AWS::Partition}:iam::${pChildAccountId}:role/sdlf-cicd-devops-crossaccount-pipeline
 
   ######## CODEPIPELINE #########
   rTeamCodePipeline:
@@ -340,7 +340,7 @@ Resources:
               - !If
                 - EnableLambdaLayerBuilder
                 - Name: CreateLambdaLayersStack
-                  RoleArn: !Sub arn:${AWS::Partition}:iam::${pChildAccountId}:role/sdlf-cicd-team-crossaccount-pipeline
+                  RoleArn: !Sub arn:${AWS::Partition}:iam::${pChildAccountId}:role/sdlf-cicd-devops-crossaccount-pipeline
                   ActionTypeId:
                     Category: Deploy
                     Owner: AWS
@@ -370,7 +370,7 @@ Resources:
               - !If
                 - EnableGlueJobDeployer
                 - Name: CreateGlueJobsStack
-                  RoleArn: !Sub arn:${AWS::Partition}:iam::${pChildAccountId}:role/sdlf-cicd-team-crossaccount-pipeline
+                  RoleArn: !Sub arn:${AWS::Partition}:iam::${pChildAccountId}:role/sdlf-cicd-devops-crossaccount-pipeline
                   ActionTypeId:
                     Category: Deploy
                     Owner: AWS
@@ -539,7 +539,7 @@ Resources:
         - Name: DeployPipelinesInfrastructure
           Actions:
             - Name: CreateStack
-              RoleArn: !Sub arn:${AWS::Partition}:iam::${pChildAccountId}:role/sdlf-cicd-team-crossaccount-pipeline
+              RoleArn: !Sub arn:${AWS::Partition}:iam::${pChildAccountId}:role/sdlf-cicd-devops-crossaccount-pipeline
               ActionTypeId:
                 Category: Deploy
                 Owner: AWS
@@ -563,7 +563,7 @@ Resources:
         - Name: DeployDatasetsInfrastructure
           Actions:
             - Name: CreateStack
-              RoleArn: !Sub arn:${AWS::Partition}:iam::${pChildAccountId}:role/sdlf-cicd-team-crossaccount-pipeline
+              RoleArn: !Sub arn:${AWS::Partition}:iam::${pChildAccountId}:role/sdlf-cicd-devops-crossaccount-pipeline
               ActionTypeId:
                 Category: Deploy
                 Owner: AWS


### PR DESCRIPTION
*Description of changes:*
`sdlf-cicd-domain-crossaccount-cfn-modules`, `sdlf-cicd-domain-crossaccount-pipeline` and `sdlf-cicd-team-crossaccount-pipeline` have been merged into a single role: `sdlf-cicd-devops-crossaccount-pipeline`

The KMS key and the bucket used to store devops artifacts had invalid policies, as `AWS::Partition` wasn't getting replaced properly and `!Sub` cannot be used in the delimiter part of `!Join`. The fix is not super elegant as conditions need adding for any partition we support. There aren't that many now, thankfully.

The longer term fix is to use KMS grants instead but support in CloudFormation is non-existent:
https://github.com/aws-cloudformation/cloudformation-coverage-roadmap/issues/489
and S3 access points but the interaction between CloudFormation and crossaccount access points isn't perfect, see commit 80efed8290c7c7085705382bad752bf05ba28534.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
