### PR TITLE
remove the -{env} suffix from files in team repository

### DIFF
--- a/sdlf-cicd/template-cicd-team.yaml
+++ b/sdlf-cicd/template-cicd-team.yaml
@@ -533,8 +533,8 @@ Resources:
                 Provider: CodeBuild
               Configuration:
                 ProjectName: !Ref pBuildCloudFormationPackage
-                EnvironmentVariables: !Sub >-
-                  [{"name":"TEMPLATE", "value":"pipelines-${pEnvironment}.yaml", "type":"PLAINTEXT"}]
+                EnvironmentVariables: >-
+                  [{"name":"TEMPLATE", "value":"pipelines.yaml", "type":"PLAINTEXT"}]
               RunOrder: 1
         - Name: DeployPipelinesInfrastructure
           Actions:
@@ -575,7 +575,7 @@ Resources:
                 ActionMode: CREATE_UPDATE
                 RoleArn: !Ref pCrossAccountTeamRole
                 StackName: !Sub sdlf-${pTeamName}-datasets-${pEnvironment}
-                TemplatePath: !Sub "TemplateSource::datasets-${pEnvironment}.yaml"
+                TemplatePath: "TemplateSource::datasets.yaml"
                 TemplateConfiguration: "TemplateSource::tags.json"
                 ParameterOverrides: |
                   {


### PR DESCRIPTION
*Description of changes:*
The -{env} suffix is unnecessary in team repositories. It makes the deployment workflow more complex (having to edit `-prod` or `-test` files for the other environments). It is still necessary in sdlf-main because that's how you do it by account.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
