### PR TITLE
do not set MaxItems when paginating

### DIFF
--- a/sdlf-team/lambda/datasets-dynamodb/src/lambda_function.py
+++ b/sdlf-team/lambda/datasets-dynamodb/src/lambda_function.py
@@ -48,10 +48,7 @@ def lambda_handler(event, context):
         table = f"octagon-Datasets-{environment}"
 
         paginator = ssm.get_paginator("get_parameters_by_path")
-        datasets_pages = paginator.paginate(
-            Path=f"/SDLF/Datasets/{team_name}",
-            PaginationConfig={"MaxItems": 30},
-        )
+        datasets_pages = paginator.paginate(Path=f"/SDLF/Datasets/{team_name}")
 
         for datasets_page in datasets_pages:
             for dataset in datasets_page["Parameters"]:

--- a/sdlf-team/lambda/pipelines-dynamodb/src/lambda_function.py
+++ b/sdlf-team/lambda/pipelines-dynamodb/src/lambda_function.py
@@ -53,7 +53,6 @@ def lambda_handler(event, context):
         stages_pages = paginator.paginate(
             Path=f"/SDLF/Pipelines/{team_name}",
             Recursive=True,
-            PaginationConfig={"MaxItems": 30},
         )
         for stages_page in stages_pages:
             for stage in stages_page["Parameters"]:


### PR DESCRIPTION
*Description of changes:*
Do not set `MaxItems` when paginating. If there is more than 30 pipelines or datasets it is obviously fine!

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
