### PR TITLE
use globbing for cfn-lint, set ignore_templates

### DIFF
--- a/.cfnlintrc
+++ b/.cfnlintrc
@@ -1,3 +1,6 @@
+ignore_templates:
+  - "*/deployspec.yaml"
+  - "sdlf-utils/workshop-examples/60-seedfarmer/manifest-sdlf*.yaml"
 include_checks:
   - I
 ignore_checks:

--- a/.github/workflows/static-checking.yml
+++ b/.github/workflows/static-checking.yml
@@ -28,8 +28,8 @@ jobs:
           gem install cfn-nag
       - name: cfn-lint
         run: |
-          find . -type f -name '*.yaml' ! -name 'deployspec.yaml' -print0 \
-          | xargs -0 cfn-lint
+          shopt -s globstar 
+          cfn-lint ./**/*.yaml
       - name: cfn-nag
         run: |
           cat <<EOT >> .cfn-nag-deny-list.yml

--- a/validate.sh
+++ b/validate.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 set -ex
+shopt -s globstar
 
 # python
 ruff format --check .
@@ -12,8 +13,7 @@ find . -type f \( -name '*.sh' -o -name '*.bash' -o -name '*.ksh' \) -print0 \
 | xargs -0 shellcheck -x --format gcc
 
 # cloudformation
-find . -type f -name '*.yaml' ! -name 'deployspec.yaml' -print0 \
-| xargs -0 cfn-lint
+cfn-lint ./**/*.yaml
 
 ## unfortunately cfn_nag doesn't support fn::foreach so we exclude files using it: https://github.com/stelligent/cfn_nag/issues/621
 find . -not \( -type f -name 'template-glue-job.yaml' -o -type f -name 'template-lambda-layer.yaml' \) -type f -name '*.yaml' -print0 \


### PR DESCRIPTION
*Description of changes:*
seedfarmer manifest files no longer checked by cfn-lint

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
