### PR TITLE
add workshop examples to sdlf-utils

### DIFF
--- a/sdlf-utils/workshop-examples/10-deployment/sdlf-main-datalake-engineering/datasets.yaml
+++ b/sdlf-utils/workshop-examples/10-deployment/sdlf-main-datalake-engineering/datasets.yaml
@@ -1,0 +1,15 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: Engineering team datasets
+
+Parameters:
+    pPipelineReference:
+        Type: String
+        Default: none
+
+Resources:
+    rLegislators:
+        Type: awslabs::sdlf::dataset::MODULE
+        Properties:
+            pPipelineReference: !Ref pPipelineReference
+            pTeamName: engineering
+            pDatasetName: legislators

--- a/sdlf-utils/workshop-examples/10-deployment/sdlf-main-datalake-engineering/pipeline-main.yaml
+++ b/sdlf-utils/workshop-examples/10-deployment/sdlf-main-datalake-engineering/pipeline-main.yaml
@@ -1,0 +1,50 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: Engineering team Main pipeline
+
+Parameters:
+    pPipelineReference:
+        Type: String
+        Default: none
+
+Resources:
+    rMainA:
+        Type: awslabs::sdlf::stageA::MODULE
+        Properties:
+            pStageName: A
+            pPipeline: main
+            pTeamName: engineering
+            pTriggerType: event
+            pEventPattern: !Sub >-
+                {
+                "source": ["aws.s3"],
+                "detail-type": ["Object Created"],
+                "detail": {
+                    "bucket": {
+                    "name": ["{{resolve:ssm:/SDLF/S3/CentralBucket}}"]
+                    },
+                    "object": {
+                    "key": [{ "prefix": "engineering/legislators/" }]
+                    }
+                }
+                }
+            pEnableTracing: false
+
+    rMainB:
+        Type: awslabs::sdlf::stageB::MODULE
+        Properties:
+            pDatasetBucket: "{{resolve:ssm:/SDLF/S3/StageBucket}}"
+            pStageName: B
+            pPipeline: main
+            pTeamName: engineering
+            pTriggerType: schedule
+            pEventPattern: !Sub >-
+                {
+                "source": ["aws.states"],
+                "detail-type": ["Step Functions Execution Status Change"],
+                "detail": {
+                    "status": ["SUCCEEDED"],
+                    "stateMachineArn": ["arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:stateMachine:sdlf-engineering-main-sm-a"]
+                }
+                }
+            pSchedule: "cron(*/5 * * * ? *)"
+            pEnableTracing: false

--- a/sdlf-utils/workshop-examples/10-deployment/sdlf-main-datalake-engineering/pipelines.yaml
+++ b/sdlf-utils/workshop-examples/10-deployment/sdlf-main-datalake-engineering/pipelines.yaml
@@ -1,0 +1,18 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: Engineering team pipelines
+
+Parameters:
+    pPipelineReference:
+        Type: String
+        Default: none
+
+Resources:
+    rMain:
+        Type: AWS::CloudFormation::Stack
+        Properties:
+            TemplateURL: ./pipeline-main.yaml
+            Parameters:
+                pPipelineReference: !Ref pPipelineReference
+            Tags:
+                - Key: sdlf:pipeline
+                  Value: main

--- a/sdlf-utils/workshop-examples/10-deployment/sdlf-main-datalake-engineering/tags.json
+++ b/sdlf-utils/workshop-examples/10-deployment/sdlf-main-datalake-engineering/tags.json
@@ -1,0 +1,5 @@
+{
+    "Tags" : {
+        "Framework" : "sdlf"
+    }
+}

--- a/sdlf-utils/workshop-examples/10-deployment/sdlf-main/datadomain-datalake-dev.yaml
+++ b/sdlf-utils/workshop-examples/10-deployment/sdlf-main/datadomain-datalake-dev.yaml
@@ -1,0 +1,26 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: datalake data domain, dev environment
+
+Parameters:
+    pPipelineReference:
+        Type: String
+        Default: none
+
+Resources:
+    rForecourt:
+        Type: AWS::CloudFormation::Stack
+        Properties:
+            TemplateURL: ./foundations-datalake-dev.yaml
+            Parameters:
+                pPipelineReference: !Ref pPipelineReference
+
+    rEngineering:
+        Type: AWS::CloudFormation::Stack
+        DependsOn: rForecourt
+        Properties:
+            TemplateURL: ./team-datalake-engineering-dev.yaml
+            Parameters:
+                pPipelineReference: !Ref pPipelineReference
+            Tags:
+                - Key: sdlf:team
+                  Value: engineering

--- a/sdlf-utils/workshop-examples/10-deployment/sdlf-main/foundations-datalake-dev.yaml
+++ b/sdlf-utils/workshop-examples/10-deployment/sdlf-main/foundations-datalake-dev.yaml
@@ -1,0 +1,18 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: SDLF Foundations in datalake domain, dev environment
+
+Parameters:
+    pPipelineReference:
+        Type: String
+        Default: none
+
+Resources:
+    rForecourt:
+        Type: awslabs::sdlf::foundations::MODULE
+        Properties:
+            pPipelineReference: !Ref pPipelineReference
+            pChildAccountId: !Ref "AWS::AccountId"
+            pOrganizationName: forecourt
+            pDomain: datalake
+            pEnvironment: dev
+            pNumBuckets: 3

--- a/sdlf-utils/workshop-examples/10-deployment/sdlf-main/tags.json
+++ b/sdlf-utils/workshop-examples/10-deployment/sdlf-main/tags.json
@@ -1,0 +1,5 @@
+{
+    "Tags" : {
+        "Framework" : "sdlf"
+    }
+}

--- a/sdlf-utils/workshop-examples/10-deployment/sdlf-main/team-datalake-engineering-dev.yaml
+++ b/sdlf-utils/workshop-examples/10-deployment/sdlf-main/team-datalake-engineering-dev.yaml
@@ -1,0 +1,16 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: Engineering SDLF Team in datalake domain, dev environment
+
+Parameters:
+    pPipelineReference:
+        Type: String
+        Default: none
+
+Resources:
+    rEngineering:
+        Type: awslabs::sdlf::team::MODULE
+        Properties:
+            pPipelineReference: !Ref pPipelineReference
+            pTeamName: engineering
+            pEnvironment: dev
+            pSNSNotificationsEmail: nobody@amazon.com

--- a/sdlf-utils/workshop-examples/20-production/sdlf-main-proserve-iot/datasets.yaml
+++ b/sdlf-utils/workshop-examples/20-production/sdlf-main-proserve-iot/datasets.yaml
@@ -1,0 +1,15 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: iot team datasets
+
+Parameters:
+    pPipelineReference:
+        Type: String
+        Default: none
+
+Resources:
+    rLegislators:
+        Type: awslabs::sdlf::dataset::MODULE
+        Properties:
+            pPipelineReference: !Ref pPipelineReference
+            pTeamName: iot
+            pDatasetName: legislators

--- a/sdlf-utils/workshop-examples/20-production/sdlf-main-proserve-iot/pipeline-main.yaml
+++ b/sdlf-utils/workshop-examples/20-production/sdlf-main-proserve-iot/pipeline-main.yaml
@@ -1,0 +1,50 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: Main pipeline
+
+Parameters:
+    pPipelineReference:
+        Type: String
+        Default: none
+
+Resources:
+    rMainA:
+        Type: awslabs::sdlf::stageA::MODULE
+        Properties:
+            pStageName: A
+            pPipeline: main
+            pTeamName: iot
+            pTriggerType: event
+            pEventPattern: !Sub >-
+                {
+                    "source": ["aws.s3"],
+                    "detail-type": ["Object Created"],
+                    "detail": {
+                        "bucket": {
+                            "name": ["{{resolve:ssm:/SDLF/S3/CentralBucket}}"]
+                        },
+                        "object": {
+                            "key": [{ "prefix": "iot/legislators/" }]
+                        }
+                    }
+                }
+            pEnableTracing: false
+
+    rMainB:
+        Type: awslabs::sdlf::stageB::MODULE
+        Properties:
+            pDatasetBucket: "{{resolve:ssm:/SDLF/S3/StageBucket}}"
+            pStageName: B
+            pPipeline: main
+            pTeamName: iot
+            pTriggerType: schedule
+            pEventPattern: !Sub >-
+                {
+                    "source": ["aws.states"],
+                    "detail-type": ["Step Functions Execution Status Change"],
+                    "detail": {
+                        "status": ["SUCCEEDED"],
+                        "stateMachineArn": ["arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:stateMachine:sdlf-iot-main-sm-a"]
+                    }
+                }
+            pSchedule: "cron(*/5 * * * ? *)"
+            pEnableTracing: false

--- a/sdlf-utils/workshop-examples/20-production/sdlf-main-proserve-iot/pipeline-singlestage.yaml
+++ b/sdlf-utils/workshop-examples/20-production/sdlf-main-proserve-iot/pipeline-singlestage.yaml
@@ -1,0 +1,30 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: Single stage pipeline
+
+Parameters:
+    pPipelineReference:
+        Type: String
+        Default: none
+
+Resources:
+    rSingleA:
+        Type: awslabs::sdlf::stageA::MODULE
+        Properties:
+            pStageName: A
+            pPipeline: singlestage
+            pTeamName: iot
+            pTriggerType: event
+            pEventPattern: !Sub >-
+                {
+                    "source": ["aws.s3"],
+                    "detail-type": ["Object Created"],
+                    "detail": {
+                        "bucket": {
+                            "name": ["{{resolve:ssm:/SDLF/S3/CentralBucket}}"]
+                        },
+                        "object": {
+                            "key": [{ "prefix": "iot/legislators/" }]
+                        }
+                    }
+                }
+            pEnableTracing: false

--- a/sdlf-utils/workshop-examples/20-production/sdlf-main-proserve-iot/pipelines.yaml
+++ b/sdlf-utils/workshop-examples/20-production/sdlf-main-proserve-iot/pipelines.yaml
@@ -1,0 +1,27 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: iot team pipelines
+
+Parameters:
+    pPipelineReference:
+        Type: String
+        Default: none
+
+Resources:
+    rMain:
+        Type: AWS::CloudFormation::Stack
+        Properties:
+            TemplateURL: ./pipeline-main.yaml
+            Parameters:
+                pPipelineReference: !Ref pPipelineReference
+            Tags:
+                - Key: sdlf:pipeline
+                  Value: main
+    rSingleStage:
+        Type: AWS::CloudFormation::Stack
+        Properties:
+            TemplateURL: ./pipeline-singlestage.yaml
+            Parameters:
+                pPipelineReference: !Ref pPipelineReference
+            Tags:
+                - Key: sdlf:pipeline
+                  Value: singlestage

--- a/sdlf-utils/workshop-examples/20-production/sdlf-main-proserve-iot/tags.json
+++ b/sdlf-utils/workshop-examples/20-production/sdlf-main-proserve-iot/tags.json
@@ -1,0 +1,6 @@
+{
+    "Tags" : {
+        "Framework" : "sdlf",
+        "sdlf:team" : "iot"
+    }
+}

--- a/sdlf-utils/workshop-examples/20-production/sdlf-main/datadomain-marketing-dev.yaml
+++ b/sdlf-utils/workshop-examples/20-production/sdlf-main/datadomain-marketing-dev.yaml
@@ -1,0 +1,26 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: marketing data domain, dev environment
+
+Parameters:
+    pPipelineReference:
+        Type: String
+        Default: none
+
+Resources:
+    rMarketing:
+        Type: AWS::CloudFormation::Stack
+        Properties:
+            TemplateURL: ./foundations-marketing-dev.yaml
+            Parameters:
+                pPipelineReference: !Ref pPipelineReference
+
+    rIndustry:
+        Type: AWS::CloudFormation::Stack
+        DependsOn: rMarketing
+        Properties:
+            TemplateURL: ./team-marketing-industry-dev.yaml
+            Parameters:
+                pPipelineReference: !Ref pPipelineReference
+            Tags:
+                - Key: sdlf:team
+                  Value: industry

--- a/sdlf-utils/workshop-examples/20-production/sdlf-main/datadomain-proserve-dev.yaml
+++ b/sdlf-utils/workshop-examples/20-production/sdlf-main/datadomain-proserve-dev.yaml
@@ -1,0 +1,26 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: proserve data domain, dev environment
+
+Parameters:
+    pPipelineReference:
+        Type: String
+        Default: none
+
+Resources:
+    rProserve:
+        Type: AWS::CloudFormation::Stack
+        Properties:
+            TemplateURL: ./foundations-proserve-dev.yaml
+            Parameters:
+                pPipelineReference: !Ref pPipelineReference
+
+    rIot:
+        Type: AWS::CloudFormation::Stack
+        DependsOn: rProserve
+        Properties:
+            TemplateURL: ./team-proserve-iot-dev.yaml
+            Parameters:
+                pPipelineReference: !Ref pPipelineReference
+            Tags:
+                - Key: sdlf:team
+                  Value: iot

--- a/sdlf-utils/workshop-examples/20-production/sdlf-main/foundations-marketing-dev.yaml
+++ b/sdlf-utils/workshop-examples/20-production/sdlf-main/foundations-marketing-dev.yaml
@@ -1,0 +1,18 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: SDLF Foundations in marketing domain, dev environment
+
+Parameters:
+    pPipelineReference:
+        Type: String
+        Default: none
+
+Resources:
+    rMarketing:
+        Type: awslabs::sdlf::foundations::MODULE
+        Properties:
+            pPipelineReference: !Ref pPipelineReference
+            pChildAccountId: 222222222222
+            pOrganizationName: forecourt
+            pDomain: marketing
+            pEnvironment: dev
+            pNumBuckets: 3

--- a/sdlf-utils/workshop-examples/20-production/sdlf-main/foundations-proserve-dev.yaml
+++ b/sdlf-utils/workshop-examples/20-production/sdlf-main/foundations-proserve-dev.yaml
@@ -1,0 +1,18 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: SDLF Foundations in proserve domain, dev environment
+
+Parameters:
+    pPipelineReference:
+        Type: String
+        Default: none
+
+Resources:
+    rProserve:
+        Type: awslabs::sdlf::foundations::MODULE
+        Properties:
+            pPipelineReference: !Ref pPipelineReference
+            pChildAccountId: 111111111111
+            pOrganizationName: forecourt
+            pDomain: proserve
+            pEnvironment: dev
+            pNumBuckets: 3

--- a/sdlf-utils/workshop-examples/20-production/sdlf-main/tags.json
+++ b/sdlf-utils/workshop-examples/20-production/sdlf-main/tags.json
@@ -1,0 +1,5 @@
+{
+    "Tags" : {
+        "Framework" : "sdlf"
+    }
+}

--- a/sdlf-utils/workshop-examples/20-production/sdlf-main/team-marketing-industry-dev.yaml
+++ b/sdlf-utils/workshop-examples/20-production/sdlf-main/team-marketing-industry-dev.yaml
@@ -1,0 +1,16 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: Industry SDLF Team in marketing domain, dev environment
+
+Parameters:
+    pPipelineReference:
+        Type: String
+        Default: none
+
+Resources:
+    rIndustry:
+        Type: awslabs::sdlf::team::MODULE
+        Properties:
+            pPipelineReference: !Ref pPipelineReference
+            pTeamName: industry
+            pEnvironment: dev
+            pSNSNotificationsEmail: nobody@amazon.com

--- a/sdlf-utils/workshop-examples/20-production/sdlf-main/team-proserve-iot-dev.yaml
+++ b/sdlf-utils/workshop-examples/20-production/sdlf-main/team-proserve-iot-dev.yaml
@@ -1,0 +1,16 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: IOT SDLF Team in proserve domain, dev environment
+
+Parameters:
+    pPipelineReference:
+        Type: String
+        Default: none
+
+Resources:
+    rIot:
+        Type: awslabs::sdlf::team::MODULE
+        Properties:
+            pPipelineReference: !Ref pPipelineReference
+            pTeamName: iot
+            pEnvironment: dev
+            pSNSNotificationsEmail: nobody@amazon.com


### PR DESCRIPTION
*Description of changes:*
Add files created during the official workshop (sdlf.workshop.aws). People should create them themselves but it is still nice to have them here as reference.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
