### PR TITLE
provide ability to override default glue database name

### DIFF
--- a/sdlf-dataset/template.yaml
+++ b/sdlf-dataset/template.yaml
@@ -58,8 +58,7 @@ Resources:
       CatalogId: !Ref AWS::AccountId
       DatabaseInput:
         Description: !Sub "${pTeamName} team ${pDatasetName} metadata catalog"
-        #Name: !Sub ${pOrg}_${pDomain}_${pEnvironment}_${pTeamName}_${pDatasetName}_db
-        Name: !Ref pGlueDatabaseName
+        Name: !Sub ${pOrg}_${pDomain}_${pEnvironment}_${pTeamName}_${pGlueDatabaseName}_db
 
   rGlueDataCatalogLakeFormationTag:
       Type: AWS::LakeFormation::TagAssociation


### PR DESCRIPTION
Added parameter for provide ability to override default glue database name instead of default database name

*Issue #, if available:*

*Description of changes: Added a new parameter in the daaset template to allow users to provide the database name instead of the defeult one. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
