### PR TITLE
add cloudformation permissions for nested stacks to allow adding of non-sdlf layers by arn

### DIFF
--- a/sdlf-cicd/nested-stacks/template-cicd-cfn-module.yaml
+++ b/sdlf-cicd/nested-stacks/template-cicd-cfn-module.yaml
@@ -301,6 +301,12 @@ Resources:
                       popd || exit
                     done
                 - |-
+                    temp_role=$(aws sts --endpoint-url "$STS_ENDPOINT_URL" assume-role --role-arn "arn:${AWS::Partition}:iam::$DOMAIN_ACCOUNT_ID:role/sdlf-cicd-devops-crossaccount-pipeline" --role-session-name "codebuild-cfn-module")
+                    AWS_ACCESS_KEY_ID=$(echo "$temp_role" | jq .Credentials.AccessKeyId | xargs)
+                    AWS_SECRET_ACCESS_KEY=$(echo "$temp_role" | jq .Credentials.SecretAccessKey | xargs)
+                    AWS_SESSION_TOKEN=$(echo "$temp_role" | jq .Credentials.SessionToken | xargs)
+                    export AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
+
                     for STAGE_REPOSITORY in $STAGES_REPOSITORIES; do
                       pushd "$STAGE_REPOSITORY" || exit
                       MODULE_NAME=${!STAGE_REPOSITORY##*-}
@@ -319,16 +325,7 @@ Resources:
                       popd || exit
                       rm -Rf module
                       popd || exit
-                    done
-                - |-
-                    temp_role=$(aws sts --endpoint-url "$STS_ENDPOINT_URL" assume-role --role-arn "arn:${AWS::Partition}:iam::$DOMAIN_ACCOUNT_ID:role/sdlf-cicd-devops-crossaccount-pipeline" --role-session-name "codebuild-cfn-module")
-                    AWS_ACCESS_KEY_ID=$(echo "$temp_role" | jq .Credentials.AccessKeyId | xargs)
-                    AWS_SECRET_ACCESS_KEY=$(echo "$temp_role" | jq .Credentials.SecretAccessKey | xargs)
-                    AWS_SESSION_TOKEN=$(echo "$temp_role" | jq .Credentials.SessionToken | xargs)
-                    export AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_SESSION_TOKEN
-
-                    for STAGE_REPOSITORY in $STAGES_REPOSITORIES; do
-                      MODULE_NAME=${!STAGE_REPOSITORY##*-}
+                      
                       # compare hashes to avoid creating a new module version when there is no change
                       if CURRENT_MODULE=$(aws ssm --endpoint-url "$SSM_ENDPOINT_URL" get-parameter --name "/SDLF/CFN/$DOMAIN_NAME-$TEAM_NAME-$MODULE_NAME-MODULE" --query "Parameter.Value" --output text); then
                         echo "Current module version commit id: $CURRENT_MODULE"

--- a/sdlf-cicd/template-cicd-domain-team-role.yaml
+++ b/sdlf-cicd/template-cicd-domain-team-role.yaml
@@ -280,7 +280,9 @@ Resources:
           - Effect: Allow
             Action:
               - lambda:GetLayerVersion
-            Resource: !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:layer:sdlf-* # there are sdlf-wide layers (datalake-lib-layer)
+            Resource: 
+              - !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:layer:sdlf-* # there are sdlf-wide layers (datalake-lib-layer)
+              - !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:336392948345:layer:AWSSDKPandas-* # allow managed AWS SDK for Pandas layer
           - Effect: Allow
             Action:
               - lambda:CreateFunction


### PR DESCRIPTION
Allow specifying of non-sdlf layers in stages by arn.

*Issue #, if available:*
https://github.com/awslabs/aws-serverless-data-lake-framework/issues/276

*Description of changes:*
Updated lambda:GetLayerVersion for sdlf-cicd-team-{pTeamName} role

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
