### PR TITLE
parameterize team main repository prefix

### DIFF
--- a/sdlf-cicd/lambda/team-cicd/src/lambda_function.py
+++ b/sdlf-cicd/lambda/team-cicd/src/lambda_function.py
@@ -263,6 +263,7 @@ def lambda_handler(event, context):
         logger.info("ENVIRONMENT: %s", environment)
         partition = os.getenv("AWS_PARTITION")
         devops_kms_key = os.getenv("DEVOPS_KMS_KEY")
+        main_repository_prefix = os.getenv("MAIN_REPOSITORY_PREFIX")
         cloudformation_role = os.getenv("CLOUDFORMATION_ROLE")
 
         for artifact in event["CodePipeline.job"]["data"]["inputArtifacts"]:
@@ -428,7 +429,7 @@ def lambda_handler(event, context):
                 cloudformation_update_waiter.wait(StackName=stack, WaiterConfig={"Delay": 30, "MaxAttempts": 10})
 
             for team in domain_details["teams"]:
-                repository_name = f"sdlf-main-{domain}-{team}"
+                repository_name = f"{main_repository_prefix}-{domain}-{team}"
                 env_branches = ["dev", "test"]
                 for env_branch in env_branches:
                     try:

--- a/sdlf-cicd/template-cicd-sdlf-pipelines.yaml
+++ b/sdlf-cicd/template-cicd-sdlf-pipelines.yaml
@@ -16,6 +16,9 @@ Parameters:
   pMainRepository:
     Type: AWS::SSM::Parameter::Value<String>
     Default: /SDLF/CodeCommit/MainCodeCommit
+  pMainRepositoriesPrefix:
+    Type: String
+    Default: sdlf-main-
   pStagesRepositoriesPrefix:
     Type: String
     Default: sdlf-stage-
@@ -312,7 +315,7 @@ Resources:
                   - codecommit:CreateBranch
                 Effect: Allow
                 Resource:
-                  - !Sub arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-main-*
+                  - !Sub arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:${pMainRepositoriesPrefix}*
                 Sid: CodeCommitRead
               - Action:
                   - codecommit:CreateApprovalRuleTemplate # W11 exception
@@ -409,7 +412,7 @@ Resources:
                   - codecommit:PutRepositoryTriggers
                   - codecommit:CreateCommit
                 Resource:
-                  - !Sub arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-main-*
+                  - !Sub arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:${pMainRepositoriesPrefix}*
               - Effect: Allow  
                 Action:
                   - kms:Decrypt
@@ -569,6 +572,7 @@ Resources:
         Variables:
           AWS_PARTITION: !Ref AWS::Partition
           DEVOPS_KMS_KEY: !Ref pKMSKey
+          MAIN_REPOSITORY_PREFIX: !Ref pMainRepositoriesPrefix
           CLOUDFORMATION_ROLE: !GetAtt rMainRepositoryCloudFormationRole.Arn
       Code: ./lambda/team-cicd/src
 

--- a/sdlf-cicd/template-cicd-team-repository.yaml
+++ b/sdlf-cicd/template-cicd-team-repository.yaml
@@ -13,6 +13,9 @@ Parameters:
   pTeamName:
     Description: Team name
     Type: String
+  pMainRepositoriesPrefix:
+    Type: String
+    Default: sdlf-main-
 
 Resources:
   rTeamMainCodeCommit:
@@ -27,7 +30,7 @@ Resources:
         BranchName: main
         S3: ./README.md
       RepositoryDescription: !Sub ${pDomain} ${pTeamName} main repository
-      RepositoryName: !Sub sdlf-main-${pDomain}-${pTeamName}
+      RepositoryName: !Sub ${pMainRepositoriesPrefix}-${pDomain}-${pTeamName}
       KmsKeyId: !Ref pKMSKey
 
   rTeamMainCodeCommitSsm:


### PR DESCRIPTION
*Description of changes:*
Parameterize team main repository prefix. `sdlf-main-*` is still the default. This makes it easier to have a side-by-side installation of SDLF v1 and v2, amongst other things.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
