### PR TITLE
sdlf-cicd: support for gitlab as an alternative to codecommit

### DIFF
--- a/sdlf-cicd/nested-stacks/template-cicd-modules-pipelines.yaml
+++ b/sdlf-cicd/nested-stacks/template-cicd-modules-pipelines.yaml
@@ -26,6 +26,10 @@ Parameters:
     Description: Environment name
     Type: String
     AllowedValues: [dev, test, prod]
+  pGitPlatform:
+    Description: Platform used to host git repositories
+    Type: String
+    AllowedValues: [CodeCommit, GitLab]
 
 Mappings:
   pCodeCommitBranch:
@@ -35,6 +39,10 @@ Mappings:
       branch: test
     prod:
       branch: main
+
+Conditions:
+  CodeCommitNoGitLab: !Equals [!Ref pGitPlatform, "CodeCommit"]
+  GitLabNoCodeCommit: !Equals [!Ref pGitPlatform, "GitLab"]
 
 Resources:
   rMainRepositoryCodePipelineRole:
@@ -54,18 +62,38 @@ Resources:
           PolicyDocument:
             Version: 2012-10-17
             Statement:
-              - Effect: Allow
-                Action:
-                  - codecommit:GetBranch
-                  - codecommit:GetCommit
-                  - codecommit:GitPull
-                  - codecommit:GetRepository
-                  - codecommit:UploadArchive
-                  - codecommit:GetUploadArchiveStatus
-                  - codecommit:CancelUploadArchive
-                Resource:
-                  - !Sub arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:${pMainRepository}
-                  - !Sub arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:${pCicdRepository}
+              - !If
+                - CodeCommitNoGitLab
+                - Effect: Allow
+                  Action:
+                    - codecommit:GetBranch
+                    - codecommit:GetCommit
+                    - codecommit:GitPull
+                    - codecommit:GetRepository
+                    - codecommit:UploadArchive
+                    - codecommit:GetUploadArchiveStatus
+                    - codecommit:CancelUploadArchive
+                  Resource:
+                    - !Sub arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:${pMainRepository}
+                    - !Sub arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:${pCicdRepository}
+                - !Ref "AWS::NoValue"
+              - !If
+                - GitLabNoCodeCommit
+                - Effect: Allow
+                  Action:
+                    - codeconnections:UseConnection
+                    - codestar-connections:UseConnection
+                  Resource:
+                    - !Sub "{{resolve:ssm:/SDLF/${pGitPlatform}/CodeConnection}}"
+                  Condition:
+                    "ForAllValues:StringLikeIfExists":
+                      "codeconnections:FullRepositoryId":
+                        - !Sub "{{resolve:ssm:/SDLF/GitLab/SdlfGitLabGroup}}/${pMainRepository}"
+                        - !Sub "{{resolve:ssm:/SDLF/GitLab/SdlfGitLabGroup}}/${pCicdRepository}"
+                      "codestar-connections:FullRepositoryId":
+                        - !Sub "{{resolve:ssm:/SDLF/GitLab/SdlfGitLabGroup}}/${pMainRepository}"
+                        - !Sub "{{resolve:ssm:/SDLF/GitLab/SdlfGitLabGroup}}/${pCicdRepository}"
+                - !Ref "AWS::NoValue"
               - Effect: Allow
                 Action:
                   - s3:Get*
@@ -105,37 +133,63 @@ Resources:
     Properties:
       RoleArn: !GetAtt rMainRepositoryCodePipelineRole.Arn
       Stages:
-        -
-          Name: Sources
-          Actions:
-            -
-              Name: SourceMain
-              ActionTypeId:
-                Category: Source
-                Owner: AWS
-                Version: "1"
-                Provider: CodeCommit
-              OutputArtifacts:
-                - Name: SourceMainArtifact
-              Configuration:
-                RepositoryName: !Ref pMainRepository
-                BranchName: !FindInMap [pCodeCommitBranch, !Ref pEnvironment, branch]
-                PollForSourceChanges: false
-              RunOrder: 1
-            -
-              Name: SourceCicd
-              ActionTypeId:
-                Category: Source
-                Owner: AWS
-                Version: "1"
-                Provider: CodeCommit
-              OutputArtifacts:
-                - Name: SourceCicdArtifact
-              Configuration:
-                RepositoryName: !Ref pCicdRepository
-                BranchName: !FindInMap [pCodeCommitBranch, !Ref pEnvironment, branch]
-                PollForSourceChanges: false
-              RunOrder: 1
+        - Name: Sources
+          Actions: !If
+            - CodeCommitNoGitLab
+            - - Name: SourceMain
+                ActionTypeId:
+                  Category: Source
+                  Owner: AWS
+                  Version: "1"
+                  Provider: CodeCommit
+                OutputArtifacts:
+                  - Name: SourceMainArtifact
+                Configuration:
+                  RepositoryName: !Ref pMainRepository
+                  BranchName: !FindInMap [pCodeCommitBranch, !Ref pEnvironment, branch]
+                  PollForSourceChanges: false
+                RunOrder: 1
+              - Name: SourceCicd
+                ActionTypeId:
+                  Category: Source
+                  Owner: AWS
+                  Version: "1"
+                  Provider: CodeCommit
+                OutputArtifacts:
+                  - Name: SourceCicdArtifact
+                Configuration:
+                  RepositoryName: !Ref pCicdRepository
+                  BranchName: !FindInMap [pCodeCommitBranch, !Ref pEnvironment, branch]
+                  PollForSourceChanges: false
+                RunOrder: 1
+            - - Name: SourceMain
+                ActionTypeId:
+                  Category: Source
+                  Owner: AWS
+                  Version: "1"
+                  Provider: CodeStarSourceConnection
+                OutputArtifacts:
+                  - Name: SourceMainArtifact
+                Configuration:
+                  ConnectionArn: !Sub "{{resolve:ssm:/SDLF/${pGitPlatform}/CodeConnection}}"
+                  FullRepositoryId: !Sub "{{resolve:ssm:/SDLF/GitLab/SdlfGitLabGroup}}/${pMainRepository}"
+                  BranchName: !FindInMap [pCodeCommitBranch, !Ref pEnvironment, branch]
+                  OutputArtifactFormat: CODE_ZIP
+                RunOrder: 1
+              - Name: SourceCicd
+                ActionTypeId:
+                  Category: Source
+                  Owner: AWS
+                  Version: "1"
+                  Provider: CodeStarSourceConnection
+                OutputArtifacts:
+                  - Name: SourceCicdArtifact
+                Configuration:
+                  ConnectionArn: !Sub "{{resolve:ssm:/SDLF/${pGitPlatform}/CodeConnection}}"
+                  FullRepositoryId: !Sub "{{resolve:ssm:/SDLF/GitLab/SdlfGitLabGroup}}/${pCicdRepository}"
+                  BranchName: !FindInMap [pCodeCommitBranch, !Ref pEnvironment, branch]
+                  OutputArtifactFormat: CODE_ZIP
+                RunOrder: 1
         -
           Name: MainRepositoryParser
           Actions:
@@ -207,6 +261,7 @@ Resources:
 
   rMainRepositoryCodeCommitTriggerRole:
     Type: AWS::IAM::Role
+    Condition: CodeCommitNoGitLab
     Properties:
       AssumeRolePolicyDocument:
         Version: 2012-10-17
@@ -228,6 +283,7 @@ Resources:
 
   rMainRepositoryCodePipelineTriggerRule:
     Type: AWS::Events::Rule
+    Condition: CodeCommitNoGitLab
     Properties:
       EventPattern:
         source:

--- a/sdlf-cicd/template-cicd-domain.yaml
+++ b/sdlf-cicd/template-cicd-domain.yaml
@@ -1,4 +1,4 @@
-AWSTemplateFormatVersion: 2010-09-09
+AWSTemplateFormatVersion: "2010-09-09"
 Description: CICD resources to handle deployment of a new domain
 
 Parameters:
@@ -10,6 +10,10 @@ Parameters:
     Description: The KMS key used by CodeBuild and CodePipeline
     Type: AWS::SSM::Parameter::Value<String>
     Default: /SDLF/KMS/CICDKeyId
+  pGitPlatform:
+    Description: Platform used to host git repositories
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: /SDLF/Misc/GitPlatform
   pMainRepository:
     Type: AWS::SSM::Parameter::Value<String>
     Default: /SDLF/CodeCommit/MainCodeCommit
@@ -66,6 +70,8 @@ Mappings:
       branch: main
 
 Conditions:
+  CodeCommitNoGitLab: !Equals [!Ref pGitPlatform, "CodeCommit"]
+  GitLabNoCodeCommit: !Equals [!Ref pGitPlatform, "GitLab"]
   EnableMonitoring: !Equals [!Ref pEnableMonitoring, true]
 
 Resources:
@@ -74,7 +80,7 @@ Resources:
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
-        Version: 2012-10-17
+        Version: "2012-10-17"
         Statement:
           - Effect: Allow
             Principal:
@@ -85,26 +91,58 @@ Resources:
       Policies:
         - PolicyName: sdlf-cicd-maincodepipelinesource
           PolicyDocument:
-            Version: 2012-10-17
+            Version: "2012-10-17"
             Statement:
-              - Effect: Allow
-                Action:
-                  - codecommit:GetBranch
-                  - codecommit:GetCommit
-                  - codecommit:GitPull
-                  - codecommit:GetRepository
-                  - codecommit:UploadArchive
-                  - codecommit:GetUploadArchiveStatus
-                  - codecommit:CancelUploadArchive
-                Resource:
-                  - !Sub arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:${pCicdRepository}
-                  - !Sub arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:${pFoundationsRepository}
-                  - !Sub arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:${pTeamRepository}
-                  - !Sub arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:${pMainRepository}
-                  - !If
+              - !If
+                - CodeCommitNoGitLab
+                - Effect: Allow
+                  Action:
+                    - codecommit:GetBranch
+                    - codecommit:GetCommit
+                    - codecommit:GitPull
+                    - codecommit:GetRepository
+                    - codecommit:UploadArchive
+                    - codecommit:GetUploadArchiveStatus
+                    - codecommit:CancelUploadArchive
+                  Resource:
+                    - !Sub arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:${pCicdRepository}
+                    - !Sub arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:${pFoundationsRepository}
+                    - !Sub arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:${pTeamRepository}
+                    - !Sub arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:${pMainRepository}
+                    - !If
                       - EnableMonitoring
                       - !Sub "arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:{{resolve:ssm:/SDLF/CodeCommit/MonitoringCodeCommit}}"
                       - !Ref AWS::NoValue
+                - !Ref "AWS::NoValue"
+              - !If
+                - GitLabNoCodeCommit
+                - Effect: Allow
+                  Action:
+                    - codeconnections:UseConnection
+                    - codestar-connections:UseConnection
+                  Resource:
+                    - !Sub "{{resolve:ssm:/SDLF/${pGitPlatform}/CodeConnection}}"
+                  Condition:
+                    "ForAllValues:StringLikeIfExists":
+                      "codeconnections:FullRepositoryId":
+                        - !Sub "{{resolve:ssm:/SDLF/GitLab/SdlfGitLabGroup}}/${pCicdRepository}"
+                        - !Sub "{{resolve:ssm:/SDLF/GitLab/SdlfGitLabGroup}}/${pFoundationsRepository}"
+                        - !Sub "{{resolve:ssm:/SDLF/GitLab/SdlfGitLabGroup}}/${pTeamRepository}"
+                        - !Sub "{{resolve:ssm:/SDLF/GitLab/SdlfGitLabGroup}}/${pMainRepository}"
+                        - !If
+                          - EnableMonitoring
+                          - !Sub "{{resolve:ssm:/SDLF/GitLab/SdlfGitLabGroup}}/{{resolve:ssm:/SDLF/${pGitPlatform}/Monitoring${pGitPlatform}}}"
+                          - !Ref AWS::NoValue
+                      "codestar-connections:FullRepositoryId":
+                        - !Sub "{{resolve:ssm:/SDLF/GitLab/SdlfGitLabGroup}}/${pCicdRepository}"
+                        - !Sub "{{resolve:ssm:/SDLF/GitLab/SdlfGitLabGroup}}/${pFoundationsRepository}"
+                        - !Sub "{{resolve:ssm:/SDLF/GitLab/SdlfGitLabGroup}}/${pTeamRepository}"
+                        - !Sub "{{resolve:ssm:/SDLF/GitLab/SdlfGitLabGroup}}/${pMainRepository}"
+                        - !If
+                          - EnableMonitoring
+                          - !Sub "{{resolve:ssm:/SDLF/GitLab/SdlfGitLabGroup}}/{{resolve:ssm:/SDLF/${pGitPlatform}/Monitoring${pGitPlatform}}}"
+                          - !Ref AWS::NoValue
+                - !Ref "AWS::NoValue"
               - Effect: Allow
                 Action:
                   - s3:Get*
@@ -130,7 +168,7 @@ Resources:
                   - !Sub "arn:${AWS::Partition}:codebuild:${AWS::Region}:${AWS::AccountId}:project/${pBuildCloudformationModuleStage}"
         - PolicyName: sdlf-cicd-cloudformation
           PolicyDocument:
-            Version: 2012-10-17
+            Version: "2012-10-17"
             Statement:
               - Effect: Allow
                 Action: sts:AssumeRole
@@ -142,81 +180,153 @@ Resources:
     Properties:
       RoleArn: !GetAtt rDomainCodePipelineRole.Arn
       Stages:
-        - Name: Source
-          Actions:
-            - Name: sdlf-main
-              ActionTypeId:
-                Category: Source
-                Owner: AWS
-                Provider: CodeCommit
-                Version: "1"
-              Namespace: SourceVariables
-              OutputArtifacts:
-                - Name: TemplateSource
-              Configuration:
-                RepositoryName: !Ref pMainRepository
-                BranchName:
-                  !FindInMap [pCodeCommitBranch, !Ref pEnvironment, branch]
-                PollForSourceChanges: false
-              RunOrder: 1
-            -
-              Name: SourceCicd
-              ActionTypeId:
-                Category: Source
-                Owner: AWS
-                Version: "1"
-                Provider: CodeCommit
-              OutputArtifacts:
-                - Name: SourceCicdArtifact
-              Configuration:
-                RepositoryName: !Ref pCicdRepository
-                BranchName: !FindInMap [pCodeCommitBranch, !Ref pEnvironment, branch]
-                PollForSourceChanges: false
-              RunOrder: 1
-            -
-              Name: SourceFoundations
-              ActionTypeId:
-                Category: Source
-                Owner: AWS
-                Version: "1"
-                Provider: CodeCommit
-              OutputArtifacts:
-                - Name: SourceFoundationsArtifact
-              Configuration:
-                RepositoryName: !Ref pFoundationsRepository
-                BranchName: !FindInMap [pCodeCommitBranch, !Ref pEnvironment, branch]
-                PollForSourceChanges: false
-              RunOrder: 1
-            -
-              Name: SourceTeam
-              ActionTypeId:
-                Category: Source
-                Owner: AWS
-                Version: "1"
-                Provider: CodeCommit
-              OutputArtifacts:
-                - Name: SourceTeamArtifact
-              Configuration:
-                RepositoryName: !Ref pTeamRepository
-                BranchName: !FindInMap [pCodeCommitBranch, !Ref pEnvironment, branch]
-                PollForSourceChanges: false
-              RunOrder: 1
-            - !If
-                - EnableMonitoring
-                - Name: SourceMonitoring
-                  ActionTypeId:
-                    Category: Source
-                    Owner: AWS
-                    Version: "1"
-                    Provider: CodeCommit
-                  OutputArtifacts:
-                    - Name: SourceMonitoringArtifact
-                  Configuration:
-                    RepositoryName: "{{resolve:ssm:/SDLF/CodeCommit/MonitoringCodeCommit}}"
-                    BranchName: !FindInMap [pCodeCommitBranch, !Ref pEnvironment, branch]
-                    PollForSourceChanges: false
-                  RunOrder: 1
-                - !Ref AWS::NoValue
+        - Name: Sources
+          Actions: !If
+            - CodeCommitNoGitLab
+            - - Name: sdlf-main
+                ActionTypeId:
+                  Category: Source
+                  Owner: AWS
+                  Provider: CodeCommit
+                  Version: "1"
+                Namespace: SourceVariables
+                OutputArtifacts:
+                  - Name: TemplateSource
+                Configuration:
+                  RepositoryName: !Ref pMainRepository
+                  BranchName:
+                    !FindInMap [pCodeCommitBranch, !Ref pEnvironment, branch]
+                  PollForSourceChanges: false
+                RunOrder: 1
+              - Name: SourceCicd
+                ActionTypeId:
+                  Category: Source
+                  Owner: AWS
+                  Provider: CodeCommit
+                  Version: "1"
+                OutputArtifacts:
+                  - Name: SourceCicdArtifact
+                Configuration:
+                  RepositoryName: !Ref pCicdRepository
+                  BranchName: !FindInMap [pCodeCommitBranch, !Ref pEnvironment, branch]
+                  PollForSourceChanges: false
+                RunOrder: 1
+              - Name: SourceFoundations
+                ActionTypeId:
+                  Category: Source
+                  Owner: AWS
+                  Provider: CodeCommit
+                  Version: "1"
+                OutputArtifacts:
+                  - Name: SourceFoundationsArtifact
+                Configuration:
+                  RepositoryName: !Ref pFoundationsRepository
+                  BranchName: !FindInMap [pCodeCommitBranch, !Ref pEnvironment, branch]
+                  PollForSourceChanges: false
+                RunOrder: 1
+              - Name: SourceTeam
+                ActionTypeId:
+                  Category: Source
+                  Owner: AWS
+                  Provider: CodeCommit
+                  Version: "1"
+                OutputArtifacts:
+                  - Name: SourceTeamArtifact
+                Configuration:
+                  RepositoryName: !Ref pTeamRepository
+                  BranchName: !FindInMap [pCodeCommitBranch, !Ref pEnvironment, branch]
+                  PollForSourceChanges: false
+                RunOrder: 1
+              - !If
+                  - EnableMonitoring
+                  - Name: SourceMonitoring
+                    ActionTypeId:
+                      Category: Source
+                      Owner: AWS
+                      Provider: CodeCommit
+                      Version: "1"
+                    OutputArtifacts:
+                      - Name: SourceMonitoringArtifact
+                    Configuration:
+                      RepositoryName: "{{resolve:ssm:/SDLF/CodeCommit/MonitoringCodeCommit}}"
+                      BranchName: !FindInMap [pCodeCommitBranch, !Ref pEnvironment, branch]
+                      PollForSourceChanges: false
+                    RunOrder: 1
+                  - !Ref AWS::NoValue
+            - - Name: sdlf-main
+                ActionTypeId:
+                  Category: Source
+                  Owner: AWS
+                  Provider: CodeStarSourceConnection
+                  Version: "1"
+                Namespace: SourceVariables
+                OutputArtifacts:
+                  - Name: TemplateSource
+                Configuration:
+                  ConnectionArn: !Sub "{{resolve:ssm:/SDLF/${pGitPlatform}/CodeConnection}}"
+                  FullRepositoryId: !Sub "{{resolve:ssm:/SDLF/GitLab/SdlfGitLabGroup}}/${pMainRepository}"
+                  BranchName: !FindInMap [pCodeCommitBranch, !Ref pEnvironment, branch]
+                  OutputArtifactFormat: CODE_ZIP
+                RunOrder: 1
+              - Name: SourceCicd
+                ActionTypeId:
+                  Category: Source
+                  Owner: AWS
+                  Provider: CodeStarSourceConnection
+                  Version: "1"
+                OutputArtifacts:
+                  - Name: SourceCicdArtifact
+                Configuration:
+                  ConnectionArn: !Sub "{{resolve:ssm:/SDLF/${pGitPlatform}/CodeConnection}}"
+                  FullRepositoryId: !Sub "{{resolve:ssm:/SDLF/GitLab/SdlfGitLabGroup}}/${pCicdRepository}"
+                  BranchName: !FindInMap [pCodeCommitBranch, !Ref pEnvironment, branch]
+                  OutputArtifactFormat: CODE_ZIP
+                RunOrder: 1
+              - Name: SourceFoundations
+                ActionTypeId:
+                  Category: Source
+                  Owner: AWS
+                  Provider: CodeStarSourceConnection
+                  Version: "1"
+                OutputArtifacts:
+                  - Name: SourceFoundationsArtifact
+                Configuration:
+                  ConnectionArn: !Sub "{{resolve:ssm:/SDLF/${pGitPlatform}/CodeConnection}}"
+                  FullRepositoryId: !Sub "{{resolve:ssm:/SDLF/GitLab/SdlfGitLabGroup}}/${pFoundationsRepository}"
+                  BranchName: !FindInMap [pCodeCommitBranch, !Ref pEnvironment, branch]
+                  OutputArtifactFormat: CODE_ZIP
+                RunOrder: 1
+              - Name: SourceTeam
+                ActionTypeId:
+                  Category: Source
+                  Owner: AWS
+                  Provider: CodeStarSourceConnection
+                  Version: "1"
+                OutputArtifacts:
+                  - Name: SourceTeamArtifact
+                Configuration:
+                  ConnectionArn: !Sub "{{resolve:ssm:/SDLF/${pGitPlatform}/CodeConnection}}"
+                  FullRepositoryId: !Sub "{{resolve:ssm:/SDLF/GitLab/SdlfGitLabGroup}}/${pTeamRepository}"
+                  BranchName: !FindInMap [pCodeCommitBranch, !Ref pEnvironment, branch]
+                  OutputArtifactFormat: CODE_ZIP
+                RunOrder: 1
+              - !If
+                  - EnableMonitoring
+                  - Name: SourceMonitoring
+                    ActionTypeId:
+                      Category: Source
+                      Owner: AWS
+                      Provider: CodeStarSourceConnection
+                      Version: "1"
+                    OutputArtifacts:
+                      - Name: SourceMonitoringArtifact
+                    Configuration:
+                      ConnectionArn: !Sub "{{resolve:ssm:/SDLF/${pGitPlatform}/CodeConnection}}"
+                      FullRepositoryId: !Sub "{{resolve:ssm:/SDLF/GitLab/SdlfGitLabGroup}}/{{resolve:ssm:/SDLF/${pGitPlatform}/Monitoring${pGitPlatform}}}"
+                      BranchName: !FindInMap [pCodeCommitBranch, !Ref pEnvironment, branch]
+                      OutputArtifactFormat: CODE_ZIP
+                    RunOrder: 1
+                  - !Ref AWS::NoValue
         - Name: BuildTemplate
           Actions:
             -
@@ -227,8 +337,8 @@ Resources:
               ActionTypeId:
                 Category: Build
                 Owner: AWS
-                Version: "1"
                 Provider: CodeBuild
+                Version: "1"
               Configuration:
                 PrimarySource: SourceFoundationsArtifact
                 ProjectName: !Ref pBuildCloudformationModuleStage
@@ -247,8 +357,8 @@ Resources:
               ActionTypeId:
                 Category: Build
                 Owner: AWS
-                Version: "1"
                 Provider: CodeBuild
+                Version: "1"
               Configuration:
                 PrimarySource: SourceTeamArtifact
                 ProjectName: !Ref pBuildCloudformationModuleStage
@@ -268,8 +378,8 @@ Resources:
                   ActionTypeId:
                     Category: Build
                     Owner: AWS
-                    Version: "1"
                     Provider: CodeBuild
+                    Version: "1"
                   Configuration:
                     PrimarySource: SourceMonitoringArtifact
                     ProjectName: !Ref pBuildCloudformationModuleStage
@@ -289,8 +399,8 @@ Resources:
               ActionTypeId:
                 Category: Build
                 Owner: AWS
-                Version: "1"
                 Provider: CodeBuild
+                Version: "1"
               Configuration:
                 ProjectName: !Ref pBuildCloudFormationPackage
                 EnvironmentVariables: !Sub >-
@@ -331,7 +441,7 @@ Resources:
     Type: AWS::IAM::Role
     Properties:
       AssumeRolePolicyDocument:
-        Version: 2012-10-17
+        Version: "2012-10-17"
         Statement:
           - Effect: Allow
             Principal:
@@ -341,7 +451,7 @@ Resources:
       Policies:
         - PolicyName: sdlf-cicd-trigger-rule
           PolicyDocument:
-            Version: 2012-10-17
+            Version: "2012-10-17"
             Statement:
               - Effect: Allow
                 Action: codepipeline:StartPipelineExecution

--- a/sdlf-cicd/template-cicd-prerequisites.yaml
+++ b/sdlf-cicd/template-cicd-prerequisites.yaml
@@ -9,6 +9,15 @@ Parameters:
   pDomainAccounts:
     Description: List of AWS account ids bootstrapped with SDLF domain roles
     Type: CommaDelimitedList
+  pGitPlatform:
+    Description: Platform used to host git repositories
+    Type: String
+    AllowedValues: [CodeCommit, GitLab]
+    Default: CodeCommit
+  pEnableGitlab:
+    Description: Use GitLab instead of CodeCommit for SDLF repositories
+    Type: String
+    Default: false
   pEnableGlueJobDeployer:
     Description: Enable Glue Job Deployer optional feature
     Type: String
@@ -35,6 +44,24 @@ Conditions:
 
 Resources:
   ######## OPTIONAL SDLF FEATURES #########
+  # when enabling Gitlab support, /SDLF/GitLab/Url and /SDLF/GitLab/AccessToken are required too (as secure strings)
+  # then enable GitLab::Projects::Project third-party resource type in CloudFormation Registry
+  rGitlabFeatureSsm:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: /SDLF/GitLab/Enabled
+      Type: String
+      Value: !Ref pEnableGitlab
+      Description: Create repositories on GitLab instead of CodeCommit
+
+  rGitPlatformSsm:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: /SDLF/Misc/GitPlatform
+      Type: String
+      Value: !Ref pGitPlatform
+      Description: Platform used to host git repositories
+
   rGlueJobDeployerFeatureSsm:
     Type: AWS::SSM::Parameter
     Properties:

--- a/sdlf-cicd/template-cicd-sdlf-pipelines.yaml
+++ b/sdlf-cicd/template-cicd-sdlf-pipelines.yaml
@@ -10,6 +10,10 @@ Parameters:
     Description: The KMS key used by CodeBuild and CodePipeline
     Type: AWS::SSM::Parameter::Value<String>
     Default: /SDLF/KMS/CICDKeyId
+  pGitPlatform:
+    Description: Platform used to host git repositories
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: /SDLF/Misc/GitPlatform
   pCicdRepository:
     Type: AWS::SSM::Parameter::Value<String>
     Default: /SDLF/CodeCommit/CicdCodeCommit
@@ -63,6 +67,7 @@ Resources:
     Properties:
       TemplateURL: ./nested-stacks/template-cicd-modules-pipelines.yaml
       Parameters:
+        pGitPlatform: !Ref pGitPlatform
         pCicdRepository: !Ref pCicdRepository
         pMainRepository: !Ref pMainRepository
         pMainRepositoryParserLambda: !Ref rMainRepositoryParserLambda
@@ -81,6 +86,7 @@ Resources:
     Properties:
       TemplateURL: ./nested-stacks/template-cicd-modules-pipelines.yaml
       Parameters:
+        pGitPlatform: !Ref pGitPlatform
         pCicdRepository: !Ref pCicdRepository
         pMainRepository: !Ref pMainRepository
         pMainRepositoryParserLambda: !Ref rMainRepositoryParserLambda
@@ -99,6 +105,7 @@ Resources:
     Properties:
       TemplateURL: ./nested-stacks/template-cicd-modules-pipelines.yaml
       Parameters:
+        pGitPlatform: !Ref pGitPlatform
         pCicdRepository: !Ref pCicdRepository
         pMainRepository: !Ref pMainRepository
         pMainRepositoryParserLambda: !Ref rMainRepositoryParserLambda
@@ -306,7 +313,7 @@ Resources:
                   - codecommit:GetFile
                   - codecommit:GetFolder
                   - codecommit:AssociateApprovalRuleTemplateWithRepository
-                Effect: Allow
+                Effect: Allow # TODO if codecommit?
                 Resource:
                   - !Sub arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:${pMainRepository}
                   - !Sub arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:${pCicdRepository}
@@ -401,7 +408,7 @@ Resources:
                 Action:
                   - codecommit:ListRepositories # W11 exception
                 Resource: "*"
-              - Effect: Allow
+              - Effect: Allow # TODO if codecommit?
                 Action:
                   - codecommit:GetRepository
                   - codecommit:CreateRepository
@@ -498,6 +505,7 @@ Resources:
                   - !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/GlueJobDeployer/Enabled
                   - !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/Monitoring/Enabled
                   - !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/CodeCommit/*
+                  - !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/GitLab/*
               - Effect: Allow
                 Action:
                   - codepipeline:GetPipelineState

--- a/sdlf-cicd/template-cicd-sdlf-repositories.gitlab.yaml
+++ b/sdlf-cicd/template-cicd-sdlf-repositories.gitlab.yaml
@@ -1,0 +1,273 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: Multi-environment CICD team repos resources in shared DevOps account
+
+Parameters:
+  pKMSKey:
+    Description: The KMS key used by CodeBuild and CodePipeline
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: /SDLF/KMS/CICDKeyId
+  pSdlfGitLabGroup:
+    Type: String
+    Default: sdlf
+  pCicdRepository:
+    Type: String
+    Default: sdlf-cicd
+  pFoundationsRepository:
+    Type: String
+    Default: sdlf-foundations
+  pTeamRepository:
+    Type: String
+    Default: sdlf-team
+  pPipelineRepository:
+    Type: String
+    Default: sdlf-pipeline
+  pDatasetRepository:
+    Type: String
+    Default: sdlf-dataset
+  pStageARepository:
+    Type: String
+    Default: sdlf-stageA
+  pStageBRepository:
+    Type: String
+    Default: sdlf-stageB
+  pDatalakeLibraryRepository:
+    Type: String
+    Default: sdlf-datalakeLibrary
+  pUtilsRepository:
+    Type: String
+    Default: sdlf-utils
+  pMainRepository:
+    Type: String
+    Default: sdlf-main
+  pMonitoringRepository:
+    Type: String
+    Default: sdlf-monitoring
+  pEnableMonitoring:
+    Description: Build sdlf-monitoring cloudformation module as part of domain pipelines
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: /SDLF/Monitoring/Enabled
+
+Conditions:
+  EnableMonitoring: !Equals [!Ref pEnableMonitoring, true]
+
+Resources:
+  ######## GITLAB #########
+  # rSdlfGitLabGroup:
+  #   Type: GitLab::Groups::Group
+  #   Properties:
+  #     Name: SDLF
+  #     Path: !Ref pSdlfGitLabGroup
+
+  rCicdGitLab:
+    Type: GitLab::Projects::Project
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+          - E3001
+    Properties:
+      Name: !Ref pCicdRepository
+#      Path: !Ref pSdlfGitLabGroup
+
+  rFoundationsGitLab:
+    Type: GitLab::Projects::Project
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+          - E3001
+    Properties:
+      Name: !Ref pFoundationsRepository
+#      Path: !Ref pSdlfGitLabGroup
+
+  rTeamGitLab:
+    Type: GitLab::Projects::Project
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+          - E3001
+    Properties:
+      Name: !Ref pTeamRepository
+#      Path: !Ref pSdlfGitLabGroup
+
+  rPipelineGitLab:
+    Type: GitLab::Projects::Project
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+          - E3001
+    Properties:
+      Name: !Ref pPipelineRepository
+#      Path: !Ref pSdlfGitLabGroup
+
+  rDatasetGitLab:
+    Type: GitLab::Projects::Project
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+          - E3001
+    Properties:
+      Name: !Ref pDatasetRepository
+#      Path: !Ref pSdlfGitLabGroup
+
+  rStageAGitLab:
+    Type: GitLab::Projects::Project
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+          - E3001
+    Properties:
+      Name: !Ref pStageARepository
+#      Path: !Ref pSdlfGitLabGroup
+
+  rStageBGitLab:
+    Type: GitLab::Projects::Project
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+          - E3001
+    Properties:
+      Name: !Ref pStageBRepository
+#      Path: !Ref pSdlfGitLabGroup
+
+  rDatalakeLibraryGitLab:
+    Type: GitLab::Projects::Project
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+          - E3001
+    Properties:
+      Name: !Ref pDatalakeLibraryRepository
+#      Path: !Ref pSdlfGitLabGroup
+
+  rMainGitLab:
+    Type: GitLab::Projects::Project
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+          - E3001
+    Properties:
+      Name: !Ref pMainRepository
+#      Path: !Ref pSdlfGitLabGroup
+
+  rMonitoringGitLab:
+    Type: GitLab::Projects::Project
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+          - E3001
+    Condition: EnableMonitoring
+    Properties:
+      Name: !Ref pMonitoringRepository
+#      Path: !Ref pSdlfGitLabGroup
+
+  rSdlfGitLabGroupSsm:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: /SDLF/GitLab/SdlfGitLabGroup
+      Type: String
+      Value: !Ref pSdlfGitLabGroup # !GetAtt rSdlfGitLabGroup.Name
+      Description: Name of the GitLab group for SDLF default repositories
+
+  rCicdGitLabSsm:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: /SDLF/GitLab/CicdGitLab
+      Type: String
+      Value: !Ref pCicdRepository # !GetAtt rCicdGitLab.Name
+      Description: Name of the Cicd repository
+
+  rFoundationsGitLabSsm:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: /SDLF/GitLab/FoundationsGitLab
+      Type: String
+      Value: !Ref pFoundationsRepository # !GetAtt rFoundationsGitLab.Name
+      Description: Name of the Foundations repository
+
+  rTeamGitLabSsm:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: /SDLF/GitLab/TeamGitLab
+      Type: String
+      Value: !Ref pTeamRepository # !GetAtt rTeamGitLab.Name
+      Description: Name of the Team repository
+
+  rPipelineGitLabSsm:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: /SDLF/GitLab/PipelineGitLab
+      Type: String
+      Value: !Ref pPipelineRepository # !GetAtt rPipelineGitLab.Name
+      Description: Name of the Pipeline repository
+
+  rDatasetGitLabSsm:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: /SDLF/GitLab/DatasetGitLab
+      Type: String
+      Value: !Ref pDatasetRepository # !GetAtt rDatasetGitLab.Name
+      Description: Name of the Dataset repository
+
+  rStageAGitLabSsm:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: /SDLF/GitLab/StageAGitLab
+      Type: String
+      Value: !Ref pStageARepository # !GetAtt rStageAGitLab.Name
+      Description: Name of the StageA repository
+
+  rStageBGitLabSsm:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: /SDLF/GitLab/StageBGitLab
+      Type: String
+      Value: !Ref pStageBRepository # !GetAtt rStageBGitLab.Name
+      Description: Name of the StageB repository
+
+  rDatalakeLibraryGitLabSsm:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: /SDLF/GitLab/DatalakeLibraryGitLab
+      Type: String
+      Value: !Ref pDatalakeLibraryRepository # !GetAtt rDatalakeLibraryGitLab.Name
+      Description: Name of the DatalakeLibrary repository
+
+  rUtilsGitLabSsm:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: /SDLF/GitLab/UtilsGitLab
+      Type: String
+      Value: !Ref pUtilsRepository
+      Description: Name of the Utils repository
+
+  rMainGitLabSsm:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: /SDLF/GitLab/MainGitLab
+      Type: String
+      Value: !Ref pMainRepository # !GetAtt rMainGitLab.Name
+      Description: Name of the main repository
+
+  rMonitoringGitLabSsm:
+    Type: AWS::SSM::Parameter
+    Condition: EnableMonitoring
+    Properties:
+      Name: /SDLF/GitLab/MonitoringGitLab
+      Type: String
+      Value: !Ref pMonitoringRepository # !GetAtt rMonitoringGitLab.Name
+      Description: Name of the monitoring repository
+
+Outputs:
+  # workaround {{resolve:ssm:}} not returning an array that can be used directly in VpcConfig blocks
+  oKmsKey:
+    Description: CICD KMS Key
+    Value: !Ref pKMSKey

--- a/sdlf-cicd/template-cicd-team-pipeline.yaml
+++ b/sdlf-cicd/template-cicd-team-pipeline.yaml
@@ -1,4 +1,4 @@
-AWSTemplateFormatVersion: 2010-09-09
+AWSTemplateFormatVersion: "2010-09-09"
 Description: CICD resources to handle deployment of a new team
 
 Parameters:
@@ -54,6 +54,10 @@ Parameters:
     Description: Add Glue job deployer infrastructure and pipeline stages
     Type: AWS::SSM::Parameter::Value<String>
     Default: /SDLF/GlueJobDeployer/Enabled
+  pGitPlatform:
+    Description: Platform used to host git repositories
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: /SDLF/Misc/GitPlatform
   pCicdRepository:
     Description: Name of the Cicd repository
     Type: AWS::SSM::Parameter::Value<String>
@@ -92,6 +96,8 @@ Mappings:
       branch: main
 
 Conditions:
+  CodeCommitNoGitLab: !Equals [!Ref pGitPlatform, "CodeCommit"]
+  GitLabNoCodeCommit: !Equals [!Ref pGitPlatform, "GitLab"]
   EnableLambdaLayerBuilder: !Equals [!Ref pEnableLambdaLayerBuilder, true]
   EnableGlueJobDeployer: !Equals [!Ref pEnableGlueJobDeployer, true]
   EnableOptionalFeatures: !Or [!Condition EnableLambdaLayerBuilder, !Condition EnableGlueJobDeployer]
@@ -103,7 +109,7 @@ Resources:
     Properties:
       Description: Role assumed by CodePipeline to fetch CloudFormation templates from the team main repository
       AssumeRolePolicyDocument:
-        Version: 2012-10-17
+        Version: "2012-10-17"
         Statement:
           - Effect: Allow
             Principal:
@@ -114,25 +120,55 @@ Resources:
       Policies:
         - PolicyName: root
           PolicyDocument:
-            Version: 2012-10-17
+            Version: "2012-10-17"
             Statement:
-              - Effect: Allow
-                Action:
-                  - codecommit:GetBranch
-                  - codecommit:GetCommit
-                  - codecommit:GitPull
-                  - codecommit:GetRepository
-                  - codecommit:UploadArchive
-                  - codecommit:GetUploadArchiveStatus
-                  - codecommit:CancelUploadArchive
-                Resource:
-                  - !Sub "arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:{{resolve:ssm:/SDLF/CodeCommit/${pTeamName}/MainCodeCommit}}"
-                  - !Sub arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:${pCicdRepository}
-                  - !Sub arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:${pDatalakeLibraryRepository}
-                  - !Sub arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:${pPipelineRepository}
-                  - !Sub arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:${pStageARepository}
-                  - !Sub arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:${pStageBRepository}
-                  - !Sub arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:${pDatasetRepository}
+              - !If
+                - CodeCommitNoGitLab
+                - Effect: Allow
+                  Action:
+                    - codecommit:GetBranch
+                    - codecommit:GetCommit
+                    - codecommit:GitPull
+                    - codecommit:GetRepository
+                    - codecommit:UploadArchive
+                    - codecommit:GetUploadArchiveStatus
+                    - codecommit:CancelUploadArchive
+                  Resource:
+                    - !Sub "arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:{{resolve:ssm:/SDLF/CodeCommit/${pTeamName}/MainCodeCommit}}"
+                    - !Sub arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:${pCicdRepository}
+                    - !Sub arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:${pDatalakeLibraryRepository}
+                    - !Sub arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:${pPipelineRepository}
+                    - !Sub arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:${pStageARepository}
+                    - !Sub arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:${pStageBRepository}
+                    - !Sub arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:${pDatasetRepository}
+                - !Ref "AWS::NoValue"
+              - !If
+                - GitLabNoCodeCommit
+                - Effect: Allow
+                  Action:
+                    - codeconnections:UseConnection
+                    - codestar-connections:UseConnection
+                  Resource:
+                    - !Sub "{{resolve:ssm:/SDLF/${pGitPlatform}/CodeConnection}}"
+                  Condition:
+                    "ForAllValues:StringLikeIfExists":
+                      "codeconnections:FullRepositoryId":
+                        - !Sub "{{resolve:ssm:/SDLF/GitLab/SdlfGitLabGroup}}/{{resolve:ssm:/SDLF/CodeCommit/${pTeamName}/MainCodeCommit}}"
+                        - !Sub "{{resolve:ssm:/SDLF/GitLab/SdlfGitLabGroup}}/${pCicdRepository}"
+                        - !Sub "{{resolve:ssm:/SDLF/GitLab/SdlfGitLabGroup}}/${pDatalakeLibraryRepository}"
+                        - !Sub "{{resolve:ssm:/SDLF/GitLab/SdlfGitLabGroup}}/${pPipelineRepository}"
+                        - !Sub "{{resolve:ssm:/SDLF/GitLab/SdlfGitLabGroup}}/${pStageARepository}"
+                        - !Sub "{{resolve:ssm:/SDLF/GitLab/SdlfGitLabGroup}}/${pStageBRepository}"
+                        - !Sub "{{resolve:ssm:/SDLF/GitLab/SdlfGitLabGroup}}/${pDatasetRepository}"
+                      "codestar-connections:FullRepositoryId":
+                        - !Sub "{{resolve:ssm:/SDLF/GitLab/SdlfGitLabGroup}}/{{resolve:ssm:/SDLF/CodeCommit/${pTeamName}/MainCodeCommit}}"
+                        - !Sub "{{resolve:ssm:/SDLF/GitLab/SdlfGitLabGroup}}/${pCicdRepository}"
+                        - !Sub "{{resolve:ssm:/SDLF/GitLab/SdlfGitLabGroup}}/${pDatalakeLibraryRepository}"
+                        - !Sub "{{resolve:ssm:/SDLF/GitLab/SdlfGitLabGroup}}/${pPipelineRepository}"
+                        - !Sub "{{resolve:ssm:/SDLF/GitLab/SdlfGitLabGroup}}/${pStageARepository}"
+                        - !Sub "{{resolve:ssm:/SDLF/GitLab/SdlfGitLabGroup}}/${pStageBRepository}"
+                        - !Sub "{{resolve:ssm:/SDLF/GitLab/SdlfGitLabGroup}}/${pDatasetRepository}"
+                - !Ref "AWS::NoValue"
               - Effect: Allow
                 Action:
                   - s3:Get*
@@ -168,7 +204,7 @@ Resources:
                     - !Ref AWS::NoValue
         - PolicyName: sdlf-cicd-cloudformation
           PolicyDocument:
-            Version: 2012-10-17
+            Version: "2012-10-17"
             Statement:
               - Effect: Allow
                 Action: sts:AssumeRole
@@ -181,105 +217,197 @@ Resources:
       RoleArn: !GetAtt rTeamMainCodePipelineRole.Arn
       Stages:
         - Name: Sources
-          Actions:
-            - Name: Source
-              ActionTypeId:
-                Category: Source
-                Owner: AWS
-                Provider: CodeCommit
-                Version: "1"
-              OutputArtifacts:
-                - Name: TemplateSource
-              Configuration:
-                RepositoryName: !Sub "{{resolve:ssm:/SDLF/CodeCommit/${pTeamName}/MainCodeCommit}}"
-                BranchName:
-                  !FindInMap [pCodeCommitBranch, !Ref pEnvironment, branch]
-                PollForSourceChanges: false
-              RunOrder: 1
-            -
-              Name: SourceCicd
-              ActionTypeId:
-                Category: Source
-                Owner: AWS
-                Provider: CodeCommit
-                Version: "1"
-              OutputArtifacts:
-                - Name: SourceCicdArtifact
-              Configuration:
-                RepositoryName: !Ref pCicdRepository
-                BranchName: !FindInMap [pCodeCommitBranch, !Ref pEnvironment, branch]
-                PollForSourceChanges: false
-              RunOrder: 1
-            -
-              Name: SourceDatalakeLibrary
-              ActionTypeId:
-                Category: Source
-                Owner: AWS
-                Version: "1"
-                Provider: CodeCommit
-              OutputArtifacts:
-                - Name: SourceDatalakeLibraryArtifact
-              Configuration:
-                RepositoryName: !Ref pDatalakeLibraryRepository
-                BranchName: !FindInMap [pCodeCommitBranch, !Ref pEnvironment, branch]
-                PollForSourceChanges: false
-              RunOrder: 1
-            -
-              Name: SourcePipeline
-              ActionTypeId:
-                Category: Source
-                Owner: AWS
-                Version: "1"
-                Provider: CodeCommit
-              OutputArtifacts:
-                - Name: SourcePipelineArtifact
-              Configuration:
-                RepositoryName: !Ref pPipelineRepository
-                BranchName: !FindInMap [pCodeCommitBranch, !Ref pEnvironment, branch]
-                PollForSourceChanges: false
-              RunOrder: 1
-            -
-              Name: SourceStageA
-              ActionTypeId:
-                Category: Source
-                Owner: AWS
-                Version: "1"
-                Provider: CodeCommit
-              OutputArtifacts:
-                - Name: SourceStageAArtifact
-              Configuration:
-                RepositoryName: !Ref pStageARepository
-                BranchName: !FindInMap [pCodeCommitBranch, !Ref pEnvironment, branch]
-                PollForSourceChanges: false
-              RunOrder: 1
-            -
-              Name: SourceStageB
-              ActionTypeId:
-                Category: Source
-                Owner: AWS
-                Version: "1"
-                Provider: CodeCommit
-              OutputArtifacts:
-                - Name: SourceStageBArtifact
-              Configuration:
-                RepositoryName: !Ref pStageBRepository
-                BranchName: !FindInMap [pCodeCommitBranch, !Ref pEnvironment, branch]
-                PollForSourceChanges: false
-              RunOrder: 1
-            -
-              Name: SourceDataset
-              ActionTypeId:
-                Category: Source
-                Owner: AWS
-                Version: "1"
-                Provider: CodeCommit
-              OutputArtifacts:
-                - Name: SourceDatasetArtifact
-              Configuration:
-                RepositoryName: !Ref pDatasetRepository
-                BranchName: !FindInMap [pCodeCommitBranch, !Ref pEnvironment, branch]
-                PollForSourceChanges: false
-              RunOrder: 1
+          Actions: !If
+            - CodeCommitNoGitLab
+            - - Name: Source
+                ActionTypeId:
+                  Category: Source
+                  Owner: AWS
+                  Provider: CodeCommit
+                  Version: "1"
+                OutputArtifacts:
+                  - Name: TemplateSource
+                Configuration:
+                  RepositoryName: !Sub "{{resolve:ssm:/SDLF/CodeCommit/${pTeamName}/MainCodeCommit}}"
+                  BranchName: !FindInMap [pCodeCommitBranch, !Ref pEnvironment, branch]
+                  PollForSourceChanges: false
+                RunOrder: 1
+              - Name: SourceCicd
+                ActionTypeId:
+                  Category: Source
+                  Owner: AWS
+                  Provider: CodeCommit
+                  Version: "1"
+                OutputArtifacts:
+                  - Name: SourceCicdArtifact
+                Configuration:
+                  RepositoryName: !Ref pCicdRepository
+                  BranchName: !FindInMap [pCodeCommitBranch, !Ref pEnvironment, branch]
+                  PollForSourceChanges: false
+                RunOrder: 1
+              - Name: SourceDatalakeLibrary
+                ActionTypeId:
+                  Category: Source
+                  Owner: AWS
+                  Provider: CodeCommit
+                  Version: "1"
+                OutputArtifacts:
+                  - Name: SourceDatalakeLibraryArtifact
+                Configuration:
+                  RepositoryName: !Ref pDatalakeLibraryRepository
+                  BranchName: !FindInMap [pCodeCommitBranch, !Ref pEnvironment, branch]
+                  PollForSourceChanges: false
+                RunOrder: 1
+              - Name: SourcePipeline
+                ActionTypeId:
+                  Category: Source
+                  Owner: AWS
+                  Provider: CodeCommit
+                  Version: "1"
+                OutputArtifacts:
+                  - Name: SourcePipelineArtifact
+                Configuration:
+                  RepositoryName: !Ref pPipelineRepository
+                  BranchName: !FindInMap [pCodeCommitBranch, !Ref pEnvironment, branch]
+                  PollForSourceChanges: false
+                RunOrder: 1
+              - Name: SourceStageA
+                ActionTypeId:
+                  Category: Source
+                  Owner: AWS
+                  Provider: CodeCommit
+                  Version: "1"
+                OutputArtifacts:
+                  - Name: SourceStageAArtifact
+                Configuration:
+                  RepositoryName: !Ref pStageARepository
+                  BranchName: !FindInMap [pCodeCommitBranch, !Ref pEnvironment, branch]
+                  PollForSourceChanges: false
+                RunOrder: 1
+              - Name: SourceStageB
+                ActionTypeId:
+                  Category: Source
+                  Owner: AWS
+                  Provider: CodeCommit
+                  Version: "1"
+                OutputArtifacts:
+                  - Name: SourceStageBArtifact
+                Configuration:
+                  RepositoryName: !Ref pStageBRepository
+                  BranchName: !FindInMap [pCodeCommitBranch, !Ref pEnvironment, branch]
+                  PollForSourceChanges: false
+                RunOrder: 1
+              - Name: SourceDataset
+                ActionTypeId:
+                  Category: Source
+                  Owner: AWS
+                  Provider: CodeCommit
+                  Version: "1"
+                OutputArtifacts:
+                  - Name: SourceDatasetArtifact
+                Configuration:
+                  RepositoryName: !Ref pDatasetRepository
+                  BranchName: !FindInMap [pCodeCommitBranch, !Ref pEnvironment, branch]
+                  PollForSourceChanges: false
+                RunOrder: 1
+            - - Name: Source
+                ActionTypeId:
+                  Category: Source
+                  Owner: AWS
+                  Provider: CodeStarSourceConnection
+                  Version: "1"
+                OutputArtifacts:
+                  - Name: TemplateSource
+                Configuration:
+                  ConnectionArn: !Sub "{{resolve:ssm:/SDLF/${pGitPlatform}/CodeConnection}}"
+                  FullRepositoryId: !Sub "{{resolve:ssm:/SDLF/GitLab/SdlfGitLabGroup}}/{{resolve:ssm:/SDLF/${pGitPlatform}/${pTeamName}/Main${pGitPlatform}}}"
+                  BranchName: !FindInMap [pCodeCommitBranch, !Ref pEnvironment, branch]
+                  OutputArtifactFormat: CODE_ZIP
+                RunOrder: 1
+              - Name: SourceCicd
+                ActionTypeId:
+                  Category: Source
+                  Owner: AWS
+                  Provider: CodeStarSourceConnection
+                  Version: "1"
+                OutputArtifacts:
+                  - Name: SourceCicdArtifact
+                Configuration:
+                  ConnectionArn: !Sub "{{resolve:ssm:/SDLF/${pGitPlatform}/CodeConnection}}"
+                  FullRepositoryId: !Sub "{{resolve:ssm:/SDLF/GitLab/SdlfGitLabGroup}}/${pCicdRepository}"
+                  BranchName: !FindInMap [pCodeCommitBranch, !Ref pEnvironment, branch]
+                  OutputArtifactFormat: CODE_ZIP
+                RunOrder: 1
+              - Name: SourceDatalakeLibrary
+                ActionTypeId:
+                  Category: Source
+                  Owner: AWS
+                  Provider: CodeStarSourceConnection
+                  Version: "1"
+                OutputArtifacts:
+                  - Name: SourceDatalakeLibraryArtifact
+                Configuration:
+                  ConnectionArn: !Sub "{{resolve:ssm:/SDLF/${pGitPlatform}/CodeConnection}}"
+                  FullRepositoryId: !Sub "{{resolve:ssm:/SDLF/GitLab/SdlfGitLabGroup}}/${pDatalakeLibraryRepository}"
+                  BranchName: !FindInMap [pCodeCommitBranch, !Ref pEnvironment, branch]
+                  OutputArtifactFormat: CODE_ZIP
+                RunOrder: 1
+              - Name: SourcePipeline
+                ActionTypeId:
+                  Category: Source
+                  Owner: AWS
+                  Provider: CodeStarSourceConnection
+                  Version: "1"
+                OutputArtifacts:
+                  - Name: SourcePipelineArtifact
+                Configuration:
+                  ConnectionArn: !Sub "{{resolve:ssm:/SDLF/${pGitPlatform}/CodeConnection}}"
+                  FullRepositoryId: !Sub "{{resolve:ssm:/SDLF/GitLab/SdlfGitLabGroup}}/${pPipelineRepository}"
+                  BranchName: !FindInMap [pCodeCommitBranch, !Ref pEnvironment, branch]
+                  OutputArtifactFormat: CODE_ZIP
+                RunOrder: 1
+              - Name: SourceStageA
+                ActionTypeId:
+                  Category: Source
+                  Owner: AWS
+                  Provider: CodeStarSourceConnection
+                  Version: "1"
+                OutputArtifacts:
+                  - Name: SourceStageAArtifact
+                Configuration:
+                  ConnectionArn: !Sub "{{resolve:ssm:/SDLF/${pGitPlatform}/CodeConnection}}"
+                  FullRepositoryId: !Sub "{{resolve:ssm:/SDLF/GitLab/SdlfGitLabGroup}}/${pStageARepository}"
+                  BranchName: !FindInMap [pCodeCommitBranch, !Ref pEnvironment, branch]
+                  OutputArtifactFormat: CODE_ZIP
+                RunOrder: 1
+              - Name: SourceStageB
+                ActionTypeId:
+                  Category: Source
+                  Owner: AWS
+                  Provider: CodeStarSourceConnection
+                  Version: "1"
+                OutputArtifacts:
+                  - Name: SourceStageBArtifact
+                Configuration:
+                  ConnectionArn: !Sub "{{resolve:ssm:/SDLF/${pGitPlatform}/CodeConnection}}"
+                  FullRepositoryId: !Sub "{{resolve:ssm:/SDLF/GitLab/SdlfGitLabGroup}}/${pStageBRepository}"
+                  BranchName: !FindInMap [pCodeCommitBranch, !Ref pEnvironment, branch]
+                  OutputArtifactFormat: CODE_ZIP
+                RunOrder: 1
+              - Name: SourceDataset
+                ActionTypeId:
+                  Category: Source
+                  Owner: AWS
+                  Provider: CodeStarSourceConnection
+                  Version: "1"
+                OutputArtifacts:
+                  - Name: SourceDatasetArtifact
+                Configuration:
+                  ConnectionArn: !Sub "{{resolve:ssm:/SDLF/${pGitPlatform}/CodeConnection}}"
+                  FullRepositoryId: !Sub "{{resolve:ssm:/SDLF/GitLab/SdlfGitLabGroup}}/${pDatasetRepository}"
+                  BranchName: !FindInMap [pCodeCommitBranch, !Ref pEnvironment, branch]
+                  OutputArtifactFormat: CODE_ZIP
+                RunOrder: 1
         - !If
           - EnableOptionalFeatures
           - Name: BuildOptionalFeatures
@@ -602,9 +730,10 @@ Resources:
 
   rTeamMainCodeCommitTriggerRole:
     Type: AWS::IAM::Role
+    Condition: CodeCommitNoGitLab
     Properties:
       AssumeRolePolicyDocument:
-        Version: 2012-10-17
+        Version: "2012-10-17"
         Statement:
           - Effect: Allow
             Principal:
@@ -614,7 +743,7 @@ Resources:
       Policies:
         - PolicyName: sdlf-cicd-trigger-rule
           PolicyDocument:
-            Version: 2012-10-17
+            Version: "2012-10-17"
             Statement:
               - Effect: Allow
                 Action: codepipeline:StartPipelineExecution
@@ -623,6 +752,7 @@ Resources:
 
   rTeamMainCodeCommitTriggerRule:
     Type: AWS::Events::Rule
+    Condition: CodeCommitNoGitLab
     Properties:
       State: ENABLED
       EventPattern:

--- a/sdlf-cicd/template-cicd-team-repository.yaml
+++ b/sdlf-cicd/template-cicd-team-repository.yaml
@@ -1,4 +1,4 @@
-AWSTemplateFormatVersion: 2010-09-09
+AWSTemplateFormatVersion: "2010-09-09"
 Description: CICD resources to handle deployment of a new team (repository)
 
 Parameters:
@@ -13,13 +13,22 @@ Parameters:
   pTeamName:
     Description: Team name
     Type: String
+  pGitPlatform:
+    Description: Platform used to host git repositories
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: /SDLF/Misc/GitPlatform
   pMainRepositoriesPrefix:
     Type: String
     Default: sdlf-main-
 
+Conditions:
+  CodeCommitNoGitLab: !Equals [!Ref pGitPlatform, "CodeCommit"]
+  GitLabNoCodeCommit: !Equals [!Ref pGitPlatform, "GitLab"]
+
 Resources:
   rTeamMainCodeCommit:
     Type: AWS::CodeCommit::Repository
+    Condition: CodeCommitNoGitLab
     Metadata:
       cfn-lint:
         config:
@@ -33,10 +42,25 @@ Resources:
       RepositoryName: !Sub ${pMainRepositoriesPrefix}${pDomain}-${pTeamName}
       KmsKeyId: !Ref pKMSKey
 
+  rTeamMainGitLab:
+    Type: GitLab::Projects::Project
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+          - E3001
+    Condition: GitLabNoCodeCommit
+    Properties:
+      Name: !Sub ${pMainRepositoriesPrefix}${pDomain}-${pTeamName}
+#      Path: !Ref pSdlfGitLabGroup
+
   rTeamMainCodeCommitSsm:
     Type: AWS::SSM::Parameter
     Properties:
-      Name: !Sub /SDLF/CodeCommit/${pTeamName}/MainCodeCommit
+      Name: !Sub /SDLF/${pGitPlatform}/${pTeamName}/Main${pGitPlatform}
       Type: String
-      Value: !GetAtt rTeamMainCodeCommit.Name
+      Value: !If
+        - CodeCommitNoGitLab
+        - !GetAtt rTeamMainCodeCommit.Name
+        - !Sub ${pMainRepositoriesPrefix}${pDomain}-${pTeamName} # !GetAtt rTeamMainGitLab.Name
       Description: !Sub Name of the ${pDomain} ${pTeamName} main repository


### PR DESCRIPTION
*Issue #, if available:*
#270 

*Description of changes:*
Replace CodeCommit entirely with GitLab - all SDLF repositories (components, main and team repositories) can now be hosted on GitLab. This does *not* replace CodeBuild and CodePipeline, GitLab CI/CD is not used.

Creating repositories is done through CloudFormation third-party resource types: https://github.com/aws-ia/cloudformation-gitlab-resource-providers/tree/main/GitLab-Projects-Project

Currently SDLF is very rigid in terms of setup for GitLab, in part due to limitations of the aforementioned resource types.
* Setup a CodeConnection to your GitLab instance.
* Populate `/SDLF/GitLab/CodeConnection` in SSM Parameter Store with the ARN of the CodeConnection.
* Populate `/SDLF/GitLab/Url` in SSM Parameter Store as a secure string with the URL of the GitLab instance, including a trailing slash.
* Create a dedicated `sdlf` user on GitLab, and an access token named `aws` with this user, providing the `api` and `repository write` permissions.
* Put the token in `/SDLF/GitLab/AccessToken` in SSM Parameter Store as a secure string.
* Enable the third-party resource type `GitLab:Projects:Project` on CloudFormation Registry. Do not forget to configure it.
* Use `-f gitlab` when deploying SDLF with `deploy.sh`.

Resource type configuration example:
```
{
    "GitLabAccess": {
        "AccessToken": "{{resolve:ssm-secure:/SDLF/GitLab/AccessToken:1}}",
        "Url": "{{resolve:ssm-secure:/SDLF/GitLab/Url:1}}"
    }
}
```

This is a first stab at supporting third-party managed Git services.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
