### PR TITLE
restrict sdlf-catalog lambda to its dedicated sqs queues

### DIFF
--- a/sdlf-foundations/template.yaml
+++ b/sdlf-foundations/template.yaml
@@ -841,7 +841,8 @@ Resources:
                   - sqs:SendMessage
                   - sqs:SendMessageBatch
                 Resource:
-                  - !Sub arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:sdlf-*
+                  - !GetAtt rQueueCatalog.Arn
+                  - !GetAtt rDeadLetterQueueCatalog.Arn
               - Effect: Allow
                 Action:
                   - dynamodb:BatchGetItem


### PR DESCRIPTION
*Description of changes:*
restrict sdlf-catalog lambda to its dedicated sqs queues

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
