### PR TITLE
create team repository in a separate stack from team codepipeline

### DIFF
--- a/sdlf-cicd/template-cicd-team-pipeline.yaml
+++ b/sdlf-cicd/template-cicd-team-pipeline.yaml
@@ -97,17 +97,7 @@ Conditions:
   EnableOptionalFeatures: !Or [!Condition EnableLambdaLayerBuilder, !Condition EnableGlueJobDeployer]
 
 Resources:
-  rTeamMainCodeCommit:
-    Type: AWS::CodeCommit::Repository
-    Properties:
-      # Code:
-      #   S3:
-      #     Bucket:
-      #     Key: zip
-      RepositoryDescription: !Sub ${pDomain} ${pTeamName} main repository
-      RepositoryName: !Sub sdlf-main-${pDomain}-${pTeamName}
-      KmsKeyId: !Ref pKMSKey
-
+  ######## CODEPIPELINE #########
   rTeamMainCodePipelineRole:
     Type: AWS::IAM::Role
     Properties:
@@ -136,7 +126,7 @@ Resources:
                   - codecommit:GetUploadArchiveStatus
                   - codecommit:CancelUploadArchive
                 Resource:
-                  - !GetAtt rTeamMainCodeCommit.Arn
+                  - !Sub "arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:{{resolve:ssm:/SDLF/CodeCommit/${pTeamName}/MainCodeCommit}}"
                   - !Sub arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:${pCicdRepository}
                   - !Sub arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:${pDatalakeLibraryRepository}
                   - !Sub arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:${pPipelineRepository}
@@ -185,7 +175,6 @@ Resources:
                 Resource:
                   - !Sub arn:${AWS::Partition}:iam::${pChildAccountId}:role/sdlf-cicd-devops-crossaccount-pipeline
 
-  ######## CODEPIPELINE #########
   rTeamCodePipeline:
     Type: AWS::CodePipeline::Pipeline
     Properties:
@@ -202,7 +191,7 @@ Resources:
               OutputArtifacts:
                 - Name: TemplateSource
               Configuration:
-                RepositoryName: !GetAtt rTeamMainCodeCommit.Name
+                RepositoryName: !Sub "{{resolve:ssm:/SDLF/CodeCommit/${pTeamName}/MainCodeCommit}}"
                 BranchName:
                   !FindInMap [pCodeCommitBranch, !Ref pEnvironment, branch]
                 PollForSourceChanges: false
@@ -622,7 +611,7 @@ Resources:
         detail-type:
           - CodeCommit Repository State Change
         resources:
-          - !GetAtt rTeamMainCodeCommit.Arn
+          - !Sub "arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:{{resolve:ssm:/SDLF/CodeCommit/${pTeamName}/MainCodeCommit}}"
         detail:
           event:
             - referenceCreated

--- a/sdlf-cicd/template-cicd-team-repository.yaml
+++ b/sdlf-cicd/template-cicd-team-repository.yaml
@@ -1,0 +1,35 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: CICD resources to handle deployment of a new team (repository)
+
+Parameters:
+  pKMSKey:
+    Description: The KMS key used by CodeBuild and CodePipeline
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: /SDLF/KMS/CICDKeyId
+  pDomain:
+    Description: Name of the data domain (all lowercase, no symbols or spaces)
+    Type: String
+    AllowedPattern: "[a-z0-9]{2,9}"
+  pTeamName:
+    Description: Team name
+    Type: String
+
+Resources:
+  rTeamMainCodeCommit:
+    Type: AWS::CodeCommit::Repository
+    Properties:
+      # Code:
+      #   S3:
+      #     Bucket:
+      #     Key: zip
+      RepositoryDescription: !Sub ${pDomain} ${pTeamName} main repository
+      RepositoryName: !Sub sdlf-main-${pDomain}-${pTeamName}
+      KmsKeyId: !Ref pKMSKey
+
+  rTeamMainCodeCommitSsm:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !Sub /SDLF/CodeCommit/${pTeamName}/MainCodeCommit
+      Type: String
+      Value: !GetAtt rTeamMainCodeCommit.Name
+      Description: !Sub Name of the ${pDomain} ${pTeamName} main repository


### PR DESCRIPTION
*Description of changes:*
Fix environment support (a new env would fail when trying to create an already-created team repository).

Also paves the way to not showing irrelevant CodePipeline failures to the user, although that's for a future PR!

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
