### PR TITLE
access control using lakeformation only

### DIFF
--- a/sdlf-foundations/template.yaml
+++ b/sdlf-foundations/template.yaml
@@ -158,6 +158,9 @@ Resources:
       Admins:
         - DataLakePrincipalIdentifier: !GetAtt rDataLakeAdminRole.Arn
         - DataLakePrincipalIdentifier: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/sdlf-cicd-domain
+      CreateDatabaseDefaultPermissions: []
+      CreateTableDefaultPermissions: []
+      MutationType: REPLACE
 
   rLakeFormationDataAccessRole: # https://docs.aws.amazon.com/lake-formation/latest/dg/registration-role.html
     Type: AWS::IAM::Role


### PR DESCRIPTION
*Description of changes:*
set lakeformation datalake settings: access control using lakeformation only

note that `MutatePolicy: REPLACE` means pre-existing admins are removed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
