### PR TITLE
SeedFarmer Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -153,3 +153,6 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
+
+# AWS CodeSeeder/SeedFarmer
+codeseeder.out/

--- a/docs/constructs/foundations.md
+++ b/docs/constructs/foundations.md
@@ -11,7 +11,7 @@
 
 - **Raw:** All data ingested from various data sources into the data lake lands in the raw bucket, in their original data format (*raw*). This can include structured, semi-structured, and unstructured data objects such as databases, backups, archives, JSON, CSV, XML, text files, or images.
 - **Stage:** After raw data have been transformed or normalized through data pipelines, it is stored in a staging bucket (also called *transformed*). In this stage, data can be transformed into columnar data formats such as Apache Parquet and Apache ORC. These formats can be used by Amazon Athena.
-- **Analytics:** Transformed data can be further enreched by blending other datasets to provide additional insights. This layer typically contains S3 objects which are optimized for analytics, reporting using Amazon Athena, Amazon Redshift Spectrum, and loading into massively-parallel processing data warehouses such as Amazon Redshift.
+- **Analytics:** Transformed data can be further enriched by blending other datasets to provide additional insights. This layer typically contains S3 objects which are optimized for analytics, reporting using Amazon Athena, Amazon Redshift Spectrum, and loading into massively-parallel processing data warehouses such as Amazon Redshift.
 
 An important building block of a data lake on AWS is [AWS Lake Formation](https://aws.amazon.com/lake-formation/). It allows managing fine-grained data access permissions and share data. `sdlf-foundations` enables Lake Formation and register the previous buckets so that they can be managed through it.
 

--- a/sdlf-cicd/template-generic-cfn-module.yaml
+++ b/sdlf-cicd/template-generic-cfn-module.yaml
@@ -1,0 +1,40 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: Deploy a CloudFormation module
+
+Parameters:
+  pArtifactsBucket:
+    Description: The artifacts bucket used by CodeBuild and CodePipeline
+    Type: String
+  pLibraryOrg:
+    Description: Name of the org (all lowercase, no symbols or spaces)
+    Type: String
+  pLibraryFramework:
+    Description: Name of the framework (all lowercase, no symbols or spaces)
+    Type: String
+  pLibraryModule:
+    Description: Name of the module
+    Type: String
+  pModuleGitRef:
+    Description: Git reference (commit id) with the sources of this module version
+    Type: String
+
+Resources:
+  rCloudFormationModule:
+      Type: AWS::CloudFormation::ModuleVersion
+      Properties:
+        ModuleName: !Sub "${pLibraryOrg}::${pLibraryFramework}::${pLibraryModule}::MODULE"
+        ModulePackage: !Sub "s3://${pArtifactsBucket}/modules/${pLibraryOrg}/${pLibraryFramework}/${pLibraryModule}-${pModuleGitRef}.zip"
+
+  rCloudFormationModuleDefaultVersion:
+    Type: AWS::CloudFormation::ModuleDefaultVersion
+    Properties:
+      Arn: !Ref rCloudFormationModule
+
+  rCloudFormationModuleSsm:
+    Type: AWS::SSM::Parameter
+    DependsOn: rCloudFormationModuleDefaultVersion
+    Properties:
+      Name: !Sub /SDLF/CFN/${pLibraryOrg}-${pLibraryFramework}-${pLibraryModule}-MODULE
+      Type: String
+      Value: !Ref pModuleGitRef
+      Description: Git reference (commit id) with the sources of this module version

--- a/sdlf-foundations/deployspec.yaml
+++ b/sdlf-foundations/deployspec.yaml
@@ -1,0 +1,150 @@
+publishGenericEnvVariables: true
+deploy:
+  phases:
+    install:
+      runtime-versions:
+        python: 3.12
+      commands:
+        - |-
+            export ARTIFACTS_BUCKET=$(aws cloudformation describe-stacks --query "Stacks[?StackName=='aws-codeseeder-$SEEDFARMER_PROJECT_NAME'][].Outputs[?OutputKey=='Bucket'].OutputValue" --output text)
+            export DIRNAME=$(pwd)
+
+            aws s3api get-object --bucket "$ARTIFACTS_BUCKET" --key sam-translate.py sam-translate.py || {
+              curl -L -O https://raw.githubusercontent.com/aws/serverless-application-model/develop/bin/sam-translate.py
+              aws --region "$AWS_REGION" s3api put-object --bucket "$ARTIFACTS_BUCKET" --key sam-translate.py --body "$DIRNAME"/sam-translate.py
+            }
+
+            aws s3api get-object --bucket "$ARTIFACTS_BUCKET" --key aws-sam-cli-linux-x86_64.zip aws-sam-cli-linux-x86_64.zip || {
+              curl -L -O --output-dir "$DIRNAME" https://github.com/aws/aws-sam-cli/releases/latest/download/aws-sam-cli-linux-x86_64.zip
+              aws --region "$AWS_REGION" s3api put-object --bucket "$ARTIFACTS_BUCKET" --key aws-sam-cli-linux-x86_64.zip --body "$DIRNAME"/aws-sam-cli-linux-x86_64.zip
+            }
+
+            aws s3api get-object --bucket "$ARTIFACTS_BUCKET" --key template-generic-cfn-module.yaml template-generic-cfn-module.yaml || {
+              curl -L -O https://raw.githubusercontent.com/awslabs/aws-serverless-data-lake-framework/main/sdlf-cicd/template-generic-cfn-module.yaml
+              aws --region "$AWS_REGION" s3api put-object --bucket "$ARTIFACTS_BUCKET" --key template-generic-cfn-module.yaml --body "$DIRNAME"/template-generic-cfn-module.yaml
+            }
+        - |-
+            pip3 uninstall -y aws-sam-cli && unzip -q aws-sam-cli-linux-x86_64.zip -d sam-installation
+            ./sam-installation/install \
+            && sam --version
+            pip3 install "cfn-lint<1"
+            pip3 install cloudformation-cli
+            npm install -g aws-cdk@2.149.0
+        - pip3 install -r requirements.txt
+    build:
+      commands:
+        - |-
+          # deployment-type possible values: cfn-module, cdk-construct, cdk-stack
+          # cfn-module creates a CloudFormation Registry module out of template.yaml
+          # cdk-construct publishes a pip library out of template.py on CodeArtifact
+          # cdk-stack deploys the infrastructure directly as a CloudFormation stack
+
+          if [ "$SEEDFARMER_PARAMETER_DEPLOYMENT_TYPE" = "cfn-module" ]; then
+            echo "$SEEDFARMER_PARAMETER_DEPLOYMENT_TYPE"
+            # SEEDFARMER_PARAMETER_LIBRARY_MODULE can be used to pass the module name. If not, the module name is inferred from SEEDFARMER_MODULE_NAME
+            # by removing everything up to the first hyphen, then anything that isn't a letter/number, and lower-casing everything.
+            seedfarmer_module_name_without_prefix="${SEEDFARMER_MODULE_NAME#*-}"
+            seedfarmer_module_name_alnum="${seedfarmer_module_name_without_prefix//[^[:alnum:]]/}"
+            MODULE="${seedfarmer_module_name_alnum,,}"
+
+            : "${SEEDFARMER_PARAMETER_LIBRARY_ORG:=awslabs}" "${SEEDFARMER_PARAMETER_LIBRARY_FRAMEWORK:=sdlf}" "${SEEDFARMER_PARAMETER_LIBRARY_MODULE:=$MODULE}"
+            sam package --template-file ./template.yaml --s3-bucket "$ARTIFACTS_BUCKET" --s3-prefix sdlf --output-template-file template.yaml
+            python3 sam-translate.py --template-file=template.yaml --output-template=translated-template.json
+
+            CLOUDFORMATION_ENDPOINT_URL="https://cloudformation.$AWS_REGION.amazonaws.com"
+            SSM_ENDPOINT_URL="https://ssm.$AWS_REGION.amazonaws.com"
+            STS_ENDPOINT_URL="https://sts.$AWS_REGION.amazonaws.com"
+            aws s3api put-object --bucket "$ARTIFACTS_BUCKET" \
+              --key "modules/$SEEDFARMER_PARAMETER_LIBRARY_ORG/$SEEDFARMER_PARAMETER_LIBRARY_FRAMEWORK/$SEEDFARMER_PARAMETER_LIBRARY_MODULE/translated-template.json" \
+              --body translated-template.json
+            TEMPLATE_URL="https://$ARTIFACTS_BUCKET.s3.$AWS_REGION.amazonaws.com/modules/$SEEDFARMER_PARAMETER_LIBRARY_ORG/$SEEDFARMER_PARAMETER_LIBRARY_FRAMEWORK/$SEEDFARMER_PARAMETER_LIBRARY_MODULE/translated-template.json"
+            aws cloudformation --endpoint-url "$CLOUDFORMATION_ENDPOINT_URL" validate-template --template-url "$TEMPLATE_URL"
+
+            mkdir module
+            cd module || exit
+            cfn init --artifact-type MODULE --type-name "$SEEDFARMER_PARAMETER_LIBRARY_ORG::$SEEDFARMER_PARAMETER_LIBRARY_FRAMEWORK::$SEEDFARMER_PARAMETER_LIBRARY_MODULE::MODULE" && rm fragments/sample.json
+            cp -i -a ../translated-template.json fragments/
+            cfn generate
+            zip --quiet -r "../$SEEDFARMER_PARAMETER_LIBRARY_MODULE.zip" .rpdk-config fragments/ schema.json
+
+            NEW_MODULE="$(sha256sum "../$SEEDFARMER_PARAMETER_LIBRARY_MODULE.zip" | cut -c1-12)"
+            aws s3api put-object --bucket "$ARTIFACTS_BUCKET" \
+                                  --key "modules/$SEEDFARMER_PARAMETER_LIBRARY_ORG/$SEEDFARMER_PARAMETER_LIBRARY_FRAMEWORK/$SEEDFARMER_PARAMETER_LIBRARY_MODULE-$NEW_MODULE.zip" \
+                                  --body "../$SEEDFARMER_PARAMETER_LIBRARY_MODULE.zip"
+
+            # compare hashes to avoid creating a new module version when there is no change
+            if CURRENT_MODULE=$(aws ssm --endpoint-url "$SSM_ENDPOINT_URL" get-parameter --name "/SDLF/CFN/$SEEDFARMER_PARAMETER_LIBRARY_ORG-$SEEDFARMER_PARAMETER_LIBRARY_FRAMEWORK-$SEEDFARMER_PARAMETER_LIBRARY_MODULE-MODULE" --query "Parameter.Value" --output text); then
+              echo "Current module version commit id: $CURRENT_MODULE"
+              echo "New module version commit id: $NEW_MODULE"
+              if [ "$NEW_MODULE" == "$CURRENT_MODULE" ]; then
+                echo "No change since last build, exiting module creation."
+                exit 0
+              fi
+            fi
+
+            STACK_NAME="sdlf-cfn-module-$SEEDFARMER_PARAMETER_LIBRARY_FRAMEWORK-$SEEDFARMER_PARAMETER_LIBRARY_MODULE"
+            aws cloudformation --endpoint-url "$CLOUDFORMATION_ENDPOINT_URL" deploy \
+                --stack-name "$STACK_NAME" \
+                --template-file "$DIRNAME"/template-generic-cfn-module.yaml \
+                --parameter-overrides \
+                    pArtifactsBucket="$ARTIFACTS_BUCKET" \
+                    pLibraryOrg="$SEEDFARMER_PARAMETER_LIBRARY_ORG" \
+                    pLibraryFramework="$SEEDFARMER_PARAMETER_LIBRARY_FRAMEWORK" \
+                    pLibraryModule="$SEEDFARMER_PARAMETER_LIBRARY_MODULE" \
+                    pModuleGitRef="$NEW_MODULE" \
+                --tags Framework=sdlf \
+                --capabilities "CAPABILITY_NAMED_IAM" "CAPABILITY_AUTO_EXPAND" || exit 1
+            echo "done"
+            cd .. && rm -Rf module
+          fi
+        - |-
+          if [ "$SEEDFARMER_PARAMETER_DEPLOYMENT_TYPE" = "cdk-stack" ]; then
+            echo "$SEEDFARMER_PARAMETER_DEPLOYMENT_TYPE"
+
+            cat >app.py <<EOL
+          #!/usr/bin/env python3
+          import importlib
+          import aws_cdk as cdk
+          construct = importlib.import_module("template")
+
+          app = cdk.App()
+
+          stack = cdk.Stack(app, "Stack", stack_name="$SEEDFARMER_MODULE_NAME")
+          construct.SdlfFoundations(stack, "$SEEDFARMER_MODULE_NAME")
+
+          app.synth()
+          EOL
+
+            cat app.py
+            cdk --no-previous-parameters \
+                --parameters Foundations:pOrg="$SEEDFARMER_PARAMETER_ORG" \
+                --parameters Foundations:pEnvironment="$SEEDFARMER_PARAMETER_ENVIRONMENT" \
+                --parameters Foundations:pDomain="$SEEDFARMER_PARAMETER_DOMAIN" \
+                --parameters Foundations:pChildAccountId="$SEEDFARMER_PARAMETER_CHILD_ACCOUNT_ID" \
+                deploy --require-approval never --progress events --app "python3 app.py" --outputs-file ./cdk-exports.json || exit 1
+            # Export metadata
+            seedfarmer metadata convert -f cdk-exports.json || true
+          fi
+    post_build:
+      commands:
+      - echo "Deploy successful"
+destroy:
+  phases:
+    build:
+      commands:
+      - echo "DESTROY!"
+      - |-
+          # deployment-type possible values: cfn-module, cdk-construct, cdk-stack
+          if [ "$SEEDFARMER_PARAMETER_DEPLOYMENT_TYPE" = "cfn-module" ]; then
+            echo "$SEEDFARMER_PARAMETER_DEPLOYMENT_TYPE"
+            STACK_NAME="sdlf-cfn-module-$SEEDFARMER_PARAMETER_LIBRARY_FRAMEWORK-$SEEDFARMER_PARAMETER_LIBRARY_MODULE"
+            aws cloudformation delete-stack --stack-name "$STACK_NAME"
+          fi
+          if [ "$SEEDFARMER_PARAMETER_DEPLOYMENT_TYPE" = "cdk-stack" ]; then
+            echo "$SEEDFARMER_PARAMETER_DEPLOYMENT_TYPE"
+            cdk destroy --force --app "python3 app.py"
+          fi
+    post_build:
+      commands:
+      - echo "Destroy successful"
+build_type: BUILD_GENERAL1_SMALL

--- a/sdlf-foundations/modulestack.yaml
+++ b/sdlf-foundations/modulestack.yaml
@@ -1,0 +1,75 @@
+AWSTemplateFormatVersion: 2010-09-09
+Description: This template deploys a Module specific IAM permissions
+
+Parameters:
+  DeploymentName:
+    Type: String
+    Description: The name of the deployment
+  ModuleName:
+    Type: String
+    Description: The name of the Module
+  RoleName:
+    Type: String
+    Description: The name of the IAM Role
+
+Resources:
+  Policy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyDocument:
+        Statement:
+          - Effect: Allow
+            Action:
+              - cloudformation:ListStacks # W11 exception
+              - cloudformation:ValidateTemplate # W11 exception
+            Resource: "*"
+          - Effect: Allow
+            Action:
+              - cloudformation:CreateChangeSet
+              - cloudformation:CreateStack
+              - cloudformation:DeleteChangeSet
+              - cloudformation:DeleteStack
+              - cloudformation:DescribeChangeSet
+              - cloudformation:DescribeStackEvents
+              - cloudformation:ExecuteChangeSet
+              - cloudformation:SetStackPolicy
+              - cloudformation:UpdateStack
+              - cloudformation:GetTemplateSummary
+            Resource:
+              - !Sub arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/sdlf-cfn-module-*
+          - Effect: Allow
+            Action:
+              - cloudformation:DescribeStacks
+            Resource:
+              - !Sub arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/sdlf-cfn-module-*
+          - Effect: Allow
+            Action:
+              - cloudformation:RegisterType
+              - cloudformation:SetTypeDefaultVersion
+              - cloudformation:DescribeType
+              - cloudformation:DeregisterType
+            Resource:
+              - !Sub "arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:type/MODULE/awslabs::sdlf::*"
+              - !Sub "arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:type/module/awslabs-sdlf-*"
+              - !Sub "arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:type/MODULE/*"
+              - !Sub "arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:type/module/*"
+          - Effect: Allow
+            Action:
+              - cloudformation:DescribeTypeRegistration # W11 exception
+            Resource:
+              - "*"
+          - Effect: Allow
+            Action:
+              - ssm:GetParameter
+              - ssm:GetParameters
+              - ssm:GetParametersByPath
+              - ssm:PutParameter
+              - ssm:AddTagsToResource
+              - ssm:ListTagsForResource
+              - ssm:RemoveTagsFromResource
+              - ssm:DeleteParameter
+            Resource:
+              - !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/CFN/*
+        Version: "2012-10-17"
+      PolicyName: "sdlf-module-policy"
+      Roles: [!Ref RoleName]

--- a/sdlf-foundations/requirements.txt
+++ b/sdlf-foundations/requirements.txt
@@ -1,2 +1,2 @@
-aws-cdk-lib==2.147.0
+aws-cdk-lib==2.149.0
 constructs>=10.0.0,<11.0.0


### PR DESCRIPTION
*Description of changes:*
Initial seedfarmer support - kind of an alternative to `sdlf-cicd`.

Try to make SDLF play well with seedfarmer, starting with `sdlf-foundations`. Allows building the CloudFormation module, or deploy a stack (from the CDK template) directly.

See for more information:
https://github.com/awslabs/seed-farmer
https://catalog.us-east-1.prod.workshops.aws/workshops/dfd2f6b2-3923-4d79-80bd-7db6c4842122/en-US

Support for building and publishing foundations as a CDK construct is something we're exploring as well.

**This is all in preview state, not fit for production use.**.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
