### PR TITLE
Mark Octagon Configuration, Events, Artifacts, Metrics as legacy

### DIFF
--- a/sdlf-foundations/src/template.yaml
+++ b/sdlf-foundations/src/template.yaml
@@ -1131,6 +1131,7 @@ Resources:
 
   rDynamoOctagonConfiguration:
     Type: AWS::DynamoDB::Table
+    Condition: UseLegacyTables
     Metadata:
       cfn_nag:
         rules_to_suppress:

--- a/sdlf-foundations/src/template.yaml
+++ b/sdlf-foundations/src/template.yaml
@@ -1215,6 +1215,7 @@ Resources:
 
   rDynamoOctagonEvents:
     Type: AWS::DynamoDB::Table
+    Condition: UseLegacyTables
     Metadata:
       cfn_nag:
         rules_to_suppress:

--- a/sdlf-foundations/src/template.yaml
+++ b/sdlf-foundations/src/template.yaml
@@ -29,6 +29,10 @@ Parameters:
     Description: Name of the IAM role used to deploy SDLF constructs
     Type: String
     Default: sdlf-cicd-domain
+  pLegacyTables:
+    Description: Deploy old Octagon tables
+    Type: String
+    Default: true
   pCloudWatchLogsRetentionInDays:
     Description: The number of days log events are kept in CloudWatch Logs
     Type: Number
@@ -74,6 +78,7 @@ Parameters:
 
 Conditions:
   UseCustomBucketPrefix: !Not [!Equals [!Ref pCustomBucketPrefix, sdlf]]
+  UseLegacyTables: !Equals [!Ref pLegacyTables, true]
   RunInVpc: !Equals [!Ref pEnableVpc, true]
 
 Globals:
@@ -986,6 +991,7 @@ Resources:
 
   rDynamoOctagonArtifacts:
     Type: AWS::DynamoDB::Table
+    Condition: UseLegacyTables
     Metadata:
       cfn_nag:
         rules_to_suppress:

--- a/sdlf-foundations/src/template.yaml
+++ b/sdlf-foundations/src/template.yaml
@@ -1069,6 +1069,7 @@ Resources:
 
   rDynamoOctagonMetrics:
     Type: AWS::DynamoDB::Table
+    Condition: UseLegacyTables
     Metadata:
       cfn_nag:
         rules_to_suppress:


### PR DESCRIPTION
*Description of changes:*
These tables have not been used in years and are confusing people unnecessarily. This PR is part of a bigger change to remove Octagon-specific code as it is no longer relevant.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
