### PR TITLE
stageA/stageB: replace hardcoded suffix -a/-b with stage name

### DIFF
--- a/sdlf-stageA/template.yaml
+++ b/sdlf-stageA/template.yaml
@@ -441,7 +441,7 @@ Resources:
             reason: Permissions to write CloudWatch Logs are granted by rLambdaCommonPolicy
     Properties:
       CodeUri: ./lambda/stage-a-redrive/src
-      FunctionName: !Sub sdlf-${pTeamName}-${pPipeline}-redrive-a
+      FunctionName: !Sub sdlf-${pTeamName}-${pPipeline}-redrive-${pStageName}
       Environment:
         Variables:
           TEAM: !Ref pTeamName
@@ -461,7 +461,7 @@ Resources:
             reason: Permissions to write CloudWatch Logs are granted by rLambdaCommonPolicy
     Properties:
       CodeUri: ./lambda/stage-a-preupdate-metadata/src
-      FunctionName: !Sub sdlf-${pTeamName}-${pPipeline}-preupdate-a
+      FunctionName: !Sub sdlf-${pTeamName}-${pPipeline}-preupdate-${pStageName}
       Description: Pre-Update the metadata in the DynamoDB Catalog table
       Environment:
         Variables:
@@ -479,7 +479,7 @@ Resources:
             reason: Permissions to write CloudWatch Logs are granted by rLambdaCommonPolicy
     Properties:
       CodeUri: ./lambda/stage-a-process-object/src
-      FunctionName: !Sub sdlf-${pTeamName}-${pPipeline}-process-a
+      FunctionName: !Sub sdlf-${pTeamName}-${pPipeline}-process-${pStageName}
       Description: Processing pipeline
       MemorySize: 1536
       Timeout: 600
@@ -494,7 +494,7 @@ Resources:
             reason: Permissions to write CloudWatch Logs are granted by rLambdaCommonPolicy
     Properties:
       CodeUri: ./lambda/stage-a-postupdate-metadata/src
-      FunctionName: !Sub sdlf-${pTeamName}-${pPipeline}-postupdate-a
+      FunctionName: !Sub sdlf-${pTeamName}-${pPipeline}-postupdate-${pStageName}
       Description: Post-Update the metadata in the DynamoDB Catalog table
       MemorySize: 256
       Timeout: 300
@@ -509,7 +509,7 @@ Resources:
             reason: Permissions to write CloudWatch Logs are granted by rLambdaCommonPolicy
     Properties:
       CodeUri: ./lambda/stage-a-error/src
-      FunctionName: !Sub sdlf-${pTeamName}-${pPipeline}-error-a
+      FunctionName: !Sub sdlf-${pTeamName}-${pPipeline}-error-${pStageName}
       Description: Fallback lambda to handle messages which failed processing
       MemorySize: 256
       Timeout: 300
@@ -702,7 +702,7 @@ Resources:
   rStateMachine:
     Type: AWS::Serverless::StateMachine
     Properties:
-      Name: !Sub sdlf-${pTeamName}-${pPipeline}-sm-a
+      Name: !Sub sdlf-${pTeamName}-${pPipeline}-sm-${pStageName}
       DefinitionUri: ./state-machine/stage-a.asl.json
       DefinitionSubstitutions:
         lStep1: !GetAtt rLambdaStep1.Arn

--- a/sdlf-stageB/template.yaml
+++ b/sdlf-stageB/template.yaml
@@ -377,7 +377,7 @@ Resources:
             reason: Permissions to write CloudWatch Logs are granted by rLambdaCommonPolicy
     Properties:
       CodeUri: ./lambda/stage-b-fetch-metadata/src
-      FunctionName: !Sub sdlf-${pTeamName}-${pPipeline}-fetch-metadata-b
+      FunctionName: !Sub sdlf-${pTeamName}-${pPipeline}-fetch-metadata-${pStageName}
       Description: Fetches transform metadata from DynamoDB
       MemorySize: 128
       Timeout: 300
@@ -392,7 +392,7 @@ Resources:
             reason: Permissions to write CloudWatch Logs are granted by rLambdaCommonPolicy
     Properties:
       CodeUri: ./lambda/stage-b-postupdate-metadata/src
-      FunctionName: !Sub sdlf-${pTeamName}-${pPipeline}-postupdate-b
+      FunctionName: !Sub sdlf-${pTeamName}-${pPipeline}-postupdate-${pStageName}
       Description: Post-Update the metadata in the DynamoDB Catalog table
       MemorySize: 512
       Timeout: 600
@@ -407,7 +407,7 @@ Resources:
             reason: Permissions to write CloudWatch Logs are granted by rLambdaCommonPolicy
     Properties:
       CodeUri: ./lambda/stage-b-error/src
-      FunctionName: !Sub sdlf-${pTeamName}-${pPipeline}-error-b
+      FunctionName: !Sub sdlf-${pTeamName}-${pPipeline}-error-${pStageName}
       Description: Fallback lambda to handle messages which failed processing
       MemorySize: 256
       Timeout: 300
@@ -596,7 +596,7 @@ Resources:
   rStateMachine:
     Type: AWS::Serverless::StateMachine
     Properties:
-      Name: !Sub sdlf-${pTeamName}-${pPipeline}-sm-b
+      Name: !Sub sdlf-${pTeamName}-${pPipeline}-sm-${pStageName}
       DefinitionUri: ./state-machine/stage-b.asl.json
       DefinitionSubstitutions:
         lStep1: !GetAtt rLambdaStep1.Arn


### PR DESCRIPTION
*Description of changes:*
Use the stage name instead of a hardcoded `-a` or `-b` to name some of the Lambda functions/state machines in stage A and B. This was already done for some of them so this is a matter of consistency.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
