### PR TITLE
force use of cfn-lint 0.87.7 since release 1.3.0 break cloudformation-cli

### DIFF
--- a/sdlf-cicd/nested-stacks/template-cicd-cfn-module.yaml
+++ b/sdlf-cicd/nested-stacks/template-cicd-cfn-module.yaml
@@ -167,7 +167,9 @@ Resources:
                     && unzip -q aws-sam-cli-linux-x86_64.zip -d sam-installation
                     ./sam-installation/install \
                     && sam --version
-                - pip3 install cloudformation-cli
+                - |-
+                    pip3 install cfn-lint==0.87.7
+                    pip3 install cloudformation-cli
                 - aws s3api get-object --bucket "$ARTIFACTS_BUCKET" --key sam-translate.py sam-translate.py
             build:
               commands:


### PR DESCRIPTION
*Description of changes:*
It looks like the [latest update](https://github.com/aws-cloudformation/cfn-lint/releases/tag/v1.3.0) from cfn-lint (1.3.0, up from 0.87.7 if we ignore alpha releases) broke cloudformation-cli module submission:

```
Initializing new project
Directory  /codebuild/output/src4169/src/s3/00/module/fragments  Created 
Initialized a new project in /codebuild/output/src4169/src/s3/00/module
=== Unhandled exception ===
Please report this issue to the team.
Issue tracker: github.com/aws-cloudformation/cloudformation-cli/issues
Please include the log file 'rpdk.log'
{
    "ETag": "\"604bd20b47c2aa7f201f21e36245d5c4\"",
    "ServerSideEncryption": "aws:kms",
    "SSEKMSKeyId": "arn:aws:kms:eu-west-1:111111111111:key/fxxx3",
    "BucketKeyEnabled": true
}
```

Full `rpdk.log`:
```
[2024-06-20T09:55:06Z] DEBUG    - Logging set up successfully
[2024-06-20T09:55:06Z] DEBUG    - Running None: Namespace(version=False, subparser_name=None, command=<function init at 0x7f8927b20cc0>, verbose=0, force=False, type_name='awslabs::sdlf::foundations::MODULE', artifact_type='MODULE', endpoint_url=None, region=None, target_schemas=[], profile=None)
[2024-06-20T09:55:06Z] DEBUG    - Root directory: /codebuild/output/src4169/src/s3/00/module
[2024-06-20T09:55:06Z] WARNING  - Initializing new project
[2024-06-20T09:55:06Z] DEBUG    - Loading project file '/codebuild/output/src4169/src/s3/00/module/.rpdk-config'
[2024-06-20T09:55:06Z] DEBUG    - Overwriting '/codebuild/output/src4169/src/s3/00/module/.rpdk-config'
[2024-06-20T09:55:06Z] DEBUG    - Fragment directory: /codebuild/output/src4169/src/s3/00/module/fragments
[2024-06-20T09:55:06Z] DEBUG    - Overwriting '/codebuild/output/src4169/src/s3/00/module/fragments/sample.json'
[2024-06-20T09:55:06Z] WARNING  - Initialized a new project in /codebuild/output/src4169/src/s3/00/module
[2024-06-20T09:55:06Z] DEBUG    - Finished None
[2024-06-20T09:55:07Z] DEBUG    - Logging set up successfully
[2024-06-20T09:55:07Z] DEBUG    - Running generate: Namespace(version=False, subparser_name='generate', command=<function generate at 0x7f9896d26840>, verbose=0, endpoint_url=None, region=None, local_only=False, target_schemas=[], profile=None)
[2024-06-20T09:55:07Z] DEBUG    - Root directory: /codebuild/output/src4169/src/s3/00/module
[2024-06-20T09:55:07Z] DEBUG    - Loading project file '/codebuild/output/src4169/src/s3/00/module/.rpdk-config'
[2024-06-20T09:55:07Z] INFO     - Validating your module fragments...
[2024-06-20T09:55:07Z] DEBUG    - Fragment directory: /codebuild/output/src4169/src/s3/00/module/fragments
[2024-06-20T09:55:07Z] DEBUG    - Unhandled exception
Traceback (most recent call last):
  File "/root/.pyenv/versions/3.12.2/lib/python3.12/site-packages/rpdk/core/cli.py", line 105, in main
    args.command(args)
  File "/root/.pyenv/versions/3.12.2/lib/python3.12/site-packages/rpdk/core/generate.py", line 14, in generate
    project.load()
  File "/root/.pyenv/versions/3.12.2/lib/python3.12/site-packages/rpdk/core/project.py", line 619, in load
    self._load_modules_project()
  File "/root/.pyenv/versions/3.12.2/lib/python3.12/site-packages/rpdk/core/project.py", line 642, in _load_modules_project
    self._validate_fragments(template_fragment)
  File "/root/.pyenv/versions/3.12.2/lib/python3.12/site-packages/rpdk/core/project.py", line 673, in _validate_fragments
    template_fragment.validate_fragments()
  File "/root/.pyenv/versions/3.12.2/lib/python3.12/site-packages/rpdk/core/fragment/generator.py", line 78, in validate_fragments
    print_cfn_lint_warnings(self.fragment_dir)
  File "/root/.pyenv/versions/3.12.2/lib/python3.12/site-packages/rpdk/core/fragment/lint_warning_printer.py", line 13, in print_cfn_lint_warnings
    lint_warnings = __get_cfn_lint_matches(fragment_dir)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/.pyenv/versions/3.12.2/lib/python3.12/site-packages/rpdk/core/fragment/lint_warning_printer.py", line 51, in __get_cfn_lint_matches
    matches = cfnlint.core.run_checks(filepath, template, rules, regions)
              ^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: module 'cfnlint.core' has no attribute 'run_checks'
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
