### PR TITLE
Glue security config SSM

### DIFF
--- a/sdlf-dataset/template.yaml
+++ b/sdlf-dataset/template.yaml
@@ -73,7 +73,7 @@ Resources:
     Type: AWS::Glue::Crawler
     Properties:
       Role: !Sub "{{resolve:ssm:/SDLF/IAM/${pTeamName}/CrawlerRoleArn}}"
-      CrawlerSecurityConfiguration: !Sub sdlf-${pTeamName}-glue-security-config
+      CrawlerSecurityConfiguration: !Sub "{{resolve:ssm:/SDLF2/Glue/${pTeamName}/SecurityConfigurationId}}"
       DatabaseName: !Ref rGlueDataCatalog
       Name: !Sub sdlf-${pTeamName}-${pDatasetName}-post-stage-crawler
       Targets:

--- a/sdlf-utils/workshop-examples/legislators/scripts/legislators-glue-job.yaml
+++ b/sdlf-utils/workshop-examples/legislators/scripts/legislators-glue-job.yaml
@@ -80,5 +80,5 @@ Resources:
       MaxCapacity: 2.0
       GlueVersion: "4.0"
       Name: !Sub sdlf-${pTeamName}-${pDatasetName}-glue-job
-      SecurityConfiguration: !Sub sdlf-${pTeamName}-glue-security-config
+      SecurityConfiguration: !Sub "{{resolve:ssm:/SDLF2/Glue/${pTeamName}/SecurityConfigurationId:1}}"
       Role: !Ref rGlueRole


### PR DESCRIPTION
*Description of changes:*
Use SSM parameter to retrieve the Glue security config to use for Glue jobs and crawlers, instead of rebuilding it manually.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
