### PR TITLE
remove hash from glue job cfn reference & script name

### DIFF
--- a/sdlf-cicd/nested-stacks/template-cicd-glue-job.yaml
+++ b/sdlf-cicd/nested-stacks/template-cicd-glue-job.yaml
@@ -179,12 +179,10 @@ Resources:
                             echo "Moving into dir..."
                             echo "Current directory contents:"
                             ls
-                            TRANSFORM_HASH=$(sha256sum "$TRANSFORM_NAME.py")
-                            S3_BASE_OBJECT_NAME="$TRANSFORM_NAME-${TRANSFORM_HASH:0:7}"
                             aws s3api put-object --bucket "$ARTIFACTS_BUCKET" \
-                                                  --key "$TEAM/transforms/$TRANSFORM_NAME-${TRANSFORM_HASH:0:7}.py" \
+                                                  --key "$TEAM/transforms/$TRANSFORM_NAME.py" \
                                                   --body "$TRANSFORM_NAME.py" || exit 1
-                            TRANSFORMS+=("$S3_BASE_OBJECT_NAME")
+                            TRANSFORMS+=("$TRANSFORM_NAME")
                             popd || exit
                             echo "============= COMPLETED DIRECTORY BUILD ============="
                         done


### PR DESCRIPTION
*Description of changes:*
Remove hash from Glue Job CloudFormation reference & script name.

Using a hash forced the glue job to be deleted and recreated - except creation would fail as the deletion only happens after, and the glue job name would still be in-use.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
