### PR TITLE
update s3 access logs and artifacts buckets names to avoid length issue

### DIFF
--- a/sdlf-cicd/template-cicd-prerequisites.yaml
+++ b/sdlf-cicd/template-cicd-prerequisites.yaml
@@ -215,8 +215,8 @@ Resources:
       BucketName:
         !If [
           UseCustomBucketPrefix,
-          !Sub "${pCustomBucketPrefix}-devops-s3-access-logs",
-          !Sub "sdlf-${AWS::Region}-${AWS::AccountId}-devops-s3-access-logs",
+          !Sub "${pCustomBucketPrefix}-devops-s3logs",
+          !Sub "sdlf-${AWS::Region}-${AWS::AccountId}-devops-s3logs",
         ]
       LifecycleConfiguration:
         Rules:

--- a/sdlf-foundations/template.yaml
+++ b/sdlf-foundations/template.yaml
@@ -343,8 +343,8 @@ Resources:
       BucketName:
         !If [
           UseCustomBucketPrefix,
-          !Sub "${pCustomBucketPrefix}-s3-access-logs",
-          !Sub "${pOrganizationName}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}-s3-access-logs",
+          !Sub "${pCustomBucketPrefix}-s3logs",
+          !Sub "${pOrganizationName}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}-s3logs",
         ]
       LifecycleConfiguration:
         Rules:
@@ -459,16 +459,16 @@ Resources:
       BucketName:
         !If [
           UseCustomBucketPrefix,
-          !Sub "${pCustomBucketPrefix}-artifactory",
-          !Sub "${pOrganizationName}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}-artifactory",
+          !Sub "${pCustomBucketPrefix}-artifacts",
+          !Sub "${pOrganizationName}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}-artifacts",
         ]
       LoggingConfiguration:
         DestinationBucketName: !Ref rS3AccessLogsBucket
         LogFilePrefix:
           !If [
             UseCustomBucketPrefix,
-            !Sub "${pCustomBucketPrefix}-artifactory",
-            !Sub "${pOrganizationName}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}-artifactory",
+            !Sub "${pCustomBucketPrefix}-artifacts",
+            !Sub "${pOrganizationName}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}-artifacts",
           ]
       BucketEncryption:
         ServerSideEncryptionConfiguration:


### PR DESCRIPTION
*Issue #, if available:*
#239 

*Description of changes:*
Renaming the two longest bucket names as the current names are too long when deploying SDLF on region with longer region codes. All regions should be fine following this fix, even when using an organisation name and a data domain name with the maximum number of characters.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
