### PR TITLE
add DescribeStackEvents to CodePipeline role permissions (#245)

### DIFF
--- a/sdlf-cicd/template-cicd-domain-roles.yaml
+++ b/sdlf-cicd/template-cicd-domain-roles.yaml
@@ -96,7 +96,7 @@ Resources:
                   - cloudformation:DeleteChangeSet
                   - cloudformation:DeleteStack
                   - cloudformation:DescribeChangeSet
-                  - cloudformation:DescribeStacks
+                  - cloudformation:DescribeStackEvents
                   - cloudformation:ExecuteChangeSet
                   - cloudformation:SetStackPolicy
                   - cloudformation:UpdateStack

--- a/sdlf-cicd/template-cicd-team.yaml
+++ b/sdlf-cicd/template-cicd-team.yaml
@@ -544,7 +544,7 @@ Resources:
                 Category: Deploy
                 Owner: AWS
                 Provider: CloudFormation
-                Version: '1'
+                Version: "1"
               InputArtifacts:
                 - Name: TemplateSource
                 - Name: TemplatePackage


### PR DESCRIPTION
*Issue #, if available:*
#245 

*Description of changes:*
CodePipeline provides a View details button to know more about the issue without having to check the CloudFormation console directly - but it requires DescribeStackEvents.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
