### PR TITLE
Lake Formation tag (LF-Tag) support for sdlf pipelines

### DIFF
--- a/sdlf-cicd/template-cicd-domain-roles.yaml
+++ b/sdlf-cicd/template-cicd-domain-roles.yaml
@@ -546,6 +546,11 @@ Resources:
                   - lakeformation:RegisterResource # W11 exception
                   - lakeformation:RevokePermissions # W11 exception
                   - lakeformation:UpdateResource # W11 exception
+                  - lakeformation:CreateLFTag # W11 exception
+                  - lakeformation:DeleteLFTag # W11 exception
+                  - lakeformation:UpdateLFTag # W11 exception
+                  - lakeformation:ListPermissions # W11 exception
+                  - lakeformation:GetLFTag # W11 exception
                 Resource: "*"
               - Effect: Allow
                 Action:

--- a/sdlf-cicd/template-cicd-domain-team-role.yaml
+++ b/sdlf-cicd/template-cicd-domain-team-role.yaml
@@ -243,6 +243,10 @@ Resources:
               - lakeformation:GetDataAccess # W11 exception
               - lakeformation:GrantPermissions # W11 exception
               - lakeformation:RevokePermissions # W11 exception
+              - lakeformation:GetResourceLFTags # W11 exception
+              - lakeformation:AddLFTagsToResource # W11 exception
+              - lakeformation:RemoveLFTagsFromResource # W11 exception
+              - lakeformation:ListPermissions # W11 exception
             Resource: "*"
           - Effect: Allow
             Action:

--- a/sdlf-dataset/template.yaml
+++ b/sdlf-dataset/template.yaml
@@ -56,6 +56,19 @@ Resources:
         Description: !Sub "${pTeamName} team ${pDatasetName} metadata catalog"
         Name: !Sub ${pOrg}_${pDomain}_${pEnvironment}_${pTeamName}_${pDatasetName}_db
 
+  rGlueDataCatalogLakeFormationTag:
+      Type: AWS::LakeFormation::TagAssociation
+      Properties:
+        Resource:
+          Database:
+            CatalogId: !Ref AWS::AccountId
+            Name: !Ref rGlueDataCatalog
+        LFTags:
+          - CatalogId: !Ref AWS::AccountId
+            TagKey: !Sub "sdlf:team:${pTeamName}"
+            TagValues:
+              - !Sub ${pTeamName}
+
   rGlueCrawler:
     Type: AWS::Glue::Crawler
     Properties:

--- a/sdlf-stage-dataquality/template.yaml
+++ b/sdlf-stage-dataquality/template.yaml
@@ -318,6 +318,23 @@ Resources:
                   - xray:GetSamplingTargets # W11 exception
                 Resource: "*"
 
+  rStatesExecutionLakeFormationPermissions:
+    Type: AWS::LakeFormation::PrincipalPermissions
+    Properties:
+      Principal:
+        DataLakePrincipalIdentifier: !GetAtt rStatesExecutionRole.Arn
+      Resource:
+        LFTagPolicy:
+          CatalogId: !Ref AWS::AccountId
+          ResourceType: TABLE
+          Expression:
+            - TagKey: !Sub "sdlf:team:${pTeamName}"
+              TagValues:
+                - !Sub ${pTeamName}
+      Permissions:
+        - SELECT
+      PermissionsWithGrantOption: []
+
   ######## LAMBDA #########
   rLambdaRoutingStep:
     Type: AWS::Serverless::Function

--- a/sdlf-team/template.yaml
+++ b/sdlf-team/template.yaml
@@ -930,6 +930,48 @@ Resources:
               !Sub "arn:${AWS::Partition}:s3:::${pCentralBucket}/analytics/${pTeamName}/",
             ]
 
+  rTeamLakeFormationTag:
+    Type: AWS::LakeFormation::Tag
+    Properties:
+      CatalogId: !Ref AWS::AccountId
+      # sdlf:team as key and team names as values would be best but impossible here
+      TagKey: !Sub "sdlf:team:${pTeamName}"
+      TagValues:
+        - !Sub ${pTeamName}
+
+  rTeamLakeFormationTagPermissions: # allows associating this lf-tag to datasets in sdlf-dataset
+      Type: AWS::LakeFormation::PrincipalPermissions
+      Properties:
+        Principal:
+          DataLakePrincipalIdentifier: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/sdlf-cicd-team-${pTeamName}
+        Resource:
+          LFTag:
+            CatalogId: !Ref AWS::AccountId
+            TagKey: !Ref rTeamLakeFormationTag
+            TagValues:
+              - !Sub ${pTeamName}
+        Permissions:
+          - ASSOCIATE
+        PermissionsWithGrantOption: []
+
+  rTeamLakeFormationTagTablesPermissions: # allows sdlf pipelines to grant permissions on tables associated with this lf-tag
+    Type: AWS::LakeFormation::PrincipalPermissions
+    Properties:
+      Principal:
+        DataLakePrincipalIdentifier: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/sdlf-cicd-team-${pTeamName}
+      Resource:
+        LFTagPolicy:
+          CatalogId: !Ref AWS::AccountId
+          ResourceType: TABLE
+          Expression:
+            - TagKey: !Sub "sdlf:team:${pTeamName}"
+              TagValues:
+                - !Sub ${pTeamName}
+      Permissions:
+        - ALL
+      PermissionsWithGrantOption:
+        - ALL
+
   rAthenaWorkgroup:
     Type: AWS::Athena::WorkGroup
     Properties:


### PR DESCRIPTION
*Description of changes:*
Create a dedicated LF-Tag per team (Key: `sdlf:team:pTeamName`, Value: `pTeamName`)
Associate this LF-Tag to team datasets
Grant teams Lake Formation permissions (grantable included) on tagged dataset tables

Use all this in sdlf-stage-dataquality as an example to avoid manually granting the required permissions for this stage.

Teams can only associate and grant permissions on their own team LF-Tag.

I would have preferred using `sdlf:team` as key but the `AWS::LakeFormation::Tag` resource requires knowing all values at creation time. The same key cannot be redeclared elsewhere.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
