### PR TITLE
Fixed incorrectly named variable in the for loop which deletes legacy…

### DIFF
--- a/sdlf-cicd/lambda/domain-cicd/src/lambda_function.py
+++ b/sdlf-cicd/lambda/domain-cicd/src/lambda_function.py
@@ -244,7 +244,7 @@ def lambda_handler(event, context):
             "stack_delete_complete": [],
         }
         for legacy_domain in legacy_domains:
-            stack_details = delete_domain_cicd_stack(domain, environment, cloudformation_role)
+            stack_details = delete_domain_cicd_stack(legacy_domain, environment, cloudformation_role)
             cloudformation_waiters[stack_details[1]].append(stack_details[0])
         cloudformation_waiter = cloudformation.get_waiter("stack_delete_complete")
         for stack in cloudformation_waiters["stack_delete_complete"]:


### PR DESCRIPTION
… domains

*Issue #, if available:*
Deleting legacy domains would fail b/c the delete_domain_cicd_stack function was given an incorrectly named domain variable.
for legacy_domain in legacy_domains:
            stack_details = delete_domain_cicd_stack(domain, environment, cloudformation_role)

Here's the error you get when triggering the delete_domain_cicd_stack funciton from the for loop:
[ERROR] UnboundLocalError: cannot access local variable 'domain' where it is not associated with a value
Traceback (most recent call last):
  File "/var/task/lambda_function.py", line 247, in lambda_handler
    stack_details = delete_domain_cicd_stack(domain, environment, cloudformation_role)

*Description of changes:*
I changed domain to legacy_domain in the delete_domain_cicd_stack argument.
Also my Amazon email address is waltmayf@amazon.com. Would love to contribute to this project!

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
