### PR TITLE
rename pOrganizationName parameter to pOrg to be consistent across all SDLF

### DIFF
--- a/sdlf-dataset/template.yaml
+++ b/sdlf-dataset/template.yaml
@@ -5,6 +5,10 @@ Parameters:
   pPipelineReference:
     Type: String
     Default: none
+  pOrg:
+    Description: Name of the organization owning the datalake
+    Type: String
+    Default: "{{resolve:ssm:/SDLF/Misc/pOrg}}"
   pDomain:
     Description: Data domain name
     Type: String
@@ -17,10 +21,6 @@ Parameters:
     Description: Environment name
     Type: String
     Default: "{{resolve:ssm:/SDLF/Misc/pEnv}}"
-  pOrg:
-    Description: Name of the organization owning the datalake
-    Type: String
-    Default: "{{resolve:ssm:/SDLF/Misc/pOrg}}"
   pStageBucket:
     Description: The stage bucket for the solution
     Type: String

--- a/sdlf-foundations/template.yaml
+++ b/sdlf-foundations/template.yaml
@@ -11,6 +11,10 @@ Parameters:
     Type: String
     AllowedPattern: (\d{12}|^$)
     ConstraintDescription: Must be an AWS account ID
+  pOrg:
+    Description: Name of the organization owning the datalake (all lowercase, no symbols or spaces)
+    Type: String
+    AllowedPattern: "[a-z0-9]{2,9}"
   pDomain:
     Description: Data domain name
     Type: String
@@ -27,10 +31,6 @@ Parameters:
     Type: String
     AllowedValues: ["3", "1"]
     ConstraintDescription: Must specify 3 or 1
-  pOrganizationName:
-    Description: Name of the organization (all lowercase, no symbols or spaces)
-    Type: String
-    AllowedPattern: "[a-z0-9]{2,9}"
   pCloudWatchLogsRetentionInDays:
     Description: The number of days log events are kept in CloudWatch Logs
     Type: Number
@@ -344,7 +344,7 @@ Resources:
         !If [
           UseCustomBucketPrefix,
           !Sub "${pCustomBucketPrefix}-s3logs",
-          !Sub "${pOrganizationName}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}-s3logs",
+          !Sub "${pOrg}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}-s3logs",
         ]
       LifecycleConfiguration:
         Rules:
@@ -391,7 +391,7 @@ Resources:
                   !If [
                     UseCustomBucketPrefix,
                     !Sub "arn:${AWS::Partition}:s3:::${pCustomBucketPrefix}*",
-                    !Sub "arn:${AWS::Partition}:s3:::${pOrganizationName}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}*",
+                    !Sub "arn:${AWS::Partition}:s3:::${pOrg}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}*",
                   ]
               StringEquals:
                 "aws:SourceAccount": !Sub ${AWS::AccountId}
@@ -460,7 +460,7 @@ Resources:
         !If [
           UseCustomBucketPrefix,
           !Sub "${pCustomBucketPrefix}-artifacts",
-          !Sub "${pOrganizationName}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}-artifacts",
+          !Sub "${pOrg}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}-artifacts",
         ]
       LoggingConfiguration:
         DestinationBucketName: !Ref rS3AccessLogsBucket
@@ -468,7 +468,7 @@ Resources:
           !If [
             UseCustomBucketPrefix,
             !Sub "${pCustomBucketPrefix}-artifacts",
-            !Sub "${pOrganizationName}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}-artifacts",
+            !Sub "${pOrg}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}-artifacts",
           ]
       BucketEncryption:
         ServerSideEncryptionConfiguration:
@@ -510,7 +510,7 @@ Resources:
         !If [
           UseCustomBucketPrefix,
           !Ref pCustomBucketPrefix,
-          !Sub "${pOrganizationName}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}",
+          !Sub "${pOrg}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}",
         ]
       LoggingConfiguration:
         DestinationBucketName: !Ref rS3AccessLogsBucket
@@ -518,7 +518,7 @@ Resources:
           !If [
             UseCustomBucketPrefix,
             !Ref pCustomBucketPrefix,
-            !Sub "${pOrganizationName}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}",
+            !Sub "${pOrg}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}",
           ]
       BucketEncryption:
         ServerSideEncryptionConfiguration:
@@ -574,7 +574,7 @@ Resources:
         !If [
           UseCustomBucketPrefix,
           !Sub "${pCustomBucketPrefix}-raw",
-          !Sub "${pOrganizationName}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}-raw",
+          !Sub "${pOrg}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}-raw",
         ]
       LoggingConfiguration:
         DestinationBucketName: !Ref rS3AccessLogsBucket
@@ -582,7 +582,7 @@ Resources:
           !If [
             UseCustomBucketPrefix,
             !Sub "${pCustomBucketPrefix}-raw",
-            !Sub "${pOrganizationName}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}-raw",
+            !Sub "${pOrg}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}-raw",
           ]
       BucketEncryption:
         ServerSideEncryptionConfiguration:
@@ -638,7 +638,7 @@ Resources:
         !If [
           UseCustomBucketPrefix,
           !Sub "${pCustomBucketPrefix}-stage",
-          !Sub "${pOrganizationName}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}-stage",
+          !Sub "${pOrg}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}-stage",
         ]
       LoggingConfiguration:
         DestinationBucketName: !Ref rS3AccessLogsBucket
@@ -646,7 +646,7 @@ Resources:
           !If [
             UseCustomBucketPrefix,
             !Sub "${pCustomBucketPrefix}-stage",
-            !Sub "${pOrganizationName}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}-stage",
+            !Sub "${pOrg}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}-stage",
           ]
       BucketEncryption:
         ServerSideEncryptionConfiguration:
@@ -702,7 +702,7 @@ Resources:
         !If [
           UseCustomBucketPrefix,
           !Sub "${pCustomBucketPrefix}-analytics",
-          !Sub "${pOrganizationName}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}-analytics",
+          !Sub "${pOrg}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}-analytics",
         ]
       LoggingConfiguration:
         DestinationBucketName: !Ref rS3AccessLogsBucket
@@ -710,7 +710,7 @@ Resources:
           !If [
             UseCustomBucketPrefix,
             !Sub "${pCustomBucketPrefix}-analytics",
-            !Sub "${pOrganizationName}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}-analytics",
+            !Sub "${pOrg}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}-analytics",
           ]
       BucketEncryption:
         ServerSideEncryptionConfiguration:
@@ -764,7 +764,7 @@ Resources:
         !If [
           UseCustomBucketPrefix,
           !Sub "${pCustomBucketPrefix}-athena",
-          !Sub "${pOrganizationName}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}-athena",
+          !Sub "${pOrg}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}-athena",
         ]
       LoggingConfiguration:
         DestinationBucketName: !Ref rS3AccessLogsBucket
@@ -772,7 +772,7 @@ Resources:
           !If [
             UseCustomBucketPrefix,
             !Sub "${pCustomBucketPrefix}-athena",
-            !Sub "${pOrganizationName}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}-athena",
+            !Sub "${pOrg}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}-athena",
           ]
       BucketEncryption:
         ServerSideEncryptionConfiguration:
@@ -902,11 +902,11 @@ Resources:
                     !If [
                       CreateMultipleBuckets,
                       [
-                        !Sub "arn:${AWS::Partition}:s3:::${pOrganizationName}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}-raw",
-                        !Sub "arn:${AWS::Partition}:s3:::${pOrganizationName}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}-stage",
-                        !Sub "arn:${AWS::Partition}:s3:::${pOrganizationName}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}-analytics",
+                        !Sub "arn:${AWS::Partition}:s3:::${pOrg}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}-raw",
+                        !Sub "arn:${AWS::Partition}:s3:::${pOrg}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}-stage",
+                        !Sub "arn:${AWS::Partition}:s3:::${pOrg}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}-analytics",
                       ],
-                      !Sub "arn:${AWS::Partition}:s3:::${pOrganizationName}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}",
+                      !Sub "arn:${AWS::Partition}:s3:::${pOrg}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}",
                     ],
                   ]
               StringEquals:
@@ -1635,7 +1635,7 @@ Resources:
     Properties:
       Name: /SDLF/Misc/pOrg
       Type: String
-      Value: !Ref pOrganizationName
+      Value: !Ref pOrg
       Description: Name of the Organization owning the datalake
 
   rDomainSsm:

--- a/sdlf-monitoring/template.yaml
+++ b/sdlf-monitoring/template.yaml
@@ -5,6 +5,8 @@ Description: Monitoring stack - SNS, CloudTrail, StorageLens, CloudWatch Dashboa
 Parameters:
   pDomain:
     Type: String
+  pOrg:
+    Type: String
   pEnvironment:
     Type: String
     Default: "{{resolve:ssm:/SDLF/Misc/pEnv:1}}"
@@ -21,8 +23,6 @@ Parameters:
     Description: Optional The log file prefix.
     Type: String
     Default: ""
-  pOrganizationName:
-    Type: String
   pOpenSearchDomain:
     Description: OpenSearch domain name
     Type: String
@@ -256,7 +256,7 @@ Resources:
         !If [
           UseCustomBucketPrefix,
           !Sub "${pCustomBucketPrefix}-cloudtrail",
-          !Sub "${pOrganizationName}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}-cloudtrail",
+          !Sub "${pOrg}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}-cloudtrail",
         ]
       LoggingConfiguration:
         DestinationBucketName: "{{resolve:ssm:/SDLF/S3/AccessLogsBucket}}"
@@ -264,7 +264,7 @@ Resources:
           !If [
             UseCustomBucketPrefix,
             !Ref pCustomBucketPrefix,
-            !Sub "${pOrganizationName}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}",
+            !Sub "${pOrg}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}",
           ]
       BucketEncryption:
         ServerSideEncryptionConfiguration:
@@ -753,7 +753,7 @@ Resources:
           !If [
             UseCustomBucketPrefix,
             !Ref pCustomBucketPrefix,
-            !Sub "${pOrganizationName}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}",
+            !Sub "${pOrg}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}",
           ]
       BucketEncryption:
         ServerSideEncryptionConfiguration:

--- a/sdlf-stage-dataquality/template.yaml
+++ b/sdlf-stage-dataquality/template.yaml
@@ -7,14 +7,14 @@ Parameters:
     Description: Workaround for CloudFormation resolve:ssm not updating on stack update (https://github.com/aws-cloudformation/cloudformation-coverage-roadmap/issues/844)
     Type: String
     Default: none
-  pDomain:
-    Description: Data domain name
-    Type: String
-    Default: "{{resolve:ssm:/SDLF/Misc/pDomain}}"
   pOrg:
     Description: Name of the organization owning the datalake
     Type: String
     Default: "{{resolve:ssm:/SDLF/Misc/pOrg}}"
+  pDomain:
+    Description: Data domain name
+    Type: String
+    Default: "{{resolve:ssm:/SDLF/Misc/pDomain}}"
   pTeamName:
     Description: Name of the team owning the pipeline (all lowercase, no symbols or spaces)
     Type: String

--- a/sdlf-stageA/template.yaml
+++ b/sdlf-stageA/template.yaml
@@ -7,6 +7,14 @@ Parameters:
     Description: Workaround for CloudFormation resolve:ssm not updating on stack update (https://github.com/aws-cloudformation/cloudformation-coverage-roadmap/issues/844)
     Type: String
     Default: none
+  pOrg:
+    Description: Name of the organization owning the datalake
+    Type: String
+    Default: "{{resolve:ssm:/SDLF/Misc/pOrg}}"
+  pDomain:
+    Description: Data domain name
+    Type: String
+    Default: "{{resolve:ssm:/SDLF/Misc/pDomain}}"
   pDatasetBucket:
     Description: The raw or central bucket for the solution
     Type: String
@@ -15,14 +23,6 @@ Parameters:
     Description: The stage bucket for the solution
     Type: String
     Default: "{{resolve:ssm:/SDLF/S3/StageBucket}}"
-  pDomain:
-    Description: Data domain name
-    Type: String
-    Default: "{{resolve:ssm:/SDLF/Misc/pDomain}}"
-  pOrg:
-    Description: Name of the organization owning the datalake
-    Type: String
-    Default: "{{resolve:ssm:/SDLF/Misc/pOrg}}"
   pTeamName:
     Description: Name of the team owning the pipeline (all lowercase, no symbols or spaces)
     Type: String

--- a/sdlf-stageB/template.yaml
+++ b/sdlf-stageB/template.yaml
@@ -7,18 +7,18 @@ Parameters:
     Description: Workaround for CloudFormation resolve:ssm not updating on stack update (https://github.com/aws-cloudformation/cloudformation-coverage-roadmap/issues/844)
     Type: String
     Default: none
-  pDatasetBucket:
-    Description: The raw or central bucket for the solution
-    Type: String
-    Default: "{{resolve:ssm:/SDLF/S3/CentralBucket}}"
-  pDomain:
-    Description: Data domain name
-    Type: String
-    Default: "{{resolve:ssm:/SDLF/Misc/pDomain}}"
   pOrg:
     Description: Name of the organization owning the datalake
     Type: String
     Default: "{{resolve:ssm:/SDLF/Misc/pOrg}}"
+  pDomain:
+    Description: Data domain name
+    Type: String
+    Default: "{{resolve:ssm:/SDLF/Misc/pDomain}}"
+  pDatasetBucket:
+    Description: The raw or central bucket for the solution
+    Type: String
+    Default: "{{resolve:ssm:/SDLF/S3/CentralBucket}}"
   pTeamName:
     Description: Name of the team owning the pipeline (all lowercase, no symbols or spaces)
     Type: String

--- a/sdlf-team/template.yaml
+++ b/sdlf-team/template.yaml
@@ -6,7 +6,7 @@ Parameters:
   pPipelineReference:
     Type: String
     Default: none
-  pOrganizationName:
+  pOrg:
     Description: Name of the organization owning the datalake
     Type: String
     Default: "{{resolve:ssm:/SDLF/Misc/pOrg}}"
@@ -500,10 +500,10 @@ Resources:
               - glue:GetDataQualityRulesetEvaluationRun
             Resource:
               - !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:catalog
-              - !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:database/${pOrganizationName}_${pDomain}_${pEnvironment}_${pTeamName}_*
-              - !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:table/${pOrganizationName}_${pDomain}_${pEnvironment}_${pTeamName}_*
+              - !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:database/${pOrg}_${pDomain}_${pEnvironment}_${pTeamName}_*
+              - !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:table/${pOrg}_${pDomain}_${pEnvironment}_${pTeamName}_*
               - !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:job/sdlf-${pTeamName}-*
-              - !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:job/${pOrganizationName}-${pDomain}-${pEnvironment}-${pTeamName}-*
+              - !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:job/${pOrg}-${pDomain}-${pEnvironment}-${pTeamName}-*
               - !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:dataQualityRuleset/* # glue:StartDataQualityRuleRecommendationRun requires dataQualityRuleset/*
           - Effect: Allow
             Action:

--- a/sdlf-utils/workshop-examples/10-deployment/sdlf-main/foundations-datalake-dev.yaml
+++ b/sdlf-utils/workshop-examples/10-deployment/sdlf-main/foundations-datalake-dev.yaml
@@ -12,7 +12,7 @@ Resources:
         Properties:
             pPipelineReference: !Ref pPipelineReference
             pChildAccountId: !Ref "AWS::AccountId"
-            pOrganizationName: forecourt
+            pOrg: forecourt
             pDomain: datalake
             pEnvironment: dev
             pNumBuckets: 3

--- a/sdlf-utils/workshop-examples/20-production/sdlf-main/foundations-marketing-dev.yaml
+++ b/sdlf-utils/workshop-examples/20-production/sdlf-main/foundations-marketing-dev.yaml
@@ -12,7 +12,7 @@ Resources:
         Properties:
             pPipelineReference: !Ref pPipelineReference
             pChildAccountId: 222222222222
-            pOrganizationName: forecourt
+            pOrg: forecourt
             pDomain: marketing
             pEnvironment: dev
             pNumBuckets: 3

--- a/sdlf-utils/workshop-examples/20-production/sdlf-main/foundations-proserve-dev.yaml
+++ b/sdlf-utils/workshop-examples/20-production/sdlf-main/foundations-proserve-dev.yaml
@@ -12,7 +12,7 @@ Resources:
         Properties:
             pPipelineReference: !Ref pPipelineReference
             pChildAccountId: 111111111111
-            pOrganizationName: forecourt
+            pOrg: forecourt
             pDomain: proserve
             pEnvironment: dev
             pNumBuckets: 3


### PR DESCRIPTION
*Description of changes:*
Rename `pOrganizationName` parameter to `pOrg` to be consistent across all SDLF. This has the added benefits of matching the SSM parameter name (`/SDLF/Misc/pOrg`) and being slightly shorter so helping avoid CloudFormation template length limit.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
