### PR TITLE
add flags for optional features to deploy.sh multi-account deployment

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -233,6 +233,9 @@ devops_account () {
     rm -Rf "$DIRNAME"/output
 
     declare -a REPOSITORIES=("sdlf-cicd" "sdlf-foundations" "sdlf-team" "sdlf-pipeline" "sdlf-dataset" "sdlf-datalakeLibrary" "sdlf-stageA" "sdlf-stageB" "sdlf-main")
+    if [ "$MONITORING" = "true" ]; then
+        REPOSITORIES+=("sdlf-monitoring")
+    fi
     for REPOSITORY in "${REPOSITORIES[@]}"
     do
         latest_commit=$(aws --region "$REGION" --profile "$DEVOPS_AWS_PROFILE" codecommit get-branch --repository-name "$REPOSITORY" --branch-name main --query "branch.commitId" --output text)

--- a/sdlf-cicd/template-cicd-domain-roles.yaml
+++ b/sdlf-cicd/template-cicd-domain-roles.yaml
@@ -17,12 +17,12 @@ Parameters:
     Description: S3 Bucket Prefix if different from default. Must be a valid S3 Bucket name
     Type: String
     Default: sdlf
-  pEnableVpc:
-    Description: Deploy SDLF resources in a VPC
-    Type: String
-    Default: false
   pEnableMonitoring:
     Description: Build sdlf-monitoring cloudformation module as part of domain pipelines
+    Type: String
+    Default: false
+  pEnableVpc:
+    Description: Deploy SDLF resources in a VPC
     Type: String
     Default: false
 

--- a/sdlf-cicd/template-cicd-prerequisites.yaml
+++ b/sdlf-cicd/template-cicd-prerequisites.yaml
@@ -13,6 +13,18 @@ Parameters:
     Description: Deploy SDLF resources in a VPC
     Type: String
     Default: false
+  pEnableLambdaLayerBuilder:
+    Description: Enable Build Lambda Layers optional feature
+    Type: String
+    Default: false
+  pEnableGlueJobDeployer:
+    Description: Enable Glue Job Deployer optional feature
+    Type: String
+    Default: false
+  pEnableMonitoring:
+    Description: Enable Monitoring optional feature
+    Type: String
+    Default: false
 
 Conditions:
   UseCustomBucketPrefix: !Not [!Equals [!Ref pCustomBucketPrefix, sdlf]]
@@ -38,7 +50,7 @@ Resources:
     Properties:
       Name: /SDLF/LambdaLayerBuilder/Enabled
       Type: String
-      Value: false
+      Value: !Ref pEnableLambdaLayerBuilder
       Description: Add Lambda layer builder infrastructure and pipeline stages
 
   rGlueJobDeployerFeatureSsm:
@@ -46,7 +58,7 @@ Resources:
     Properties:
       Name: /SDLF/GlueJobDeployer/Enabled
       Type: String
-      Value: false
+      Value: !Ref pEnableGlueJobDeployer
       Description: Add Glue job deployer infrastructure and pipeline stages
 
   rMonitoringFeatureSsm:
@@ -54,7 +66,7 @@ Resources:
     Properties:
       Name: /SDLF/Monitoring/Enabled
       Type: String
-      Value: false
+      Value: !Ref pEnableMonitoring
       Description: Build sdlf-monitoring cloudformation module as part of domain pipelines
 
   ######## KMS #########

--- a/sdlf-cicd/template-cicd-prerequisites.yaml
+++ b/sdlf-cicd/template-cicd-prerequisites.yaml
@@ -9,20 +9,20 @@ Parameters:
   pDomainAccounts:
     Description: List of AWS account ids bootstrapped with SDLF domain roles
     Type: CommaDelimitedList
-  pEnableVpc:
-    Description: Deploy SDLF resources in a VPC
+  pEnableGlueJobDeployer:
+    Description: Enable Glue Job Deployer optional feature
     Type: String
     Default: false
   pEnableLambdaLayerBuilder:
     Description: Enable Build Lambda Layers optional feature
     Type: String
     Default: false
-  pEnableGlueJobDeployer:
-    Description: Enable Glue Job Deployer optional feature
-    Type: String
-    Default: false
   pEnableMonitoring:
     Description: Enable Monitoring optional feature
+    Type: String
+    Default: false
+  pEnableVpc:
+    Description: Deploy SDLF resources in a VPC
     Type: String
     Default: false
 
@@ -35,15 +35,13 @@ Conditions:
 
 Resources:
   ######## OPTIONAL SDLF FEATURES #########
-  # when enabling VPC support, /SDLF/VPC/VpcId, /SDLF/VPC/SecurityGroupIds and /SDLF/VPC/SubnetIds are required too (see Outputs section)
-  # both for the devops account and child accounts.
-  rVpcFeatureSsm:
+  rGlueJobDeployerFeatureSsm:
     Type: AWS::SSM::Parameter
     Properties:
-      Name: /SDLF/VPC/Enabled
+      Name: /SDLF/GlueJobDeployer/Enabled
       Type: String
-      Value: !Ref pEnableVpc
-      Description: Deploy SDLF resources in a VPC
+      Value: !Ref pEnableGlueJobDeployer
+      Description: Add Glue job deployer infrastructure and pipeline stages
 
   rBuildLambdaLayersFeatureSsm:
     Type: AWS::SSM::Parameter
@@ -53,14 +51,6 @@ Resources:
       Value: !Ref pEnableLambdaLayerBuilder
       Description: Add Lambda layer builder infrastructure and pipeline stages
 
-  rGlueJobDeployerFeatureSsm:
-    Type: AWS::SSM::Parameter
-    Properties:
-      Name: /SDLF/GlueJobDeployer/Enabled
-      Type: String
-      Value: !Ref pEnableGlueJobDeployer
-      Description: Add Glue job deployer infrastructure and pipeline stages
-
   rMonitoringFeatureSsm:
     Type: AWS::SSM::Parameter
     Properties:
@@ -68,6 +58,16 @@ Resources:
       Type: String
       Value: !Ref pEnableMonitoring
       Description: Build sdlf-monitoring cloudformation module as part of domain pipelines
+
+  # when enabling VPC support, /SDLF/VPC/VpcId, /SDLF/VPC/SecurityGroupIds and /SDLF/VPC/SubnetIds are required too (see Outputs section)
+  # both for the devops account and child accounts.
+  rVpcFeatureSsm:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: /SDLF/VPC/Enabled
+      Type: String
+      Value: !Ref pEnableVpc
+      Description: Deploy SDLF resources in a VPC
 
   ######## KMS #########
   rKMSKey:


### PR DESCRIPTION
*Description of changes:*
When running the `crossaccount-cicd-roles` or `devops-account` commands from `deploy.sh`, the user can specify the following flags as `true` to deploy the respective optional features:

- GlueJobDeployer `-g`
- LambdaLayerBuilder `-l`
- Monitoring `-m`
- EnableVpc `-v`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
