### PR TITLE
avoid hardcoding SDLF deployment role name in LakeFormation admin list

### DIFF
--- a/sdlf-foundations/src/template.yaml
+++ b/sdlf-foundations/src/template.yaml
@@ -25,6 +25,10 @@ Parameters:
   pEnvironment:
     Description: Environment name
     Type: String
+  pCicdRole:
+    Description: Name of the IAM role used to deploy SDLF constructs
+    Type: String
+    Default: sdlf-cicd-domain
   pCloudWatchLogsRetentionInDays:
     Description: The number of days log events are kept in CloudWatch Logs
     Type: Number
@@ -151,7 +155,7 @@ Resources:
     Properties:
       Admins:
         - DataLakePrincipalIdentifier: !GetAtt rDataLakeAdminRole.Arn
-        - DataLakePrincipalIdentifier: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/sdlf-cicd-domain
+        - DataLakePrincipalIdentifier: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/${pCicdRole}
       CreateDatabaseDefaultPermissions: []
       CreateTableDefaultPermissions: []
       MutationType: REPLACE

--- a/sdlf-team/src/template.yaml
+++ b/sdlf-team/src/template.yaml
@@ -49,6 +49,10 @@ Parameters:
   pLakeFormationDataAccessRole:
     Type: String
     Default: "{{resolve:ssm:/SDLF/IAM/LakeFormationDataAccessRoleArn}}"
+  pCicdRole:
+    Description: Name of the IAM role used to deploy SDLF constructs
+    Type: String
+    Default: ""
   pCloudWatchLogsRetentionInDays:
     Description: The number of days log events are kept in CloudWatch Logs
     Type: Number
@@ -93,6 +97,7 @@ Parameters:
     Default: ""
 
 Conditions:
+  CicdRoleProvided: !Not [!Equals [!Ref pCicdRole, ""]]
   RunInVpc: !Equals [!Ref pEnableVpc, true]
 
 Globals:
@@ -998,7 +1003,10 @@ Resources:
     Type: AWS::LakeFormation::PrincipalPermissions
     Properties:
       Principal:
-        DataLakePrincipalIdentifier: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/sdlf-cicd-team-${pTeamName}
+        DataLakePrincipalIdentifier: !If
+          - CicdRoleProvided
+          - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/${pCicdRole}
+          - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/sdlf-cicd-team-${pTeamName}
       Resource:
         LFTagPolicy:
           CatalogId: !Ref AWS::AccountId


### PR DESCRIPTION
*Description of changes:*
Avoid hardcoding SDLF deployment role names in LakeFormation admin list. They were set to the value `sdlf-cicd` is using, which is not a mandatory module to use SDLF components.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
