### PR TITLE
add logs permissions to glue crawler role

### DIFF
--- a/sdlf-team/template.yaml
+++ b/sdlf-team/template.yaml
@@ -551,6 +551,14 @@ Resources:
                 Resource:
                   - !GetAtt rKMSInfraKey.Arn
                   - !GetAtt rKMSDataKey.Arn
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                  - logs:AssociateKmsKey
+                Resource:
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws-glue/crawlers-role/sdlf-${pTeamName}/*
 
   ####### SSM #######
   rTeamIAMManagedPolicySsm:


### PR DESCRIPTION
*Description of changes:*
Glue Crawler now requires at least `logs:AssociateKmsKey` for its log group (when encrypted).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
