### PR TITLE
update event rule to stop rDomain CodePipeline first run

### DIFF
--- a/sdlf-cicd/template-cicd-prerequisites.yaml
+++ b/sdlf-cicd/template-cicd-prerequisites.yaml
@@ -603,6 +603,7 @@ Resources:
           - CodePipeline Pipeline Execution State Change
         resources:
           - prefix: !Sub "arn:${AWS::Partition}:codepipeline:${AWS::Region}:${AWS::AccountId}:sdlf-cicd-sdlf-pipelines-" # stop rMain CodePipeline
+          - prefix: !Sub "arn:${AWS::Partition}:codepipeline:${AWS::Region}:${AWS::AccountId}:sdlf-cicd-domain-" # stop rDomain CodePipeline
           - prefix: !Sub "arn:${AWS::Partition}:codepipeline:${AWS::Region}:${AWS::AccountId}:sdlf-cicd-teams-" # stop rTeam CodePipeline
         detail:
           state:


### PR DESCRIPTION
*Description of changes:*
Update event rule to stop rDomainCodePipeline first run. See also #261.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
