### PR TITLE
event rule to stop codepipeline first run (rMain only for now)

### DIFF
--- a/sdlf-cicd/template-cicd-prerequisites.yaml
+++ b/sdlf-cicd/template-cicd-prerequisites.yaml
@@ -488,6 +488,132 @@ Resources:
       Value: !Ref rArtifactsBucket
       Description: S3 DevOps Artifacts Bucket
 
+  rCodePipelineFirstRunStopperLambdaLogGroup:
+    Type: AWS::Logs::LogGroup
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
+    Properties:
+      LogGroupName: !Sub /aws/lambda/${rCodePipelineFirstRunStopperLambda}
+      RetentionInDays: 1
+      KmsKeyId: !GetAtt rKMSKey.Arn
+
+  rCodePipelineFirstRunStopperLambdaRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      ManagedPolicyArns:
+        - !If
+          - RunInVpc
+          - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
+          - !Ref "AWS::NoValue"
+      Policies:
+        - PolicyName: sdlf-codepipeline-stopper-lambda
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:DescribeLogGroups
+                  - logs:DeleteLogGroup
+                  - logs:TagLogGroup
+                  - logs:PutRetentionPolicy
+                  - logs:DeleteRetentionPolicy
+                  - logs:DescribeLogStreams
+                  - logs:CreateLogStream
+                  - logs:DeleteLogStream
+                  - logs:PutLogEvents
+                Resource:
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/sdlf-codepipeline-stopper
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/sdlf-codepipeline-stopper:*
+              - Effect: Allow
+                Action:
+                  - codepipeline:StopPipelineExecution
+                Resource:
+                  - !Sub arn:${AWS::Partition}:codepipeline:${AWS::Region}:${AWS::AccountId}:sdlf-cicd-*
+
+  rCodePipelineFirstRunStopperLambda:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: sdlf-codepipeline-stopper
+      Description: Stops CodePipeline automatic first run
+      Runtime: python3.11
+      Handler: index.lambda_handler
+      KmsKeyArn: !GetAtt rKMSKey.Arn
+      MemorySize: 128
+      Role: !GetAtt rCodePipelineFirstRunStopperLambdaRole.Arn
+      Timeout: 150
+      Code:
+        ZipFile: |
+          import logging
+          import os
+
+          import boto3
+
+          logger = logging.getLogger()
+          logger.setLevel(logging.INFO)
+
+          codepipeline_endpoint_url = "https://codepipeline." + os.getenv("AWS_REGION") + ".amazonaws.com"
+          codepipeline = boto3.client("codepipeline", endpoint_url=codepipeline_endpoint_url)
+
+
+          def lambda_handler(event, context):
+              try:
+                  # extract pipeline name and execution id from the source event
+                  detail = event.get("detail", {})
+                  pipeline = detail.get("pipeline", {})
+                  pipeline_execution = detail.get("execution-id", {})
+
+                  if pipeline and pipeline_execution:
+                      codepipeline.stop_pipeline_execution(pipelineName=pipeline, pipelineExecutionId=pipeline_execution)
+                      logger.info("Stopped pipeline: %s, execution %s", pipeline, pipeline_execution)
+                  else:
+                      logger.info("Pipeline name or execution id not found in the source event")
+              except Exception as e:
+                  message = "Function exception: " + str(e)
+                  logger.info(message)
+                  raise
+
+              return {"statusCode": 200, "body": "Pipeline execution stopped successfully"}
+
+  rPermissionForCodePipelineFirstRunStopperEventsToInvokeLambda:
+    Type: AWS::Lambda::Permission
+    Properties:
+      FunctionName: !Ref rCodePipelineFirstRunStopperLambda
+      Action: lambda:InvokeFunction
+      Principal: events.amazonaws.com
+      SourceArn: !GetAtt rCodePipelineFirstRunStopperTriggerRule.Arn
+
+  rCodePipelineFirstRunStopperTriggerRule:
+    Type: AWS::Events::Rule
+    Properties:
+      State: ENABLED
+      EventPattern:
+        source:
+          - aws.codepipeline
+        detail-type:
+          - CodePipeline Pipeline Execution State Change
+        resources:
+          - prefix: !Sub "arn:${AWS::Partition}:codepipeline:${AWS::Region}:${AWS::AccountId}:sdlf-cicd-sdlf-repositories-" # stop rMain CodePipeline
+        detail:
+          state:
+            - STARTED
+          execution-trigger:
+            trigger-type:
+              - CreatePipeline
+      Targets:
+        - Arn: !GetAtt rCodePipelineFirstRunStopperLambda.Arn
+          Id: !Sub sdlf-${rCodePipelineFirstRunStopperLambda}-trigger
+
+
 Outputs:
   # workaround {{resolve:ssm:}} not returning an array that can be used directly in VpcConfig blocks
   oVpcFeatureSecurityGroupIds:


### PR DESCRIPTION
*Description of changes:*
For some reason CodePipeline starts newly-created pipelines automatically. In SDLF this means they are usually failing, especially because source branches are not available yet: [AWS::CodeCommit::Repository](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-codecommit-repository.html) does not allow creating more than one branch through the `Code` parameter, so [when creating pipelines](https://github.com/awslabs/aws-serverless-data-lake-framework/blob/main/sdlf-cicd/nested-stacks/template-cicd-modules-pipelines.yaml) for all environments (dev, test and main branches), `dev` and `test` would fail.

Even if these branches existed the content would need to be relevant to not fail in later stages of the pipelines.

This is confusing for users as these failures are not relevant. This PR adds an event rule and a Lambda function to stop CodePipelines as soon as they start their first run. This is *a* solution, not a *great* solution, but let's improve things bit by bit.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
