### PR TITLE
make sure lf-tag is created before using it in permissions

### DIFF
--- a/sdlf-team/template.yaml
+++ b/sdlf-team/template.yaml
@@ -1013,7 +1013,7 @@ Resources:
           CatalogId: !Ref AWS::AccountId
           ResourceType: TABLE
           Expression:
-            - TagKey: !Sub "sdlf:team:${pTeamName}"
+            - TagKey: !Ref rTeamLakeFormationTag
               TagValues:
                 - !Sub ${pTeamName}
       Permissions:


### PR DESCRIPTION
*Description of changes:*
Make sure lf-tag is created before using it in permissions. CloudFormation may try to create the permissions first, which obviously fails. Using a reference to the tag resource instead of writing its name "manually" avoids this.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
