### PR TITLE
Glue Job Deployer: use /service-role/ path for role

### DIFF
--- a/sdlf-cicd/template-cicd-domain-team-role.yaml
+++ b/sdlf-cicd/template-cicd-domain-team-role.yaml
@@ -482,10 +482,34 @@ Resources:
               - !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/VPC/*
           - Effect: Allow
             Action:
+              - iam:CreateRole
+              - iam:PutRolePermissionsBoundary
+            Resource:
+              - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/service-role/sdlf-${pTeamName}-* # Glue Jobs always prepend /service-role/ as path
+            Condition:
+              ArnLike:
+                "iam:PermissionsBoundary": !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:policy/sdlf/${pTeamName}/sdlf-domain-*
+          - Effect: Allow
+            Action:
+              - iam:DeleteRole
+              - iam:DeleteRolePolicy
+              - iam:GetRole
+              - iam:GetRolePolicy
+              - iam:ListRolePolicies
+              - iam:PutRolePolicy
+              - iam:UntagRole
+              - iam:UpdateRole
+              - iam:UpdateRoleDescription
+              - iam:TagRole
+              - iam:UpdateAssumeRolePolicy
+            Resource:
+              - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/service-role/sdlf-${pTeamName}-*
+          - Effect: Allow
+            Action:
               - iam:AttachRolePolicy
               - iam:DetachRolePolicy
             Resource:
-              - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/sdlf-${pTeamName}/sdlf-${pTeamName}-*
+              - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/service-role/sdlf-${pTeamName}-*
             Condition:
               ArnEquals:
                 "iam:PolicyARN":

--- a/sdlf-cicd/template-glue-job.yaml
+++ b/sdlf-cicd/template-glue-job.yaml
@@ -40,7 +40,7 @@ Resources:
   rGlueRole:
     Type: AWS::IAM::Role
     Properties:
-      Path: !Sub /sdlf-${pTeamName}/
+      Path: /service-role/
       PermissionsBoundary: !Sub "{{resolve:ssm:/SDLF/IAM/${pTeamName}/TeamPermissionsBoundary}}"
       AssumeRolePolicyDocument:
         Version: 2012-10-17
@@ -89,7 +89,7 @@ Resources:
         Description: "Network connected to the VPC data source"
         Name: !Sub sdlf-${pTeamName}-glue-conn
         PhysicalConnectionRequirements:
-          AvailabilityZone: us-east-1a # this is not taking into account at all, but the property needs to be present anyway
+          AvailabilityZone: us-east-1a # this is not taken into account at all, but the property needs to be present anyway
           SecurityGroupIdList: !Split [",", !ImportValue sdlf-cicd-domain-roles-vpc-security-groups]
           SubnetId: !Select
             - "1"

--- a/sdlf-stageB/lambda/stage-b-fetch-metadata/src/lambda_function.py
+++ b/sdlf-stageB/lambda/stage-b-fetch-metadata/src/lambda_function.py
@@ -13,10 +13,9 @@ def get_glue_transform_details(bucket, team, dataset, pipeline, stage):
     # we assume a Glue Job has already been created based on customer needs
     job_name = f"sdlf-{team}-{dataset}-glue-job"  # Name of the Glue Job
     glue_capacity = {"WorkerType": "G.1X", "NumberOfWorkers": 10}
-    wait_time = 45
+    wait_time = 60
     glue_arguments = {
         # Specify any arguments needed based on bucket and keys (e.g. input/output S3 locations)
-        "--JOB_NAME": f"sdlf-{team}-{dataset}-glue-job",
         "--SOURCE_LOCATION": f"s3://{bucket}/pre-stage/{team}/{dataset}",
         "--OUTPUT_LOCATION": f"s3://{bucket}/post-stage/{team}/{dataset}",
         "--job-bookmark-option": "job-bookmark-enable",

--- a/sdlf-team/template.yaml
+++ b/sdlf-team/template.yaml
@@ -508,6 +508,7 @@ Resources:
               - logs:DescribeLogStreams
               - logs:GetLogEvents
               - logs:PutLogEvents
+              - logs:AssociateKmsKey
             Resource:
               - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/sdlf-${pTeamName}-*
               - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/sdlf-${pTeamName}-*


### PR DESCRIPTION
*Issue #, if available:*
#312 

*Description of changes:*
Glue Job Deployer: use `/service-role/` path for role
Glue only specify the name, not the full ARN or the name+path, then appends `/service-role/` so service-role has to be used.

`--JOB_NAME` is no longer set. This is now documented as an "internal Glue argument":
https://docs.aws.amazon.com/glue/latest/dg/aws-glue-programming-etl-glue-arguments.html

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
