### PR TITLE
Enforce TLS on devops S3 access logs bucket

### DIFF
--- a/sdlf-cicd/template-cicd-prerequisites.yaml
+++ b/sdlf-cicd/template-cicd-prerequisites.yaml
@@ -289,6 +289,16 @@ Resources:
                   ]
               StringEquals:
                 "aws:SourceAccount": !Sub ${AWS::AccountId}
+          - Sid: AllowSSLRequestsOnly
+            Action: s3:*
+            Effect: Deny
+            Resource:
+              - !Sub arn:${AWS::Partition}:s3:::${rS3AccessLogsBucket}/*
+              - !Sub arn:${AWS::Partition}:s3:::${rS3AccessLogsBucket}
+            Condition:
+              Bool:
+                aws:SecureTransport: False
+            Principal: "*"
 
   rArtifactsBucket:
     Type: AWS::S3::Bucket
@@ -336,18 +346,16 @@ Resources:
       Bucket: !Ref rArtifactsBucket
       PolicyDocument:
         Statement:
-          - Sid: EnforceTlsRequests
-            Effect: Deny
-            Principal: "*"
+          - Sid: AllowSSLRequestsOnly
             Action: s3:*
+            Effect: Deny
             Resource:
-              - !GetAtt rArtifactsBucket.Arn
-              - !Sub ${rArtifactsBucket.Arn}/*
+              - !Sub arn:${AWS::Partition}:s3:::${rArtifactsBucket}/*
+              - !Sub arn:${AWS::Partition}:s3:::${rArtifactsBucket}
             Condition:
               Bool:
                 aws:SecureTransport: False
-              NumericLessThan:
-                s3:TlsVersion: "1.2"
+            Principal: "*"
           - Sid: CrossAccount Pipelines
             Effect: Allow
             Principal: !If

--- a/sdlf-foundations/template.yaml
+++ b/sdlf-foundations/template.yaml
@@ -370,7 +370,7 @@ Resources:
     Properties:
       Bucket: !Ref rS3AccessLogsBucket
       PolicyDocument:
-        Version: 2012-10-17
+        Version: "2012-10-17"
         Statement:
           - Action:
               - s3:PutObject
@@ -470,7 +470,7 @@ Resources:
     Properties:
       Bucket: !Ref rArtifactsBucket
       PolicyDocument:
-        Version: 2012-10-17
+        Version: "2012-10-17"
         Statement:
           - Sid: AllowSSLRequestsOnly
             Action: s3:*
@@ -522,7 +522,7 @@ Resources:
     Properties:
       Bucket: !Ref rRawBucket
       PolicyDocument:
-        Version: 2012-10-17
+        Version: "2012-10-17"
         Statement:
           - Sid: AllowSSLRequestsOnly
             Action: s3:*
@@ -581,7 +581,7 @@ Resources:
     Properties:
       Bucket: !Ref rStageBucket
       PolicyDocument:
-        Version: 2012-10-17
+        Version: "2012-10-17"
         Statement:
           - Sid: AllowSSLRequestsOnly
             Action: s3:*
@@ -640,7 +640,7 @@ Resources:
     Properties:
       Bucket: !Ref rAnalyticsBucket
       PolicyDocument:
-        Version: 2012-10-17
+        Version: "2012-10-17"
         Statement:
           - Sid: AllowSSLRequestsOnly
             Action: s3:*
@@ -693,7 +693,7 @@ Resources:
     Properties:
       Bucket: !Ref rAthenaBucket
       PolicyDocument:
-        Version: 2012-10-17
+        Version: "2012-10-17"
         Statement:
           - Sid: AllowSSLRequestsOnly
             Action: s3:*
@@ -778,7 +778,7 @@ Resources:
     Type: AWS::SQS::QueuePolicy
     Properties:
       PolicyDocument:
-        Version: 2012-10-17
+        Version: "2012-10-17"
         Statement:
           - Effect: Allow
             Principal:


### PR DESCRIPTION
*Description of changes:*
- Enforce TLS on devops s3 access logs bucket
- Update bucket policy for devops artifacts bucket to use a statement similar to the other buckets to enforce TLS. This makes it easier to review.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
