### PR TITLE
get dataschemas table name from ssm in replicate lambda

### DIFF
--- a/sdlf-foundations/lambda/replicate/src/lambda_function.py
+++ b/sdlf-foundations/lambda/replicate/src/lambda_function.py
@@ -15,7 +15,7 @@ ssm_endpoint_url = "https://ssm." + os.getenv("AWS_REGION") + ".amazonaws.com"
 ssm = boto3.client("ssm", endpoint_url=ssm_endpoint_url)
 lf_endpoint_url = "https://lakeformation." + os.getenv("AWS_REGION") + ".amazonaws.com"
 lf = boto3.client("lakeformation", endpoint_url=lf_endpoint_url)
-schemas_table = "octagon-DataSchemas-{}".format(os.getenv("ENV"))
+schemas_table = ssm.get_parameter(Name="/SDLF/Dynamo/DataSchemas")["Parameter"]["Value"]
 
 
 def get_current_time():

--- a/sdlf-foundations/template.yaml
+++ b/sdlf-foundations/template.yaml
@@ -141,7 +141,9 @@ Resources:
                 Action:
                   - ssm:GetParameter
                   - ssm:GetParameters
-                Resource: !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/IAM/DataLakeAdminRoleArn
+                Resource:
+                  - !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/IAM/DataLakeAdminRoleArn
+                  - !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/Dynamo/DataSchemas
 
   ######## LAKE FORMATION #########
   rDataLakeSettings:


### PR DESCRIPTION
*Description of changes:*
Avoid using a hardcoded name for the DataSchemas table.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
