### PR TITLE
Fix #272: Replace logs:TagLogGroup permission with logs:TagResource

### DIFF
--- a/sdlf-cicd/template-cicd-domain-roles.yaml
+++ b/sdlf-cicd/template-cicd-domain-roles.yaml
@@ -475,7 +475,7 @@ Resources:
                   - logs:DescribeLogStreams
                   - logs:PutLogEvents
                   - logs:PutRetentionPolicy
-                  - logs:TagLogGroup
+                  - logs:TagResource
                 Resource:
                   - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/*/sdlf-*
               - Effect: Allow

--- a/sdlf-cicd/template-cicd-domain-team-role.yaml
+++ b/sdlf-cicd/template-cicd-domain-team-role.yaml
@@ -231,7 +231,7 @@ Resources:
               - logs:DescribeLogStreams
               - logs:PutLogEvents
               - logs:PutRetentionPolicy
-              - logs:TagLogGroup
+              - logs:TagResource
             Resource:
               - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/sdlf-${pTeamName}-*
           - Effect: Allow

--- a/sdlf-cicd/template-cicd-prerequisites.yaml
+++ b/sdlf-cicd/template-cicd-prerequisites.yaml
@@ -544,7 +544,7 @@ Resources:
                   - logs:CreateLogGroup
                   - logs:DescribeLogGroups
                   - logs:DeleteLogGroup
-                  - logs:TagLogGroup
+                  - logs:TagResource
                   - logs:PutRetentionPolicy
                   - logs:DeleteRetentionPolicy
                   - logs:DescribeLogStreams

--- a/sdlf-team/template.yaml
+++ b/sdlf-team/template.yaml
@@ -720,7 +720,7 @@ Resources:
                   - logs:CreateLogGroup
                   - logs:DescribeLogGroups
                   - logs:DeleteLogGroup
-                  - logs:TagLogGroup
+                  - logs:TagResource
                   - logs:PutRetentionPolicy
                   - logs:DeleteRetentionPolicy
                   - logs:DescribeLogStreams
@@ -833,7 +833,7 @@ Resources:
                   - logs:CreateLogGroup
                   - logs:DescribeLogGroups
                   - logs:DeleteLogGroup
-                  - logs:TagLogGroup
+                  - logs:TagResource
                   - logs:PutRetentionPolicy
                   - logs:DeleteRetentionPolicy
                   - logs:DescribeLogStreams


### PR DESCRIPTION
*Issue #272 , if available:*

*Description of changes:*
I saw no one is working on this, so if you don't mind, I want to take a shot.
Replaced deprecated `logs:TagLogGroup` with new permission `logs:TagResource` under these files:
```
./sdlf-team/template.yaml
./sdlf-cicd/template-cicd-domain-roles.yaml
./sdlf-cicd/template-cicd-domain-team-role.yaml
./sdlf-cicd/template-cicd-prerequisites.yaml
```

If you think the above fix looks good to you, I can send out another PR later against master branch to fix in SDLF 1.x.
Please let me know if there is anything else I missed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
