### PR TITLE
replace deprecated utcnow() with now(datetime.timezone.utc) for expli…

### DIFF
--- a/sdlf-cicd/template-codecommit-pr-check.yaml
+++ b/sdlf-cicd/template-codecommit-pr-check.yaml
@@ -128,7 +128,7 @@ Resources:
                     repositoryName = repository_name,
                     beforeCommitId = source_commit,
                     afterCommitId = destination_commit,
-                    content = '**Validation Build started at {}. Please wait until validation results received.**'.format(datetime.datetime.utcnow().time())
+                    content = '**Validation Build started at {}. Please wait until validation results received.**'.format(datetime.datetime.now(datetime.timezone.utc).time())
                   )
 
   rPullRequestLambdaLogGroup:

--- a/sdlf-datalakeLibrary/python/datalake_library/interfaces/dynamo_interface.py
+++ b/sdlf-datalakeLibrary/python/datalake_library/interfaces/dynamo_interface.py
@@ -97,7 +97,7 @@ class DynamoInterface:
 
     def update_object_metadata_catalog(self, item):
         item["id"] = self.build_id(item["bucket"], item["key"])
-        item["timestamp"] = int(round(dt.datetime.utcnow().timestamp() * 1000, 0))
+        item["timestamp"] = int(round(dt.datetime.now(dt.timezone.utc).timestamp() * 1000, 0))
         return self.put_item_in_object_metadata_table(item)
 
     def put_item_in_object_metadata_table(self, item):
@@ -106,7 +106,7 @@ class DynamoInterface:
     def batch_update_object_metadata_catalog(self, items):
         for item in items:
             item["id"] = self.build_id(item["bucket"], item["key"])
-            item["timestamp"] = int(round(dt.datetime.utcnow().timestamp() * 1000, 0))
+            item["timestamp"] = int(round(dt.datetime.now(dt.timezone.utc).timestamp() * 1000, 0))
 
         return self.batch_put_item_in_object_metadata_table(items)
 
@@ -195,7 +195,7 @@ class DynamoInterface:
 
     def update_manifests_control_table_stagea(self, ddb_key, status, s3_key=None):
         if status == "STARTED":
-            starttime_time = dt.datetime.utcnow()
+            starttime_time = dt.datetime.now(dt.timezone.utc)
             starttime = str(starttime_time)
             starttimestamp = int(starttime_time.timestamp())
             expr_names = {
@@ -226,7 +226,7 @@ class DynamoInterface:
             return self.update_manifests_control_table(ddb_key, update_expr, expr_names, expr_values)
 
         elif status == "COMPLETED":
-            endtime_time = dt.datetime.utcnow()
+            endtime_time = dt.datetime.now(dt.timezone.utc)
             endtime = str(endtime_time)
             endtimestamp = int(endtime_time.timestamp())
             s3_prefix = s3_key
@@ -244,7 +244,7 @@ class DynamoInterface:
             return self.update_manifests_control_table(ddb_key, update_expr, expr_names, expr_values)
 
         elif status == "FAILED":
-            endtime_time = dt.datetime.utcnow()
+            endtime_time = dt.datetime.now(dt.timezone.utc)
             endtime = str(endtime_time)
             endtimestamp = int(endtime_time.timestamp())
             expr_names = {
@@ -265,7 +265,7 @@ class DynamoInterface:
 
     def update_manifests_control_table_stageb(self, ddb_key, status, s3_key=None, comment=None):
         if status == "STARTED":
-            starttime_time = dt.datetime.utcnow()
+            starttime_time = dt.datetime.now(dt.timezone.utc)
             starttime = str(starttime_time)
             starttimestamp = int(starttime_time.timestamp())
             expr_names = {
@@ -285,7 +285,7 @@ class DynamoInterface:
             return self.update_manifests_control_table(ddb_key, update_expr, expr_names, expr_values)
 
         elif status == "COMPLETED":
-            endtime_time = dt.datetime.utcnow()
+            endtime_time = dt.datetime.now(dt.timezone.utc)
             endtime = str(endtime_time)
             endtimestamp = int(endtime_time.timestamp())
             expr_names = {
@@ -301,7 +301,7 @@ class DynamoInterface:
             return self.update_manifests_control_table(ddb_key, update_expr, expr_names, expr_values)
 
         elif status == "FAILED":
-            endtime_time = dt.datetime.utcnow()
+            endtime_time = dt.datetime.now(dt.timezone.utc)
             endtime = str(endtime_time)
             endtimestamp = int(endtime_time.timestamp())
             expr_names = {

--- a/sdlf-datalakeLibrary/python/datalake_library/octagon/artifact.py
+++ b/sdlf-datalakeLibrary/python/datalake_library/octagon/artifact.py
@@ -93,7 +93,7 @@ class ArtifactAPI:
         throw_if_false(self.client.is_pipeline_set(), "Pipeline execution is not yet assigned")
         throw_if_none(artifact, "Artifact is not defined")
 
-        current_time = datetime.datetime.utcnow()
+        current_time = datetime.datetime.now(datetime.timezone.utc)
         utc_time_iso = get_timestamp_iso(current_time)
         local_date_iso = get_local_date()
 

--- a/sdlf-datalakeLibrary/python/datalake_library/octagon/event.py
+++ b/sdlf-datalakeLibrary/python/datalake_library/octagon/event.py
@@ -42,7 +42,7 @@ class EventAPI:
         # Put to DDB
 
         item = {}
-        current_time = datetime.datetime.utcnow()
+        current_time = datetime.datetime.now(datetime.timezone.utc)
         local_date_iso = get_local_date()
         utc_time_iso = get_timestamp_iso(current_time)
         # Add extra fields

--- a/sdlf-datalakeLibrary/python/datalake_library/octagon/peh.py
+++ b/sdlf-datalakeLibrary/python/datalake_library/octagon/peh.py
@@ -49,7 +49,7 @@ class PipelineExecutionHistoryAPI:
             return None
 
         peh_id = str(uuid.uuid4())
-        current_time = datetime.datetime.utcnow()
+        current_time = datetime.datetime.now(datetime.timezone.utc)
         utc_time_iso = get_timestamp_iso(current_time)
         local_date_iso = get_local_date()
 
@@ -108,7 +108,7 @@ class PipelineExecutionHistoryAPI:
         version = peh_rec["version"]
         start_time = peh_rec["start_timestamp"]
 
-        current_time = datetime.datetime.utcnow()
+        current_time = datetime.datetime.now(datetime.timezone.utc)
         utc_time_iso = get_timestamp_iso(current_time)
         local_date_iso = get_local_date()
 

--- a/sdlf-datalakeLibrary/python/datalake_library/octagon/utils.py
+++ b/sdlf-datalakeLibrary/python/datalake_library/octagon/utils.py
@@ -10,8 +10,8 @@ def get_duration_sec(start_timestamp_str, end_timestamp_str):
     return (end_ts - start_ts).total_seconds()
 
 
-# datetime.datetime.utcnow()
-def get_timestamp_iso(current_time=datetime.datetime.utcnow()):
+# datetime.datetime.now(datetime.timezone.utc)
+def get_timestamp_iso(current_time=datetime.datetime.now(datetime.timezone.utc)):
     return current_time.isoformat()[:-3] + "Z"
 
 

--- a/sdlf-foundations/lambda/catalog/src/lambda_function.py
+++ b/sdlf-foundations/lambda/catalog/src/lambda_function.py
@@ -22,7 +22,7 @@ def parse_s3_event(s3_event):
         "key": unquote_plus(s3_event["s3"]["object"]["key"]),
         "size": s3_event["s3"]["object"]["size"],
         "last_modified_date": s3_event["eventTime"].split(".")[0] + "+00:00",
-        "timestamp": int(round(datetime.utcnow().timestamp() * 1000, 0)),
+        "timestamp": int(round(datetime.now(datetime.timezone.utc).timestamp() * 1000, 0)),
     }
 
 

--- a/sdlf-foundations/lambda/replicate/src/lambda_function.py
+++ b/sdlf-foundations/lambda/replicate/src/lambda_function.py
@@ -19,7 +19,7 @@ schemas_table = "octagon-DataSchemas-{}".format(os.getenv("ENV"))
 
 
 def get_current_time():
-    return datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"
+    return datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"
 
 
 def grant_table_permissions(iam_arn, database, table, permissions):


### PR DESCRIPTION
*Issue #, if available:* #271

*Description of changes:* 
Project is slated for upgrade to Python 3.12 where datetime.datetime.utcnow() is deprecated because the datetime object it creates is not associated with a timezone. Per the linked article, https://discuss.python.org/t/deprecating-utcnow-and-utcfromtimestamp/26221, I replaced all instances with datetime.datetime.now(datetime.timezone.utc).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
