### PR TITLE
remove unused pEntryPoint parameter in stages

### DIFF
--- a/sdlf-stage-dataquality/template.yaml
+++ b/sdlf-stage-dataquality/template.yaml
@@ -31,10 +31,6 @@ Parameters:
     Description: Name of the stage (all lowercase, hyphen allowed, no other symbols or spaces)
     Type: String
     AllowedPattern: "[a-zA-Z0-9\\-]{1,12}"
-  pEntryPoint:
-    Description: Whether the stage is the first stage of the pipeline.
-    Type: String
-    Default: false
   pTriggerType:
     Description: Trigger type of the stage (event or schedule)
     Type: String
@@ -121,7 +117,6 @@ Resources:
       pTeamName: !Ref pTeamName
       pPipelineName: !Ref pPipeline
       pStageName: !Ref pStageName
-      pEntryPoint: !Ref pEntryPoint
       pTriggerType: !Ref pTriggerType
       pSchedule: !Ref pSchedule
       pEventPattern: !Ref pEventPattern

--- a/sdlf-stageA/template.yaml
+++ b/sdlf-stageA/template.yaml
@@ -39,10 +39,6 @@ Parameters:
     Description: Name of the stage (all lowercase, hyphen allowed, no other symbols or spaces)
     Type: String
     AllowedPattern: "[a-zA-Z0-9\\-]{1,12}"
-  pEntryPoint:
-    Description: Whether the stage is the first stage of the pipeline.
-    Type: String
-    Default: false
   pTriggerType:
     Description: Trigger type of the stage (event or schedule)
     Type: String
@@ -143,7 +139,6 @@ Resources:
       pTeamName: !Ref pTeamName
       pPipelineName: !Ref pPipeline
       pStageName: !Ref pStageName
-      pEntryPoint: !Ref pEntryPoint
       pTriggerType: !Ref pTriggerType
       pSchedule: !Ref pSchedule
       pEventPattern: !Ref pEventPattern

--- a/sdlf-stageB/template.yaml
+++ b/sdlf-stageB/template.yaml
@@ -35,10 +35,6 @@ Parameters:
     Description: Name of the stage (all lowercase, hyphen allowed, no other symbols or spaces)
     Type: String
     AllowedPattern: "[a-zA-Z0-9\\-]{1,12}"
-  pEntryPoint:
-    Description: Whether the stage is the first stage of the pipeline.
-    Type: String
-    Default: false
   pTriggerType:
     Description: Trigger type of the stage (event or schedule)
     Type: String
@@ -138,7 +134,6 @@ Resources:
       pTeamName: !Ref pTeamName
       pPipelineName: !Ref pPipeline
       pStageName: !Ref pStageName
-      pEntryPoint: !Ref pEntryPoint
       pTriggerType: !Ref pTriggerType
       pSchedule: !Ref pSchedule
       pEventPattern: !Ref pEventPattern


### PR DESCRIPTION
*Description of changes:*
`pEntryPoint` is a leftover from previous designs for integrating EventBridge into SDLF pipelines. It is not used at all these days.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
