### PR TITLE
add batch capability to updating object metadata in datalakeLibrary

### DIFF
--- a/sdlf-datalakeLibrary/python/datalake_library/interfaces/dynamo_interface.py
+++ b/sdlf-datalakeLibrary/python/datalake_library/interfaces/dynamo_interface.py
@@ -87,6 +87,20 @@ class DynamoInterface:
     def put_item_in_object_metadata_table(self, item):
         return self.put_item(self.object_metadata_table, item)
 
+    def batch_update_object_metadata_catalog(self, items):
+        for item in items:
+            item["id"] = self.build_id(item["bucket"], item["key"])
+            item["timestamp"] = int(round(dt.datetime.utcnow().timestamp() * 1000, 0))
+
+        return self.batch_put_item_in_object_metadata_table(items)
+
+    def batch_put_item_in_object_metadata_table(self, items):
+        with self.object_metadata_table.batch_writer() as writer:
+            for item in items:
+                writer.put_item(Item=item)
+
+        return
+
     def update_object(self, bucket, key, attribute_updates):
         try:
             self.object_metadata_table.update_item(

--- a/sdlf-stageB/lambda/stage-b-postupdate-metadata/src/lambda_function.py
+++ b/sdlf-stageB/lambda/stage-b-postupdate-metadata/src/lambda_function.py
@@ -41,6 +41,7 @@ def lambda_handler(event, context):
         dynamo_interface = DynamoInterface(dynamo_config)
 
         logger.info("Storing metadata to DynamoDB")
+        all_objects_metadata = []
         for key in processed_keys:
             size, last_modified_date = S3Interface().get_size_and_last_modified(bucket, key)
             object_metadata = {
@@ -58,7 +59,8 @@ def lambda_handler(event, context):
                 "pipeline_stage": stage,
                 "peh_id": peh_id,
             }
-            dynamo_interface.update_object_metadata_catalog(object_metadata)
+            all_objects_metadata.append(object_metadata)
+        dynamo_interface.batch_update_object_metadata_catalog(all_objects_metadata)
 
         octagon_client.update_pipeline_execution(
             status="{} {} Processing".format(stage, component), component=component


### PR DESCRIPTION
*Description of changes:*
see https://github.com/awslabs/aws-serverless-data-lake-framework/discussions/210 for more information

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
