### PR TITLE
create sdlf-main-{domain}-{team} repository with default content and branches

### DIFF
--- a/sdlf-cicd/nested-stacks/template-cicd-modules-pipelines.yaml
+++ b/sdlf-cicd/nested-stacks/template-cicd-modules-pipelines.yaml
@@ -20,6 +20,8 @@ Parameters:
     Type: String
   pMainRepositoryTeamLambda:
     Type: String
+  pBuildCloudFormationPackage:
+    Type: String
   pEnvironment:
     Description: Environment name
     Type: String
@@ -91,6 +93,12 @@ Resources:
                   - !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:${pMainRepositoryDomainLambda}
                   - !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:${pMainRepositoryCrossAccountTeamLambda}
                   - !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:${pMainRepositoryTeamLambda}
+              - Effect: Allow
+                Action:
+                  - codebuild:StartBuild
+                  - codebuild:BatchGetBuilds
+                Resource:
+                  - !Sub "arn:${AWS::Partition}:codebuild:${AWS::Region}:${AWS::AccountId}:project/${pBuildCloudFormationPackage}"
 
   rMainRepositoryPipeline:
     Type: AWS::CodePipeline::Pipeline
@@ -163,6 +171,21 @@ Resources:
         -
           Name: TeamPipeline
           Actions:
+            - Name: PackageTemplate
+              InputArtifacts:
+                - Name: SourceCicdArtifact
+              OutputArtifacts:
+                - Name: TemplatePackage
+              ActionTypeId:
+                Category: Build
+                Owner: AWS
+                Version: "1"
+                Provider: CodeBuild
+              Configuration:
+                ProjectName: !Ref pBuildCloudFormationPackage
+                EnvironmentVariables: >-
+                  [{"name":"TEMPLATE", "value":"template-cicd-team-repository.yaml", "type":"PLAINTEXT"}]
+              RunOrder: 1
             - Name: CreateTeamCodePipeline
               ActionTypeId:
                 Category: Invoke
@@ -172,10 +195,11 @@ Resources:
               InputArtifacts:
                 - Name: SourceMainArtifact
                 - Name: SourceCicdArtifact
+                - Name: TemplatePackage
               Configuration:
                 FunctionName: !Ref pMainRepositoryTeamLambda
                 UserParameters: !FindInMap [pCodeCommitBranch, !Ref pEnvironment, branch]
-              RunOrder: 1
+              RunOrder: 2
       ArtifactStore:
         Type: S3
         EncryptionKey:

--- a/sdlf-cicd/template-cicd-sdlf-pipelines.yaml
+++ b/sdlf-cicd/template-cicd-sdlf-pipelines.yaml
@@ -65,6 +65,7 @@ Resources:
         pMainRepositoryDomainLambda: !Ref rMainRepositoryDomainLambda
         pMainRepositoryCrossAccountTeamLambda: !Ref rMainRepositoryCrossAccountTeamLambda
         pMainRepositoryTeamLambda: !Ref rMainRepositoryTeamLambda
+        pBuildCloudFormationPackage: !Ref rCloudFormationPackageCodeBuildProject
         pEnvironment: dev
 
   rCloudFormationModulesTestDeploymentPipelines:
@@ -82,6 +83,7 @@ Resources:
         pMainRepositoryDomainLambda: !Ref rMainRepositoryDomainLambda
         pMainRepositoryCrossAccountTeamLambda: !Ref rMainRepositoryCrossAccountTeamLambda
         pMainRepositoryTeamLambda: !Ref rMainRepositoryTeamLambda
+        pBuildCloudFormationPackage: !Ref rCloudFormationPackageCodeBuildProject
         pEnvironment: test
 
   rCloudFormationModulesProdDeploymentPipelines:
@@ -99,6 +101,7 @@ Resources:
         pMainRepositoryDomainLambda: !Ref rMainRepositoryDomainLambda
         pMainRepositoryCrossAccountTeamLambda: !Ref rMainRepositoryCrossAccountTeamLambda
         pMainRepositoryTeamLambda: !Ref rMainRepositoryTeamLambda
+        pBuildCloudFormationPackage: !Ref rCloudFormationPackageCodeBuildProject
         pEnvironment: prod
 
   rStagesRepositoriesLambdaRole:
@@ -304,6 +307,12 @@ Resources:
                 Resource:
                   - !Sub arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:${pMainRepository}
                   - !Sub arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:${pCicdRepository}
+              - Action:
+                  - codecommit:GetBranch
+                  - codecommit:CreateBranch
+                Effect: Allow
+                Resource:
+                  - !Sub arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-main-*
                 Sid: CodeCommitRead
               - Action:
                   - codecommit:CreateApprovalRuleTemplate # W11 exception
@@ -397,6 +406,7 @@ Resources:
                   - codecommit:UntagResource
                   - codecommit:UpdateRepositoryEncryptionKey
                   - codecommit:PutRepositoryTriggers
+                  - codecommit:CreateCommit
                 Resource:
                   - !Sub arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-main-*
               - Effect: Allow  
@@ -408,6 +418,11 @@ Resources:
                   - kms:ReEncrypt*
                 Resource:
                   - !Ref pKMSKey
+              - Effect: Allow
+                Action:
+                  - s3:GetObject
+                Resource:
+                  - !Sub arn:${AWS::Partition}:s3:::${pArtifactsBucket}/codebuild/*
               - Effect: Allow
                 Action:
                   - iam:PassRole

--- a/sdlf-cicd/template-cicd-team-repository.yaml
+++ b/sdlf-cicd/template-cicd-team-repository.yaml
@@ -17,11 +17,15 @@ Parameters:
 Resources:
   rTeamMainCodeCommit:
     Type: AWS::CodeCommit::Repository
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - E3002
     Properties:
-      # Code:
-      #   S3:
-      #     Bucket:
-      #     Key: zip
+      Code:
+        BranchName: main
+        S3: ./README.md
       RepositoryDescription: !Sub ${pDomain} ${pTeamName} main repository
       RepositoryName: !Sub sdlf-main-${pDomain}-${pTeamName}
       KmsKeyId: !Ref pKMSKey


### PR DESCRIPTION
*Description of changes:*
Create `sdlf-main-{domain}-{team}` repository with default content and branches.

This allows creating git branches ahead of CodePipelines - then they won't fail so fast, allowing the CodePipeline stopper to kick in (see #261 or 4e290af).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
