### PR TITLE
fix team removal workflow

### DIFF
--- a/sdlf-cicd/template-cicd-sdlf-pipelines.yaml
+++ b/sdlf-cicd/template-cicd-sdlf-pipelines.yaml
@@ -316,6 +316,7 @@ Resources:
                 Sid: CodeCommitRead
               - Action:
                   - codecommit:CreateApprovalRuleTemplate # W11 exception
+                  - codecommit:DeleteApprovalRuleTemplate # W11 exception
                 Effect: Allow
                 Resource:
                   - "*"


### PR DESCRIPTION
*Description of changes:*
- add missing permission for team-cicd lambda to remove codecommit approval rules 
- do not fail if there is no kms grant to revoke
- handle crossaccount deletion of the team role stack properly

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
