### PR TITLE
remove support for single-bucket setup

### DIFF
--- a/sdlf-foundations/lambda/catalog/src/lambda_function.py
+++ b/sdlf-foundations/lambda/catalog/src/lambda_function.py
@@ -68,10 +68,7 @@ def lambda_handler(event, context):
             else:
                 item = parse_s3_event(message)
                 item["id"] = f"s3://{item['bucket']}/{item['key']}"
-                if os.environ["NUM_BUCKETS"] == "1":
-                    item["stage"] = item["key"].split("/")[0]
-                else:
-                    item["stage"] = item["bucket"].split("-")[-1]
+                item["stage"] = item["bucket"].split("-")[-1]
                 put_item(catalog_table, item, "id")
 
     except Exception as e:

--- a/sdlf-foundations/template.yaml
+++ b/sdlf-foundations/template.yaml
@@ -25,12 +25,6 @@ Parameters:
   pEnvironment:
     Description: Environment name
     Type: String
-  pNumBuckets:
-    Description: Number of data lake buckets (3 or 1)
-    Default: "3"
-    Type: String
-    AllowedValues: ["3", "1"]
-    ConstraintDescription: Must specify 3 or 1
   pCloudWatchLogsRetentionInDays:
     Description: The number of days log events are kept in CloudWatch Logs
     Type: Number
@@ -75,8 +69,6 @@ Parameters:
     Default: ""
 
 Conditions:
-  CreateMultipleBuckets: !Equals [!Ref pNumBuckets, "3"]
-  CreateSingleBucket: !Equals [!Ref pNumBuckets, "1"]
   UseCustomBucketPrefix: !Not [!Equals [!Ref pCustomBucketPrefix, sdlf]]
   RunInVpc: !Equals [!Ref pEnableVpc, true]
 
@@ -343,11 +335,10 @@ Resources:
             reason: Access logs bucket should not have logging enabled https://docs.aws.amazon.com/AmazonS3/latest/userguide/enable-server-access-logging.html
     Properties:
       BucketName:
-        !If [
-          UseCustomBucketPrefix,
-          !Sub "${pCustomBucketPrefix}-s3logs",
-          !Sub "${pOrg}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}-s3logs",
-        ]
+        !If
+          - UseCustomBucketPrefix
+          - !Sub "${pCustomBucketPrefix}-s3logs"
+          - !Sub "${pOrg}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}-s3logs"
       LifecycleConfiguration:
         Rules:
           - Id: InfrequentAccess
@@ -390,11 +381,10 @@ Resources:
             Condition:
               ArnLike:
                 "aws:SourceArn":
-                  !If [
-                    UseCustomBucketPrefix,
-                    !Sub "arn:${AWS::Partition}:s3:::${pCustomBucketPrefix}*",
-                    !Sub "arn:${AWS::Partition}:s3:::${pOrg}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}*",
-                  ]
+                  !If
+                    - UseCustomBucketPrefix
+                    - !Sub "arn:${AWS::Partition}:s3:::${pCustomBucketPrefix}*"
+                    - !Sub "arn:${AWS::Partition}:s3:::${pOrg}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}*"
               StringEquals:
                 "aws:SourceAccount": !Sub ${AWS::AccountId}
 
@@ -424,21 +414,12 @@ Resources:
               - s3:PutObjectVersionTagging
               - s3:Abort*
             Resource:
-              !If [
-                CreateMultipleBuckets,
-                [
-                  !Sub "arn:${AWS::Partition}:s3:::${rRawBucket}",
-                  !Sub "arn:${AWS::Partition}:s3:::${rStageBucket}",
-                  !Sub "arn:${AWS::Partition}:s3:::${rAnalyticsBucket}",
-                  !Sub "arn:${AWS::Partition}:s3:::${rRawBucket}/*",
-                  !Sub "arn:${AWS::Partition}:s3:::${rStageBucket}/*",
-                  !Sub "arn:${AWS::Partition}:s3:::${rAnalyticsBucket}/*",
-                ],
-                [
-                  !Sub "arn:${AWS::Partition}:s3:::${rCentralBucket}",
-                  !Sub "arn:${AWS::Partition}:s3:::${rCentralBucket}/*",
-                ]
-              ]
+              - !Sub "arn:${AWS::Partition}:s3:::${rRawBucket}"
+              - !Sub "arn:${AWS::Partition}:s3:::${rStageBucket}"
+              - !Sub "arn:${AWS::Partition}:s3:::${rAnalyticsBucket}"
+              - !Sub "arn:${AWS::Partition}:s3:::${rRawBucket}/*"
+              - !Sub "arn:${AWS::Partition}:s3:::${rStageBucket}/*"
+              - !Sub "arn:${AWS::Partition}:s3:::${rAnalyticsBucket}/*"
           - Effect: Allow
             Action:
               - kms:Encrypt*
@@ -459,19 +440,17 @@ Resources:
     Type: AWS::S3::Bucket
     Properties:
       BucketName:
-        !If [
-          UseCustomBucketPrefix,
-          !Sub "${pCustomBucketPrefix}-artifacts",
-          !Sub "${pOrg}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}-artifacts",
-        ]
+        !If
+          - UseCustomBucketPrefix
+          - !Sub "${pCustomBucketPrefix}-artifacts"
+          - !Sub "${pOrg}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}-artifacts"
       LoggingConfiguration:
         DestinationBucketName: !Ref rS3AccessLogsBucket
         LogFilePrefix:
-          !If [
-            UseCustomBucketPrefix,
-            !Sub "${pCustomBucketPrefix}-artifacts",
-            !Sub "${pOrg}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}-artifacts",
-          ]
+          !If
+            - UseCustomBucketPrefix
+            - !Sub "${pCustomBucketPrefix}-artifacts"
+            - !Sub "${pOrg}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}-artifacts"
       BucketEncryption:
         ServerSideEncryptionConfiguration:
           - BucketKeyEnabled: True
@@ -503,89 +482,22 @@ Resources:
             Principal: "*"
 
   # To Enforce KMS encryption: https://aws.amazon.com/premiumsupport/knowledge-center/s3-bucket-store-kms-encrypted-objects/
-  rCentralBucket:
-    Type: AWS::S3::Bucket
-    Condition: CreateSingleBucket
-    DependsOn: rQueueCatalogPolicy
-    Properties:
-      BucketName:
-        !If [
-          UseCustomBucketPrefix,
-          !Ref pCustomBucketPrefix,
-          !Sub "${pOrg}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}",
-        ]
-      LoggingConfiguration:
-        DestinationBucketName: !Ref rS3AccessLogsBucket
-        LogFilePrefix:
-          !If [
-            UseCustomBucketPrefix,
-            !Ref pCustomBucketPrefix,
-            !Sub "${pOrg}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}",
-          ]
-      BucketEncryption:
-        ServerSideEncryptionConfiguration:
-          - BucketKeyEnabled: True
-            ServerSideEncryptionByDefault:
-              KMSMasterKeyID: !Ref rKMSKey
-              SSEAlgorithm: aws:kms
-      PublicAccessBlockConfiguration:
-        BlockPublicAcls: True
-        BlockPublicPolicy: True
-        IgnorePublicAcls: True
-        RestrictPublicBuckets: True
-      VersioningConfiguration:
-        Status: Enabled
-      NotificationConfiguration:
-        EventBridgeConfiguration:
-          EventBridgeEnabled: true
-
-  rCentralBucketPolicy:
-    Condition: CreateSingleBucket
-    Type: AWS::S3::BucketPolicy
-    Properties:
-      Bucket: !Ref rCentralBucket
-      PolicyDocument:
-        Version: 2012-10-17
-        Statement:
-          - Sid: AllowSSLRequestsOnly
-            Action: s3:*
-            Effect: Deny
-            Resource:
-              - !Sub arn:${AWS::Partition}:s3:::${rCentralBucket}/*
-              - !Sub arn:${AWS::Partition}:s3:::${rCentralBucket}
-            Condition:
-              Bool:
-                aws:SecureTransport: False
-            Principal: "*"
-
-  rCentralBucketLakeFormationS3Registration:
-    Type: AWS::LakeFormation::Resource
-    Condition: CreateSingleBucket
-    DependsOn: rLakeFormationDataAccessRolePolicy
-    Properties:
-      ResourceArn: !Sub arn:${AWS::Partition}:s3:::${rCentralBucket}/
-      RoleArn: !GetAtt rLakeFormationDataAccessRole.Arn
-      UseServiceLinkedRole: False
-
   rRawBucket:
     Type: AWS::S3::Bucket
-    Condition: CreateMultipleBuckets
     DependsOn: rQueueCatalogPolicy
     Properties:
       BucketName:
-        !If [
-          UseCustomBucketPrefix,
-          !Sub "${pCustomBucketPrefix}-raw",
-          !Sub "${pOrg}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}-raw",
-        ]
+        !If
+          - UseCustomBucketPrefix
+          - !Sub "${pCustomBucketPrefix}-raw"
+          - !Sub "${pOrg}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}-raw"
       LoggingConfiguration:
         DestinationBucketName: !Ref rS3AccessLogsBucket
         LogFilePrefix:
-          !If [
-            UseCustomBucketPrefix,
-            !Sub "${pCustomBucketPrefix}-raw",
-            !Sub "${pOrg}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}-raw",
-          ]
+          !If
+            - UseCustomBucketPrefix
+            - !Sub "${pCustomBucketPrefix}-raw"
+            - !Sub "${pOrg}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}-raw"
       BucketEncryption:
         ServerSideEncryptionConfiguration:
           - BucketKeyEnabled: True
@@ -605,7 +517,6 @@ Resources:
 
   rRawBucketPolicy:
     Type: AWS::S3::BucketPolicy
-    Condition: CreateMultipleBuckets
     Properties:
       Bucket: !Ref rRawBucket
       PolicyDocument:
@@ -624,7 +535,6 @@ Resources:
 
   rRawBucketLakeFormationS3Registration:
     Type: AWS::LakeFormation::Resource
-    Condition: CreateMultipleBuckets
     DependsOn: rLakeFormationDataAccessRolePolicy
     Properties:
       ResourceArn: !Sub arn:${AWS::Partition}:s3:::${rRawBucket}/
@@ -633,23 +543,20 @@ Resources:
 
   rStageBucket:
     Type: AWS::S3::Bucket
-    Condition: CreateMultipleBuckets
     DependsOn: rQueueCatalogPolicy
     Properties:
       BucketName:
-        !If [
-          UseCustomBucketPrefix,
-          !Sub "${pCustomBucketPrefix}-stage",
-          !Sub "${pOrg}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}-stage",
-        ]
+        !If
+          - UseCustomBucketPrefix
+          - !Sub "${pCustomBucketPrefix}-stage"
+          - !Sub "${pOrg}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}-stage"
       LoggingConfiguration:
         DestinationBucketName: !Ref rS3AccessLogsBucket
         LogFilePrefix:
-          !If [
-            UseCustomBucketPrefix,
-            !Sub "${pCustomBucketPrefix}-stage",
-            !Sub "${pOrg}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}-stage",
-          ]
+          !If
+            - UseCustomBucketPrefix
+            - !Sub "${pCustomBucketPrefix}-stage"
+            - !Sub "${pOrg}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}-stage"
       BucketEncryption:
         ServerSideEncryptionConfiguration:
           - BucketKeyEnabled: True
@@ -669,7 +576,6 @@ Resources:
 
   rStageBucketPolicy:
     Type: AWS::S3::BucketPolicy
-    Condition: CreateMultipleBuckets
     Properties:
       Bucket: !Ref rStageBucket
       PolicyDocument:
@@ -688,7 +594,6 @@ Resources:
 
   rStageBucketLakeFormationS3Registration:
     Type: AWS::LakeFormation::Resource
-    Condition: CreateMultipleBuckets
     DependsOn: rLakeFormationDataAccessRolePolicy
     Properties:
       ResourceArn: !Sub arn:${AWS::Partition}:s3:::${rStageBucket}/
@@ -697,23 +602,20 @@ Resources:
 
   rAnalyticsBucket:
     Type: AWS::S3::Bucket
-    Condition: CreateMultipleBuckets
     DependsOn: rQueueCatalogPolicy
     Properties:
       BucketName:
-        !If [
-          UseCustomBucketPrefix,
-          !Sub "${pCustomBucketPrefix}-analytics",
-          !Sub "${pOrg}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}-analytics",
-        ]
+        !If
+          - UseCustomBucketPrefix
+          - !Sub "${pCustomBucketPrefix}-analytics"
+          - !Sub "${pOrg}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}-analytics"
       LoggingConfiguration:
         DestinationBucketName: !Ref rS3AccessLogsBucket
         LogFilePrefix:
-          !If [
-            UseCustomBucketPrefix,
-            !Sub "${pCustomBucketPrefix}-analytics",
-            !Sub "${pOrg}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}-analytics",
-          ]
+          !If
+            - UseCustomBucketPrefix
+            - !Sub "${pCustomBucketPrefix}-analytics"
+            - !Sub "${pOrg}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}-analytics"
       BucketEncryption:
         ServerSideEncryptionConfiguration:
           - BucketKeyEnabled: True
@@ -733,7 +635,6 @@ Resources:
 
   rAnalyticsBucketPolicy:
     Type: AWS::S3::BucketPolicy
-    Condition: CreateMultipleBuckets
     Properties:
       Bucket: !Ref rAnalyticsBucket
       PolicyDocument:
@@ -752,7 +653,6 @@ Resources:
 
   rAnalyticsBucketLakeFormationS3Registration:
     Type: AWS::LakeFormation::Resource
-    Condition: CreateMultipleBuckets
     DependsOn: rLakeFormationDataAccessRolePolicy
     Properties:
       ResourceArn: !Sub arn:${AWS::Partition}:s3:::${rAnalyticsBucket}/
@@ -763,19 +663,17 @@ Resources:
     Type: AWS::S3::Bucket
     Properties:
       BucketName:
-        !If [
-          UseCustomBucketPrefix,
-          !Sub "${pCustomBucketPrefix}-athena",
-          !Sub "${pOrg}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}-athena",
-        ]
+        !If
+          - UseCustomBucketPrefix
+          - !Sub "${pCustomBucketPrefix}-athena"
+          - !Sub "${pOrg}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}-athena"
       LoggingConfiguration:
         DestinationBucketName: !Ref rS3AccessLogsBucket
         LogFilePrefix:
-          !If [
-            UseCustomBucketPrefix,
-            !Sub "${pCustomBucketPrefix}-athena",
-            !Sub "${pOrg}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}-athena",
-          ]
+          !If
+            - UseCustomBucketPrefix
+            - !Sub "${pCustomBucketPrefix}-athena"
+            - !Sub "${pOrg}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}-athena"
       BucketEncryption:
         ServerSideEncryptionConfiguration:
           - BucketKeyEnabled: True
@@ -846,7 +744,6 @@ Resources:
       Environment:
         Variables:
           ENV: !Ref pEnvironment
-          NUM_BUCKETS: !Ref pNumBuckets
       Description: Catalogs S3 Put and Delete to ObjectMetaDataCatalog
       MemorySize: 256
       Timeout: 60
@@ -889,28 +786,15 @@ Resources:
             Resource: !GetAtt rQueueCatalog.Arn
             Condition:
               ArnEquals:
-                aws:SourceArn:
-                  !If [
-                    UseCustomBucketPrefix,
-                    !If [
-                      CreateMultipleBuckets,
-                      [
-                        !Sub "arn:${AWS::Partition}:s3:::${pCustomBucketPrefix}-raw",
-                        !Sub "arn:${AWS::Partition}:s3:::${pCustomBucketPrefix}-stage",
-                        !Sub "arn:${AWS::Partition}:s3:::${pCustomBucketPrefix}-analytics",
-                      ],
-                      !Sub "arn:${AWS::Partition}:s3:::${pCustomBucketPrefix}",
-                    ],
-                    !If [
-                      CreateMultipleBuckets,
-                      [
-                        !Sub "arn:${AWS::Partition}:s3:::${pOrg}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}-raw",
-                        !Sub "arn:${AWS::Partition}:s3:::${pOrg}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}-stage",
-                        !Sub "arn:${AWS::Partition}:s3:::${pOrg}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}-analytics",
-                      ],
-                      !Sub "arn:${AWS::Partition}:s3:::${pOrg}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}",
-                    ],
-                  ]
+                "aws:SourceArn":
+                  !If
+                    - UseCustomBucketPrefix
+                    - - !Sub "arn:${AWS::Partition}:s3:::${pCustomBucketPrefix}-raw"
+                      - !Sub "arn:${AWS::Partition}:s3:::${pCustomBucketPrefix}-stage"
+                      - !Sub "arn:${AWS::Partition}:s3:::${pCustomBucketPrefix}-analytics"
+                    - - !Sub "arn:${AWS::Partition}:s3:::${pOrg}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}-raw"
+                      - !Sub "arn:${AWS::Partition}:s3:::${pOrg}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}-stage"
+                      - !Sub "arn:${AWS::Partition}:s3:::${pOrg}-${pDomain}-${pEnvironment}-${AWS::Region}-${AWS::AccountId}-analytics"
               StringEquals:
                 aws:SourceAccount: !Ref AWS::AccountId
       Queues:
@@ -997,17 +881,9 @@ Resources:
           - Object Deleted
         detail:
           bucket:
-            !If [
-              CreateMultipleBuckets,
-              [
-                !Ref rRawBucket,
-                !Ref rStageBucket,
-                !Ref rAnalyticsBucket,
-              ],
-              [
-                !Ref rCentralBucket,
-              ]
-            ]
+            - !Ref rRawBucket
+            - !Ref rStageBucket
+            - !Ref rAnalyticsBucket
       Targets:
         - Arn: !GetAtt rQueueCatalog.Arn
           RetryPolicy:
@@ -1025,27 +901,33 @@ Resources:
       Type: String
       Value: !Ref rArtifactsBucket
       Description: Name of the Artifacts S3 bucket
-  rS3CentralBucketSsm:
+  rS3CentralBucketSsm: # kept for backward compatibility
     Type: AWS::SSM::Parameter
     Properties:
       Name: /SDLF/S3/CentralBucket
       Type: String
-      Value: !If [CreateMultipleBuckets, !Ref rRawBucket, !Ref rCentralBucket]
+      Value: !Ref rRawBucket
       Description: Name of the Central S3 bucket
+  rS3RawBucketSsm:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: /SDLF/S3/RawBucket
+      Type: String
+      Value: !Ref rRawBucket
+      Description: Name of the Raw S3 bucket
   rS3StageBucketSsm:
     Type: AWS::SSM::Parameter
     Properties:
       Name: /SDLF/S3/StageBucket
       Type: String
-      Value: !If [CreateMultipleBuckets, !Ref rStageBucket, !Ref rCentralBucket]
+      Value: !Ref rStageBucket
       Description: Name of the Stage S3 bucket
   rS3AnalyticsBucketSsm:
     Type: AWS::SSM::Parameter
     Properties:
       Name: /SDLF/S3/AnalyticsBucket
       Type: String
-      Value:
-        !If [CreateMultipleBuckets, !Ref rAnalyticsBucket, !Ref rCentralBucket]
+      Value: !Ref rAnalyticsBucket
       Description: Name of the Analytics S3 bucket
   rS3AthenaBucketSsm:
     Type: AWS::SSM::Parameter

--- a/sdlf-stageA/template.yaml
+++ b/sdlf-stageA/template.yaml
@@ -273,7 +273,6 @@ Resources:
                   - s3:GetObject
                 Resource:
                   - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/${pTeamName}/*
-                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/stage/${pTeamName}/*
                   - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/pre-stage/${pTeamName}/*
                   - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/post-stage/${pTeamName}/*
 
@@ -314,9 +313,7 @@ Resources:
                   - s3:PutObject
                 Resource:
                   - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}/${pTeamName}/*
-                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}/raw/${pTeamName}/*
                   - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/${pTeamName}/*
-                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/stage/${pTeamName}/*
                   - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/pre-stage/${pTeamName}/*
                   - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/post-stage/${pTeamName}/*
               - Effect: Allow
@@ -375,7 +372,6 @@ Resources:
                   - s3:GetObject
                 Resource:
                   - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/${pTeamName}/*
-                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/stage/${pTeamName}/*
                   - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/pre-stage/${pTeamName}/*
                   - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/post-stage/${pTeamName}/*
 

--- a/sdlf-stageB/template.yaml
+++ b/sdlf-stageB/template.yaml
@@ -288,10 +288,8 @@ Resources:
                   - s3:GetObject
                 Resource:
                   - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}/${pTeamName}/*
-                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}/stage/${pTeamName}/*
                   - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}/pre-stage/${pTeamName}/*
                   - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}/post-stage/${pTeamName}/*
-                  - !Sub arn:${AWS::Partition}:s3:::${pDatasetBucket}/analytics/${pTeamName}/*
 
   # Error Handling Lambda Role
   rRoleLambdaExecutionErrorStep:

--- a/sdlf-team/template.yaml
+++ b/sdlf-team/template.yaml
@@ -93,7 +93,6 @@ Parameters:
     Default: ""
 
 Conditions:
-  CreateMultipleBuckets: !Not [!Equals [!Ref pCentralBucket, !Ref pAnalyticsBucket]]
   RunInVpc: !Equals [!Ref pEnableVpc, true]
 
 Globals:
@@ -382,20 +381,11 @@ Resources:
               - s3:PutObject
             Resource:
               - !Sub arn:${AWS::Partition}:s3:::${pArtifactsBucket}/${pTeamName}/*
-              - !If [
-                  CreateMultipleBuckets,
-                  !Sub "arn:${AWS::Partition}:s3:::${pCentralBucket}/${pTeamName}/*",
-                  !Sub "arn:${AWS::Partition}:s3:::${pCentralBucket}/raw/${pTeamName}/*",
-                ]
+              - !Sub arn:${AWS::Partition}:s3:::${pCentralBucket}/${pTeamName}/*
               - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/${pTeamName}/*
               - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/pre-stage/${pTeamName}/*
-              - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/stage/${pTeamName}/*
               - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/post-stage/${pTeamName}/*
-              - !If [
-                  CreateMultipleBuckets,
-                  !Sub "arn:${AWS::Partition}:s3:::${pAnalyticsBucket}/${pTeamName}/*",
-                  !Sub "arn:${AWS::Partition}:s3:::${pAnalyticsBucket}/analytics/${pTeamName}/*",
-                ]
+              - !Sub arn:${AWS::Partition}:s3:::${pAnalyticsBucket}/${pTeamName}/*
           - Sid: AllowFullCodeCommitOnTeamRepositories
             Effect: Allow
             Action:
@@ -610,13 +600,10 @@ Resources:
                   - s3:PutObjectVersion
                 Resource:
                   - !Sub arn:${AWS::Partition}:s3:::${pCentralBucket}/${pTeamName}/*
-                  - !Sub arn:${AWS::Partition}:s3:::${pCentralBucket}/raw/${pTeamName}/*
                   - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/${pTeamName}/*
-                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/stage/${pTeamName}/*
                   - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/pre-stage/${pTeamName}/*
                   - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/post-stage/${pTeamName}/*
                   - !Sub arn:${AWS::Partition}:s3:::${pAnalyticsBucket}/${pTeamName}/*
-                  - !Sub arn:${AWS::Partition}:s3:::${pAnalyticsBucket}/analytics/${pTeamName}/*
               - Effect: Allow
                 Action:
                   - kms:DescribeKey
@@ -928,12 +915,7 @@ Resources:
         - DATA_LOCATION_ACCESS
       Resource:
         DataLocationResource:
-          S3Resource:
-            !If [
-              CreateMultipleBuckets,
-              !Sub "arn:${AWS::Partition}:s3:::${pCentralBucket}/${pTeamName}/",
-              !Sub "arn:${AWS::Partition}:s3:::${pCentralBucket}/raw/${pTeamName}/",
-            ]
+          S3Resource: !Sub arn:${AWS::Partition}:s3:::${pCentralBucket}/${pTeamName}/
 
   rStagePreTeamLakeFormationPermissions:
     Type: AWS::LakeFormation::Permissions
@@ -944,12 +926,7 @@ Resources:
         - DATA_LOCATION_ACCESS
       Resource:
         DataLocationResource:
-          S3Resource:
-            !If [
-              CreateMultipleBuckets,
-              !Sub "arn:${AWS::Partition}:s3:::${pStageBucket}/pre-stage/${pTeamName}/",
-              !Sub "arn:${AWS::Partition}:s3:::${pCentralBucket}/pre-stage/${pTeamName}/",
-            ]
+          S3Resource: !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/pre-stage/${pTeamName}/
 
   rStagePostTeamLakeFormationPermissions:
     Type: AWS::LakeFormation::Permissions
@@ -960,12 +937,7 @@ Resources:
         - DATA_LOCATION_ACCESS
       Resource:
         DataLocationResource:
-          S3Resource:
-            !If [
-              CreateMultipleBuckets,
-              !Sub "arn:${AWS::Partition}:s3:::${pStageBucket}/post-stage/${pTeamName}/",
-              !Sub "arn:${AWS::Partition}:s3:::${pCentralBucket}/post-stage/${pTeamName}/",
-            ]
+          S3Resource: !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/post-stage/${pTeamName}/
 
   rAnalyticsTeamLakeFormationPermissions:
     Type: AWS::LakeFormation::Permissions
@@ -976,12 +948,7 @@ Resources:
         - DATA_LOCATION_ACCESS
       Resource:
         DataLocationResource:
-          S3Resource:
-            !If [
-              CreateMultipleBuckets,
-              !Sub "arn:${AWS::Partition}:s3:::${pAnalyticsBucket}/${pTeamName}/",
-              !Sub "arn:${AWS::Partition}:s3:::${pCentralBucket}/analytics/${pTeamName}/",
-            ]
+          S3Resource: !Sub arn:${AWS::Partition}:s3:::${pAnalyticsBucket}/${pTeamName}/
 
   rTeamLakeFormationTag:
     Type: AWS::LakeFormation::Tag

--- a/sdlf-utils/workshop-examples/10-deployment/sdlf-main/foundations-datalake-dev.yaml
+++ b/sdlf-utils/workshop-examples/10-deployment/sdlf-main/foundations-datalake-dev.yaml
@@ -15,4 +15,3 @@ Resources:
             pOrg: forecourt
             pDomain: datalake
             pEnvironment: dev
-            pNumBuckets: 3

--- a/sdlf-utils/workshop-examples/20-production/sdlf-main/foundations-marketing-dev.yaml
+++ b/sdlf-utils/workshop-examples/20-production/sdlf-main/foundations-marketing-dev.yaml
@@ -15,4 +15,3 @@ Resources:
             pOrg: forecourt
             pDomain: marketing
             pEnvironment: dev
-            pNumBuckets: 3

--- a/sdlf-utils/workshop-examples/20-production/sdlf-main/foundations-proserve-dev.yaml
+++ b/sdlf-utils/workshop-examples/20-production/sdlf-main/foundations-proserve-dev.yaml
@@ -15,4 +15,3 @@ Resources:
             pOrg: forecourt
             pDomain: proserve
             pEnvironment: dev
-            pNumBuckets: 3


### PR DESCRIPTION
*Description of changes:*
Historically SDLF supported two bucket setups:
- a single bucket for the three layers raw/stage/analytics
- one bucket per layer raw/stage/analytics

The three-bucket setup (`pNumBuckets` set to 3) has always been preferred not only in the workshop, but in customer engagements and aws documentation as well (see for example https://aws.amazon.com/blogs/big-data/design-a-data-mesh-architecture-using-aws-lake-formation-and-aws-glue/)

I'm removing the single-bucket setup as this is not best practice - and truth be told, it is not currently functional in SDLF 2.x anyway!

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.