### PR TITLE
dedicated event bus per team in child accounts (#165)

### DIFF
--- a/sdlf-cicd/template-cicd-domain-roles.yaml
+++ b/sdlf-cicd/template-cicd-domain-roles.yaml
@@ -321,7 +321,14 @@ Resources:
                   - events:PutRule
                   - events:PutTargets
                   - events:RemoveTargets
-                Resource: !Sub arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:rule/sdlf-*
+                  - events:DescribeEventBus
+                  - events:CreateEventBus
+                  - events:DeleteEventBus
+                  - events:TagResource
+                  - events:UntagResource
+                Resource:
+                  - !Sub arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:rule/sdlf-*
+                  - !Sub arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:event-bus/sdlf-*
               - Effect: Allow
                 Action: iam:PassRole
                 Resource: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/sdlf-domain-*
@@ -330,6 +337,7 @@ Resources:
                     "iam:PassedToService":
                       - lambda.amazonaws.com
                       - lakeformation.amazonaws.com
+                      - events.amazonaws.com
               - Effect: Allow
                 Action:
                   - iam:DeleteRole

--- a/sdlf-cicd/template-cicd-domain-team-role.yaml
+++ b/sdlf-cicd/template-cicd-domain-team-role.yaml
@@ -111,7 +111,7 @@ Resources:
                   - events:PutRule
                   - events:PutTargets
                   - events:RemoveTargets
-                Resource: !Sub arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:rule/sdlf-${pTeamName}-*
+                Resource: !Sub arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:rule/sdlf-${pTeamName}/sdlf-${pTeamName}-*
               - Effect: Allow
                 Action:
                   - sqs:AddPermission

--- a/sdlf-pipeline/template.yaml
+++ b/sdlf-pipeline/template.yaml
@@ -56,8 +56,8 @@ Resources:
     Properties:
       Name: !Sub sdlf-${pTeamName}-${pPipelineName}-rule-${pStageName}
       Description: !Sub Send events to ${pStageName} queue
-      EventPattern:
-        Ref: pEventPattern
+      EventPattern: !Ref pEventPattern
+      EventBusName: !Sub "{{resolve:ssm:/SDLF/EventBridge/${pTeamName}/EventBusName}}"
       State: ENABLED
       Targets:
         - Id: !Sub sdlf-${pTeamName}-${pPipelineName}-rule-${pStageName}

--- a/sdlf-team/template.yaml
+++ b/sdlf-team/template.yaml
@@ -208,6 +208,47 @@ Resources:
       AliasName: !Sub alias/sdlf-${pTeamName}-kms-data-key
       TargetKeyId: !Ref rKMSDataKey
 
+  rEventBus:
+    Type: AWS::Events::EventBus
+    Properties:
+        Name: !Sub sdlf-${pTeamName}
+
+  rForwardEventBusTriggerRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - events.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: sdlf-cicd-events-trigger
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action: events:PutEvents
+                Resource:
+                  - !GetAtt rEventBus.Arn
+
+  rForwardEventBusRule:
+    Type: AWS::Events::Rule
+    Properties:
+      EventPattern:
+        source:
+          - prefix: aws.
+        account:
+          - !Ref AWS::AccountId
+        region:
+          - !Ref AWS::Region
+      Targets:
+        - Arn: !GetAtt rEventBus.Arn
+          RoleArn: !GetAtt rForwardEventBusTriggerRole.Arn
+          Id: default-to-sdlf-team
+
   rScheduleGroup:
     Type: AWS::Scheduler::ScheduleGroup
     Properties:
@@ -270,6 +311,14 @@ Resources:
       Type: String
       Value: !GetAtt rKMSDataKey.Arn
       Description: !Sub Arn of the ${pTeamName} KMS data key
+
+  rEventBusSsm:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub /SDLF/EventBridge/${pTeamName}/EventBusName
+      Type: String
+      Value: !Ref rEventBus
+      Description: !Sub Name of the ${pTeamName} event bus
 
   rScheduleGroupSsm:
     Type: AWS::SSM::Parameter


### PR DESCRIPTION
*Issue #, if available:*
#165 

*Description of changes:*
The hard limit for number of rules on an event bus is fairly low (2000). SDLF makes extensive use of rules in pipelines, thus hitting the limit quickly. To avoid this, teams now use a dedicated event bus. AWS events are forwarded to it with a rule on the default event bus.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
