### PR TITLE
pin cfn-lint to <1 in github workflow

### DIFF
--- a/.github/workflows/static-checking.yml
+++ b/.github/workflows/static-checking.yml
@@ -24,11 +24,11 @@ jobs:
       - name: install requirements
         run: |
           python -m pip install --upgrade pip
-          python -m pip install cfn-lint
+          python -m pip install "cfn-lint<1"
           gem install cfn-nag
       - name: cfn-lint
         run: |
-          find . -type f -name '*.yaml' -print0 \
+          find . -type f -name '*.yaml' ! -name 'deployspec.yaml' -print0 \
           | xargs -0 cfn-lint
       - name: cfn-nag
         run: |

--- a/validate.sh
+++ b/validate.sh
@@ -12,8 +12,9 @@ find . -type f \( -name '*.sh' -o -name '*.bash' -o -name '*.ksh' \) -print0 \
 | xargs -0 shellcheck -x --format gcc
 
 # cloudformation
-find . -type f -name '*.yaml' -print0 \
+find . -type f -name '*.yaml' ! -name 'deployspec.yaml' -print0 \
 | xargs -0 cfn-lint
+
 ## unfortunately cfn_nag doesn't support fn::foreach so we exclude files using it: https://github.com/stelligent/cfn_nag/issues/621
 find . -not \( -type f -name 'template-glue-job.yaml' -o -type f -name 'template-lambda-layer.yaml' \) -type f -name '*.yaml' -print0 \
 | xargs -0 -L 1 cfn_nag_scan --fail-on-warnings --ignore-fatal --deny-list-path .cfn-nag-deny-list.yml --input-path


### PR DESCRIPTION
*Issue #, if available:*
related to #341 and #349 

*Description of changes:*
pin cfn-lint to <1 in github workflow
also exclude deployspec.yaml which is not a fully-formed cloudformation template

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
