### PR TITLE
pin cfn-lint to <1 instead of 0.87.7

### DIFF
--- a/sdlf-cicd/nested-stacks/template-cicd-cfn-module.yaml
+++ b/sdlf-cicd/nested-stacks/template-cicd-cfn-module.yaml
@@ -168,7 +168,7 @@ Resources:
                     ./sam-installation/install \
                     && sam --version
                 - |-
-                    pip3 install cfn-lint==0.87.7
+                    pip3 install "cfn-lint<1"
                     pip3 install cloudformation-cli
                 - aws s3api get-object --bucket "$ARTIFACTS_BUCKET" --key sam-translate.py sam-translate.py
             build:


### PR DESCRIPTION
*Description of changes:*
Related to #341 
It's better to pin to `<1` instead of `0.87.7` to keep receiving minor updates.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
