### PR TITLE
Glue Job Deployer: handle multiple Glue Job Connections, and their AZ

### DIFF
--- a/sdlf-cicd/nested-stacks/template-cicd-glue-job.yaml
+++ b/sdlf-cicd/nested-stacks/template-cicd-glue-job.yaml
@@ -106,6 +106,7 @@ Resources:
                   - ssm:GetParametersByPath
                 Resource:
                   - !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/S3/*
+                  - !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/VPC/SubnetIds
               - !If
                 - RunInVpc
                 - Effect: Allow
@@ -183,10 +184,13 @@ Resources:
             build:
               commands:
                 - |-
-                    ARTIFACTS_BUCKET=$(aws ssm get-parameter --name "/SDLF/S3/$DOMAIN/$ENVIRONMENT/ArtifactsBucket" --query "Parameter.Value" --output text) || exit 1
+                    SSM_ENDPOINT_URL="https://ssm.$AWS_REGION.amazonaws.com"
+                    EC2_ENDPOINT_URL="https://ec2.$AWS_REGION.amazonaws.com"
+                    ARTIFACTS_BUCKET=$(aws ssm --endpoint-url "$SSM_ENDPOINT_URL" get-parameter --name "/SDLF/S3/$DOMAIN/$ENVIRONMENT/ArtifactsBucket" --query "Parameter.Value" --output text) || exit 1
                     echo "Artifacts bucket to store Glue job scripts: $ARTIFACTS_BUCKET"
-                    if [ -d "./transforms/" ]; then
-                        cd "./transforms/" || exit
+                    if [ -d "./transforms/" ]
+                    then
+                        pushd "./transforms/" || exit
                         TRANSFORMS=()
 
                         echo ">>>>> Beginning build of subdirectories >>>>>"
@@ -214,7 +218,47 @@ Resources:
                         printf -v joined "%s," "${TRANSFORMS[@]}"
                         TRANSFORMS_CDL="${joined%,}"
                         echo "TRANSFORMS_CDL - $TRANSFORMS_CDL"
+
+                        # for each subnet defined in /SDLF/VPC/SubnetIds, find in which AZ it lives in, then add to the Cloudformation template
+                        # a Glue connection per subnet. Frankly we would prefer to avoid doing these kind of things.
+                        # it can be revisited when AvailabilityZone is no longer required in PhysicalConnectionRequirements
+                        SUBNETS_CDL=$(aws ssm --endpoint-url "$SSM_ENDPOINT_URL" get-parameter --name "/SDLF/VPC/SubnetIds" --query "Parameter.Value" --output text) || exit 1
+                        echo "Subnets provided: $SUBNETS_CDL"
+                        if [[ -n "$SUBNETS_CDL" ]]
+                        then
+                            # convert comma-delimited list to array
+                            IFS="," read -ra SUBNETS <<< "$SUBNETS_CDL"
+                            BUILDSTEPVARIABLE_GLUECONNECTIONS=""
+                            for i in "${!SUBNETS[@]}"
+                            do
+                                BUILDSTEPVARIABLE_AZ=$(aws ec2 --endpoint-url "$EC2_ENDPOINT_URL" describe-subnets --subnet-id "${SUBNETS[$i]}" --query "Subnets[0].AvailabilityZone" --output text) || exit 1
+                                BUILDSTEPVARIABLE_NOHYPHEN_AZ="$i${BUILDSTEPVARIABLE_AZ//-/}"
+                                awk \
+                                    -v BUILDSTEPVARIABLE_NOHYPHEN_AZ="$BUILDSTEPVARIABLE_NOHYPHEN_AZ" \
+                                    -v BUILDSTEPVARIABLE_AZ="$BUILDSTEPVARIABLE_AZ" \
+                                    -v BUILDSTEPVARIABLE_SUBNET="${SUBNETS[$i]}" '{
+                                      sub(/%{BUILDSTEPVARIABLE_NOHYPHEN_AZ}/, BUILDSTEPVARIABLE_NOHYPHEN_AZ);
+                                      sub(/%{BUILDSTEPVARIABLE_AZ}/, BUILDSTEPVARIABLE_AZ);
+                                      sub(/%{BUILDSTEPVARIABLE_SUBNET}/, BUILDSTEPVARIABLE_SUBNET);
+                                      print;
+                                }' "$CODEBUILD_SRC_DIR_SourceCicdArtifact"/template-glue-job.part >> "$CODEBUILD_SRC_DIR_SourceCicdArtifact"/template-glue-job.yaml
+                                BUILDSTEPVARIABLE_GLUECONNECTIONS+="                - !Ref r${BUILDSTEPVARIABLE_NOHYPHEN_AZ}GlueConnection"$'\n'
+                            done
+                        fi
+                        popd || exit 1
                     fi
+                    if [[ -n "$BUILDSTEPVARIABLE_GLUECONNECTIONS" ]]
+                    then
+                        BUILDSTEPVARIABLE_GLUECONNECTIONS=${BUILDSTEPVARIABLE_GLUECONNECTIONS%$'\n'}
+                        awk -i inplace -v BUILDSTEPVARIABLE_GLUECONNECTIONS="$BUILDSTEPVARIABLE_GLUECONNECTIONS" '{
+                          sub(/              - BUILDSTEPVARIABLE_GLUECONNECTIONS/, BUILDSTEPVARIABLE_GLUECONNECTIONS);
+                          print;
+                        }' "$CODEBUILD_SRC_DIR_SourceCicdArtifact"/template-glue-job.yaml
+                    fi
+                    cp "$CODEBUILD_SRC_DIR_SourceCicdArtifact"/template-glue-job.yaml template-glue-job.full.yaml
+          artifacts:
+            files:
+              - template-glue-job.full.yaml
         Type: CODEPIPELINE
       TimeoutInMinutes: 20
 

--- a/sdlf-cicd/template-cicd-domain-team-role.yaml
+++ b/sdlf-cicd/template-cicd-domain-team-role.yaml
@@ -534,7 +534,7 @@ Resources:
                 - glue:DeleteConnection
               Resource:
                 - !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:catalog
-                - !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:connection/sdlf-${pTeamName}-glue-conn
+                - !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:connection/sdlf-${pTeamName}-glue-conn-*
             - !Ref "AWS::NoValue"
           - Effect: Allow
             Action:

--- a/sdlf-cicd/template-cicd-team-pipeline.yaml
+++ b/sdlf-cicd/template-cicd-team-pipeline.yaml
@@ -285,6 +285,29 @@ Resources:
           - Name: BuildOptionalFeatures
             Actions:
               - !If
+                - EnableGlueJobDeployer
+                - Name: BuildGlueJobs
+                  InputArtifacts:
+                    - Name: TemplateSource
+                    - Name: SourceCicdArtifact
+                  OutputArtifacts:
+                    - Name: GlueJobDeployerArtifact
+                  Namespace: GlueJobVariables
+                  ActionTypeId:
+                    Category: Build
+                    Owner: AWS
+                    Version: "1"
+                    Provider: CodeBuild
+                  Configuration:
+                    PrimarySource: TemplateSource
+                    ProjectName: "{{resolve:ssm:/SDLF/CodeBuild/PrepareGlueJobPackage}}"
+                    EnvironmentVariables: !Sub >-
+                      [{"name":"ENVIRONMENT", "value":"${pEnvironment}", "type":"PLAINTEXT"},
+                      {"name":"DOMAIN", "value":"${pDomain}", "type":"PLAINTEXT"},
+                      {"name":"TEAM", "value":"${pTeamName}", "type":"PLAINTEXT"}]
+                  RunOrder: 1
+                - !Ref AWS::NoValue
+              - !If
                 - EnableLambdaLayerBuilder
                 - Name: BuildLambdaLayers
                   InputArtifacts:
@@ -303,30 +326,37 @@ Resources:
                       {"name":"TEAM", "value":"${pTeamName}", "type":"PLAINTEXT"}]
                   RunOrder: 1
                 - !Ref AWS::NoValue
-              - !If
-                - EnableGlueJobDeployer
-                - Name: BuildGlueJobs
-                  InputArtifacts:
-                    - Name: TemplateSource
-                  Namespace: GlueJobVariables
-                  ActionTypeId:
-                    Category: Build
-                    Owner: AWS
-                    Version: "1"
-                    Provider: CodeBuild
-                  Configuration:
-                    ProjectName: "{{resolve:ssm:/SDLF/CodeBuild/PrepareGlueJobPackage}}"
-                    EnvironmentVariables: !Sub >-
-                      [{"name":"ENVIRONMENT", "value":"${pEnvironment}", "type":"PLAINTEXT"},
-                      {"name":"DOMAIN", "value":"${pDomain}", "type":"PLAINTEXT"},
-                      {"name":"TEAM", "value":"${pTeamName}", "type":"PLAINTEXT"}]
-                  RunOrder: 1
-                - !Ref AWS::NoValue
           - !Ref AWS::NoValue
         - !If
           - EnableOptionalFeatures
           - Name: DeployOptionalFeatures
             Actions:
+              - !If
+                - EnableGlueJobDeployer
+                - Name: CreateGlueJobsStack
+                  RoleArn: !Sub arn:${AWS::Partition}:iam::${pChildAccountId}:role/sdlf-cicd-devops-crossaccount-pipeline
+                  ActionTypeId:
+                    Category: Deploy
+                    Owner: AWS
+                    Provider: CloudFormation
+                    Version: "1"
+                  InputArtifacts:
+                    - Name: TemplateSource
+                    - Name: GlueJobDeployerArtifact
+                  Configuration:
+                    ActionMode: CREATE_UPDATE
+                    RoleArn: !Ref pCrossAccountTeamRole
+                    StackName: !Sub sdlf-${pTeamName}-gluejobs-${pEnvironment}
+                    TemplatePath: "GlueJobDeployerArtifact::template-glue-job.full.yaml"
+                    TemplateConfiguration: "TemplateSource::tags.json"
+                    Capabilities: CAPABILITY_NAMED_IAM,CAPABILITY_AUTO_EXPAND
+                    ParameterOverrides: !Sub |+
+                      {
+                        "pTeamName": "${pTeamName}",
+                        "pGlueJobs": "#{GlueJobVariables.TRANSFORMS_CDL}"
+                      }
+                  RunOrder: 1
+                - !Ref AWS::NoValue
               - !If
                 - EnableLambdaLayerBuilder
                 - Name: CreateLambdaLayersStack
@@ -354,32 +384,6 @@ Resources:
                         "pTeamName": "${pTeamName}",
                         "pLayers": "#{LambdaLayersVariables.LAYERS_CDL}",
                         "pGitRef": "#{LambdaLayersVariables.CODEBUILD_RESOLVED_SOURCE_VERSION}"
-                      }
-                  RunOrder: 1
-                - !Ref AWS::NoValue
-              - !If
-                - EnableGlueJobDeployer
-                - Name: CreateGlueJobsStack
-                  RoleArn: !Sub arn:${AWS::Partition}:iam::${pChildAccountId}:role/sdlf-cicd-devops-crossaccount-pipeline
-                  ActionTypeId:
-                    Category: Deploy
-                    Owner: AWS
-                    Provider: CloudFormation
-                    Version: "1"
-                  InputArtifacts:
-                    - Name: TemplateSource
-                    - Name: SourceCicdArtifact
-                  Configuration:
-                    ActionMode: CREATE_UPDATE
-                    RoleArn: !Ref pCrossAccountTeamRole
-                    StackName: !Sub sdlf-${pTeamName}-gluejobs-${pEnvironment}
-                    TemplatePath: "SourceCicdArtifact::template-glue-job.yaml"
-                    TemplateConfiguration: "TemplateSource::tags.json"
-                    Capabilities: CAPABILITY_NAMED_IAM,CAPABILITY_AUTO_EXPAND
-                    ParameterOverrides: !Sub |+
-                      {
-                        "pTeamName": "${pTeamName}",
-                        "pGlueJobs": "#{GlueJobVariables.TRANSFORMS_CDL}"
                       }
                   RunOrder: 1
                 - !Ref AWS::NoValue

--- a/sdlf-cicd/template-glue-job.part
+++ b/sdlf-cicd/template-glue-job.part
@@ -1,0 +1,20 @@
+
+  r%{BUILDSTEPVARIABLE_NOHYPHEN_AZ}GlueConnection:
+    Type: AWS::Glue::Connection
+    Condition: RunInVpc
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - W3010
+    Properties:
+      CatalogId: !Ref AWS::AccountId
+      ConnectionInput:
+        ConnectionProperties: {}
+        ConnectionType: NETWORK
+        Description: "Network connected to the VPC data source"
+        Name: !Sub sdlf-${pTeamName}-glue-conn-%{BUILDSTEPVARIABLE_NOHYPHEN_AZ}
+        PhysicalConnectionRequirements:
+          AvailabilityZone: %{BUILDSTEPVARIABLE_AZ}
+          SecurityGroupIdList: !Split [",", !ImportValue sdlf-cicd-domain-roles-vpc-security-groups]
+          SubnetId: %{BUILDSTEPVARIABLE_SUBNET}

--- a/sdlf-cicd/template-glue-job.yaml
+++ b/sdlf-cicd/template-glue-job.yaml
@@ -63,28 +63,6 @@ Resources:
                   - !Sub "{{resolve:ssm:/SDLF/KMS/${pTeamName}/DataKeyId}}"
                   - "{{resolve:ssm:/SDLF/KMS/KeyArn}}"
 
-  rGlueConnection:
-    Type: AWS::Glue::Connection
-    Condition: RunInVpc
-    Metadata:
-      cfn-lint:
-        config:
-          ignore_checks:
-            - W3010
-    Properties:
-      CatalogId: !Ref AWS::AccountId
-      ConnectionInput:
-        ConnectionProperties: {}
-        ConnectionType: NETWORK
-        Description: "Network connected to the VPC data source"
-        Name: !Sub sdlf-${pTeamName}-glue-conn
-        PhysicalConnectionRequirements:
-          AvailabilityZone: us-east-1a # this is not taken into account at all, but the property needs to be present anyway
-          SecurityGroupIdList: !Split [",", !ImportValue sdlf-cicd-domain-roles-vpc-security-groups]
-          SubnetId: !Select
-            - "1"
-            - !Split [",", !ImportValue sdlf-cicd-domain-roles-vpc-subnets]
-
   "Fn::ForEach::GlueJobResources":
   - GlueJobName
   - !Ref pGlueJobs
@@ -124,5 +102,5 @@ Resources:
         Connections: !If
           - RunInVpc
           - Connections:
-              - !Ref rGlueConnection
+              - BUILDSTEPVARIABLE_GLUECONNECTIONS
           - !Ref "AWS::NoValue"


### PR DESCRIPTION
*Issue #, if available:*
#317 
*Description of changes:*
Create a Glue connection per subnet specified in /SDLF/VPC/SubnetIds, and provide the correct value for AvailabilityZone

To do that I had to write more shell than I'd like, but truthfully as long as the Glue Connection resource requires AvailabilityZone this is probably the best way.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
