### PR TITLE
use RetainExceptOnCreate deletion policy for KMS keys and aliases

### DIFF
--- a/sdlf-cicd/template-cicd-prerequisites.yaml
+++ b/sdlf-cicd/template-cicd-prerequisites.yaml
@@ -61,7 +61,7 @@ Resources:
   rKMSKey:
     Type: AWS::KMS::Key
     UpdateReplacePolicy: Retain
-    DeletionPolicy: Retain
+    DeletionPolicy: RetainExceptOnCreate
     Metadata:
       cfn-lint:
         config:
@@ -199,7 +199,7 @@ Resources:
   rKMSKeyAlias:
     Type: AWS::KMS::Alias
     UpdateReplacePolicy: Retain
-    DeletionPolicy: Retain
+    DeletionPolicy: RetainExceptOnCreate
     Properties:
       AliasName: alias/sdlf-cicd-kms-key
       TargetKeyId: !Ref rKMSKey

--- a/sdlf-foundations/template.yaml
+++ b/sdlf-foundations/template.yaml
@@ -185,7 +185,7 @@ Resources:
   ######## KMS #########
   rKMSKey:
     Type: AWS::KMS::Key
-    DeletionPolicy: Retain
+    DeletionPolicy: RetainExceptOnCreate
     UpdateReplacePolicy: Retain
     Metadata:
       cfn_nag:
@@ -296,7 +296,7 @@ Resources:
   rKMSKeyAlias:
     Type: AWS::KMS::Alias
     UpdateReplacePolicy: Retain
-    DeletionPolicy: Retain
+    DeletionPolicy: RetainExceptOnCreate
     Properties:
       AliasName: alias/sdlf-kms-key
       TargetKeyId: !Ref rKMSKey

--- a/sdlf-team/template.yaml
+++ b/sdlf-team/template.yaml
@@ -111,7 +111,7 @@ Resources:
   rKMSInfraKey:
     Type: AWS::KMS::Key
     UpdateReplacePolicy: Retain
-    DeletionPolicy: Retain
+    DeletionPolicy: RetainExceptOnCreate
     Metadata:
       cfn_nag:
         rules_to_suppress:
@@ -169,7 +169,7 @@ Resources:
   rKMSInfraKeyAlias:
     Type: AWS::KMS::Alias
     UpdateReplacePolicy: Retain
-    DeletionPolicy: Retain
+    DeletionPolicy: RetainExceptOnCreate
     Properties:
       AliasName: !Sub alias/sdlf-${pTeamName}-kms-infra-key
       TargetKeyId: !Ref rKMSInfraKey
@@ -177,7 +177,7 @@ Resources:
   rKMSDataKey:
     Type: AWS::KMS::Key
     UpdateReplacePolicy: Retain
-    DeletionPolicy: Retain
+    DeletionPolicy: RetainExceptOnCreate
     Properties:
       Description: !Sub SDLF ${pTeamName} Data KMS Key
       EnableKeyRotation: True
@@ -206,7 +206,7 @@ Resources:
   rKMSDataKeyAlias:
     Type: AWS::KMS::Alias
     UpdateReplacePolicy: Retain
-    DeletionPolicy: Retain
+    DeletionPolicy: RetainExceptOnCreate
     Properties:
       AliasName: !Sub alias/sdlf-${pTeamName}-kms-data-key
       TargetKeyId: !Ref rKMSDataKey


### PR DESCRIPTION
*Description of changes:*
https://aws.amazon.com/about-aws/whats-new/2023/07/aws-cloudformation-deletion-policies-dev-test-cycle/

This makes it much easier to work on SDLF when making updates to foundations and team in particular.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
