### PR TITLE
[sdlf-cicd] glue job deployer: support for custom templates

### DIFF
--- a/sdlf-cicd/nested-stacks/template-cicd-glue-job.yaml
+++ b/sdlf-cicd/nested-stacks/template-cicd-glue-job.yaml
@@ -182,7 +182,25 @@ Resources:
                             aws s3api put-object --bucket "$ARTIFACTS_BUCKET" \
                                                   --key "$TEAM/transforms/$TRANSFORM_NAME.py" \
                                                   --body "$TRANSFORM_NAME.py" || exit 1
-                            TRANSFORMS+=("$TRANSFORM_NAME")
+
+                            # if there is a user-provided template, use it and do not add the glue job to the list of transforms
+                            # it must be called template.yaml and accept two parameters called pTeamName and pGlueJob.
+                            if [ -f "template.yaml" ]; then
+                                CLOUDFORMATION_ENDPOINT_URL="https://cloudformation.$AWS_REGION.amazonaws.com"
+                                STACK_NAME="sdlf-$TEAM-gluejob-$TRANSFORM_NAME-$ENVIRONMENT"
+                                aws cloudformation --endpoint-url "$CLOUDFORMATION_ENDPOINT_URL" deploy \
+                                    --stack-name "$STACK_NAME" \
+                                    --template-file template.yaml \
+                                    --parameter-overrides \
+                                        pTeamName="$TEAM" \
+                                        pGlueJob="$TRANSFORM_NAME" \
+                                    --tags Framework=sdlf \
+                                    --capabilities "CAPABILITY_NAMED_IAM" "CAPABILITY_AUTO_EXPAND" \
+                                    --role-arn "$CROSSACCOUNT_TEAM_ROLE" || exit 1
+                            else
+                                TRANSFORMS+=("$TRANSFORM_NAME")
+                            fi
+
                             popd || exit
                             echo "============= COMPLETED DIRECTORY BUILD ============="
                         done

--- a/sdlf-cicd/template-cicd-domain-roles.yaml
+++ b/sdlf-cicd/template-cicd-domain-roles.yaml
@@ -142,6 +142,7 @@ Resources:
                   - !Sub arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/sdlf-*-datasets-*
                   - !Sub arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/sdlf-*-lambdalayers-*
                   - !Sub arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/sdlf-*-gluejobs-*
+                  - !Sub arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/sdlf-*-gluejob-*
               - Effect: Allow
                 Action: iam:PassRole
                 Resource:

--- a/sdlf-cicd/template-cicd-team-pipeline.yaml
+++ b/sdlf-cicd/template-cicd-team-pipeline.yaml
@@ -496,7 +496,8 @@ Resources:
                     PrimarySource: TemplateSource
                     ProjectName: "{{resolve:ssm:/SDLF/CodeBuild/PrepareGlueJobPackage}}"
                     EnvironmentVariables: !Sub >-
-                      [{"name":"ENVIRONMENT", "value":"${pEnvironment}", "type":"PLAINTEXT"},
+                      [{"name":"CROSSACCOUNT_TEAM_ROLE", "value":"${pCrossAccountTeamRole}", "type":"PLAINTEXT"},
+                      {"name":"ENVIRONMENT", "value":"${pEnvironment}", "type":"PLAINTEXT"},
                       {"name":"DOMAIN", "value":"${pDomain}", "type":"PLAINTEXT"},
                       {"name":"TEAM", "value":"${pTeamName}", "type":"PLAINTEXT"},
                       {"name":"DOMAIN_ACCOUNT_ID", "value":"${pChildAccountId}", "type":"PLAINTEXT"}]


### PR DESCRIPTION
*Description of changes:*
Add support for custom templates when using the Glue Job Deployer. It must be called `template.yaml`, in the same directory as the Glue job script, and accept two parameters called `pTeamName` and `pGlueJob`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
