### PR TITLE
remove bogus SQS DeleteMessageBatch/SendMessageBatch permissions

### DIFF
--- a/sdlf-cicd/template-cicd-domain-roles.yaml
+++ b/sdlf-cicd/template-cicd-domain-roles.yaml
@@ -548,7 +548,6 @@ Resources:
                   - sqs:ListQueueTags
                   - sqs:RemovePermission
                   - sqs:SendMessage
-                  - sqs:SendMessageBatch
                   - sqs:SetQueueAttributes
                   - sqs:TagQueue
                   - sqs:UntagQueue

--- a/sdlf-foundations/template.yaml
+++ b/sdlf-foundations/template.yaml
@@ -831,7 +831,6 @@ Resources:
               - Effect: Allow
                 Action:
                   - sqs:DeleteMessage
-                  - sqs:DeleteMessageBatch
                   - sqs:GetQueueAttributes
                   - sqs:GetQueueUrl
                   - sqs:ListQueues
@@ -839,7 +838,6 @@ Resources:
                   - sqs:ListQueueTags
                   - sqs:ReceiveMessage
                   - sqs:SendMessage
-                  - sqs:SendMessageBatch
                 Resource:
                   - !GetAtt rQueueCatalog.Arn
                   - !GetAtt rDeadLetterQueueCatalog.Arn

--- a/sdlf-stage-dataquality/template.yaml
+++ b/sdlf-stage-dataquality/template.yaml
@@ -200,7 +200,6 @@ Resources:
               - Effect: Allow
                 Action:
                   - sqs:DeleteMessage
-                  - sqs:DeleteMessageBatch
                   - sqs:GetQueueAttributes
                   - sqs:GetQueueUrl
                   - sqs:ListQueues
@@ -208,7 +207,6 @@ Resources:
                   - sqs:ListQueueTags
                   - sqs:ReceiveMessage
                   - sqs:SendMessage
-                  - sqs:SendMessageBatch
                 Resource:
                   - !Sub arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
 

--- a/sdlf-stageA/template.yaml
+++ b/sdlf-stageA/template.yaml
@@ -221,7 +221,6 @@ Resources:
               - Effect: Allow
                 Action:
                   - sqs:DeleteMessage
-                  - sqs:DeleteMessageBatch
                   - sqs:GetQueueAttributes
                   - sqs:GetQueueUrl
                   - sqs:ListQueues
@@ -229,7 +228,6 @@ Resources:
                   - sqs:ListQueueTags
                   - sqs:ReceiveMessage
                   - sqs:SendMessage
-                  - sqs:SendMessageBatch
                 Resource:
                   - !GetAtt rPipelineInterfacerQueueRoutingStep.Arn
                   - !GetAtt rPipelineInterfacerDeadLetterQueueRoutingStep.Arn
@@ -349,7 +347,6 @@ Resources:
               - Effect: Allow
                 Action:
                   - sqs:DeleteMessage
-                  - sqs:DeleteMessageBatch
                   - sqs:GetQueueAttributes
                   - sqs:GetQueueUrl
                   - sqs:ListQueues
@@ -357,7 +354,6 @@ Resources:
                   - sqs:ListQueueTags
                   - sqs:ReceiveMessage
                   - sqs:SendMessage
-                  - sqs:SendMessageBatch
                 Resource:
                   - !GetAtt rPipelineInterfacerDeadLetterQueueRoutingStep.Arn
 

--- a/sdlf-stageB/template.yaml
+++ b/sdlf-stageB/template.yaml
@@ -217,7 +217,6 @@ Resources:
               - Effect: Allow
                 Action:
                   - sqs:DeleteMessage
-                  - sqs:DeleteMessageBatch
                   - sqs:GetQueueAttributes
                   - sqs:GetQueueUrl
                   - sqs:ListQueues
@@ -225,7 +224,6 @@ Resources:
                   - sqs:ListQueueTags
                   - sqs:ReceiveMessage
                   - sqs:SendMessage
-                  - sqs:SendMessageBatch
                 Resource:
                   - !Sub arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
 
@@ -293,7 +291,6 @@ Resources:
               - Effect: Allow
                 Action:
                   - sqs:DeleteMessage
-                  - sqs:DeleteMessageBatch
                   - sqs:GetQueueAttributes
                   - sqs:GetQueueUrl
                   - sqs:ListQueues
@@ -301,7 +298,6 @@ Resources:
                   - sqs:ListQueueTags
                   - sqs:ReceiveMessage
                   - sqs:SendMessage
-                  - sqs:SendMessageBatch
                 Resource:
                   - !Sub arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
 

--- a/sdlf-team/template.yaml
+++ b/sdlf-team/template.yaml
@@ -451,7 +451,6 @@ Resources:
             Effect: Allow
             Action:
               - sqs:DeleteMessage
-              - sqs:DeleteMessageBatch
               - sqs:GetQueueAttributes
               - sqs:GetQueueUrl
               - sqs:ListQueues
@@ -459,7 +458,6 @@ Resources:
               - sqs:ListQueueTags
               - sqs:ReceiveMessage
               - sqs:SendMessage
-              - sqs:SendMessageBatch
             Resource:
               - !Sub arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
           - Effect: Allow


### PR DESCRIPTION
*Issue #, if available:*
#287 

*Description of changes:*
Remove bogus SQS `DeleteMessageBatch`/`SendMessageBatch` permissions. These IAM permissions do not actually exist - batch is covered by `DeleteMessage`/`SendMessage`

https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-api-permissions-reference.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
