### PR TITLE
redesign sdlf-team and sdlf-dataset

### DIFF
--- a/sdlf-dataset/src/template.yaml
+++ b/sdlf-dataset/src/template.yaml
@@ -862,6 +862,98 @@ Resources:
       Value: !Ref rIamManagedPolicy
       Description: The permissions boundary IAM Managed policy for the team
 
+  rDynamoPipelineExecutionHistory:
+    Type: AWS::DynamoDB::Table
+    Condition: NotUseLegacyTeam
+    Properties:
+      KeySchema:
+        - AttributeName: id
+          KeyType: HASH
+      AttributeDefinitions:
+        - AttributeName: id
+          AttributeType: S
+        - AttributeName: pipeline
+          AttributeType: S
+        - AttributeName: last_updated_timestamp
+          AttributeType: S
+        - AttributeName: execution_date
+          AttributeType: S
+        - AttributeName: status
+          AttributeType: S
+        - AttributeName: status_last_updated_timestamp
+          AttributeType: S
+        - AttributeName: dataset
+          AttributeType: S
+      BillingMode: PAY_PER_REQUEST
+      GlobalSecondaryIndexes:
+        - IndexName: pipeline-last-updated-index
+          KeySchema:
+            - AttributeName: pipeline
+              KeyType: HASH
+            - AttributeName: last_updated_timestamp
+              KeyType: RANGE
+          Projection:
+            ProjectionType: ALL
+        - IndexName: execution_date-status-index
+          KeySchema:
+            - AttributeName: execution_date
+              KeyType: HASH
+            - AttributeName: status
+              KeyType: RANGE
+          Projection:
+            ProjectionType: ALL
+        - IndexName: pipeline-execution_date-index
+          KeySchema:
+            - AttributeName: pipeline
+              KeyType: HASH
+            - AttributeName: execution_date
+              KeyType: RANGE
+          Projection:
+            ProjectionType: ALL
+        - IndexName: execution_date-last_updated-index
+          KeySchema:
+            - AttributeName: execution_date
+              KeyType: HASH
+            - AttributeName: last_updated_timestamp
+              KeyType: RANGE
+          Projection:
+            ProjectionType: ALL
+        - IndexName: status-last_updated-index
+          KeySchema:
+            - AttributeName: status
+              KeyType: HASH
+            - AttributeName: last_updated_timestamp
+              KeyType: RANGE
+          Projection:
+            ProjectionType: ALL
+        - IndexName: pipeline-status_last_updated-index
+          KeySchema:
+            - AttributeName: pipeline
+              KeyType: HASH
+            - AttributeName: status_last_updated_timestamp
+              KeyType: RANGE
+          Projection:
+            ProjectionType: ALL
+        - IndexName: dataset-status_last_updated_timestamp-index
+          KeySchema:
+            - AttributeName: dataset
+              KeyType: HASH
+            - AttributeName: status_last_updated_timestamp
+              KeyType: RANGE
+          Projection:
+            ProjectionType: ALL
+      TimeToLiveSpecification:
+        AttributeName: ttl
+        Enabled: true
+      SSESpecification:
+        SSEEnabled: True
+        SSEType: KMS
+        KMSMasterKeyId: !GetAtt rKMSInfraKey.Arn
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: True
+    UpdateReplacePolicy: Retain
+    DeletionPolicy: Delete
+
   rDatasetSsm:
     Type: AWS::SSM::Parameter
     Properties:

--- a/sdlf-dataset/src/template.yaml
+++ b/sdlf-dataset/src/template.yaml
@@ -954,6 +954,51 @@ Resources:
     UpdateReplacePolicy: Retain
     DeletionPolicy: Delete
 
+  rDynamoPipelineExecutionHistorySsm:
+    Type: AWS::SSM::Parameter
+    Condition: NotUseLegacyTeam
+    Properties:
+      Name: !Sub /SDLF/Dynamo/${pDatasetName}/PipelineExecutionHistory
+      Type: String
+      Value: !Ref rDynamoPipelineExecutionHistory
+      Description: Name of the DynamoDB used to store pipeline execution metadata
+
+  rDynamoManifests:
+    Type: AWS::DynamoDB::Table
+    Condition: NotUseLegacyTeam
+    Properties:
+      KeySchema:
+        - AttributeName: dataset_name
+          KeyType: HASH
+        - AttributeName: datafile_name
+          KeyType: RANGE
+      AttributeDefinitions:
+        - AttributeName: dataset_name
+          AttributeType: S
+        - AttributeName: datafile_name
+          AttributeType: S
+      BillingMode: PAY_PER_REQUEST
+      TimeToLiveSpecification:
+        AttributeName: ttl
+        Enabled: true
+      SSESpecification:
+        SSEEnabled: True
+        SSEType: KMS
+        KMSMasterKeyId: !GetAtt rKMSInfraKey.Arn
+      PointInTimeRecoverySpecification:
+        PointInTimeRecoveryEnabled: True
+    UpdateReplacePolicy: Retain
+    DeletionPolicy: Delete
+
+  rDynamoManifestsSsm:
+    Type: AWS::SSM::Parameter
+    Condition: NotUseLegacyTeam
+    Properties:
+      Name: !Sub /SDLF/Dynamo/${pDatasetName}/Manifests
+      Type: String
+      Value: !Ref rDynamoManifests
+      Description: Name of the DynamoDB used to store manifest process metadata
+
   rDatasetSsm:
     Type: AWS::SSM::Parameter
     Properties:

--- a/sdlf-dataset/src/template.yaml
+++ b/sdlf-dataset/src/template.yaml
@@ -13,18 +13,45 @@ Parameters:
     Description: Data domain name
     Type: String
     Default: "{{resolve:ssm:/SDLF/Misc/pDomain}}"
-  pDatasetName:
-    Description: The name of the dataset (all lowercase, no symbols or spaces)
-    Type: String
-    AllowedPattern: "[a-z0-9]{2,14}"
   pEnvironment:
     Description: Environment name
     Type: String
     Default: "{{resolve:ssm:/SDLF/Misc/pEnv}}"
+  pRawBucket:
+    Description: The raw bucket for the solution
+    Type: String
+    Default: "{{resolve:ssm:/SDLF/S3/RawBucket}}"
   pStageBucket:
     Description: The stage bucket for the solution
     Type: String
     Default: "{{resolve:ssm:/SDLF/S3/StageBucket}}"
+  pAnalyticsBucket:
+    Description: The analytics bucket for the solution
+    Type: String
+    Default: "{{resolve:ssm:/SDLF/S3/AnalyticsBucket}}"
+  pArtifactsBucket:
+    Description: The artifacts bucket used by CodeBuild and CodePipeline
+    Type: String
+    Default: "{{resolve:ssm:/SDLF/S3/ArtifactsBucket}}"
+  pLakeFormationDataAccessRole:
+    Type: String
+    Default: "{{resolve:ssm:/SDLF/IAM/LakeFormationDataAccessRoleArn}}"
+  pDatasetName:
+    Description: The name of the dataset (all lowercase, no symbols or spaces)
+    Type: String
+    AllowedPattern: "[a-z0-9]{2,14}"
+  pLegacyTeam:
+    Description: Dataset resources are still deployed with sdlf-team
+    Type: String
+    Default: true
+  pS3Prefix:
+    Description: S3 prefix or full bucket
+    Type: String
+    AllowedPattern: ""
+  pCicdRole:
+    Description: Name of the IAM role used to deploy SDLF constructs
+    Type: String
+    Default: ""
   pTeamName:
     Description: Name of the team owning the pipeline (all lowercase, no symbols or spaces)
     Type: String
@@ -45,46 +72,382 @@ Parameters:
           }
         }
       }
+  # the ideal would be to fetch ssm:/SDLF/VPC/Enabled and not ask the user to set this variable to true manually.
+  # however between AWS::SSM::Parameter::Value<String> not working in CloudFormation modules,
+  # Fn::ImportValue not being accepted in CloudFormation modules template fragments,
+  # {{resolve:}} being evaluated later than the Conditions block, options are limited.
+  pEnableVpc:
+    Description: Deploy SDLF resources in a VPC
+    Type: String
+    Default: false
+
+Conditions:
+  CicdRoleProvided: !Not [!Equals [!Ref pCicdRole, ""]]
+  NotUseLegacyTeam: !Not [!Equals [!Ref pLegacyTeam, true]]
+  IsS3Prefix: !And
+    - !Condition NotUseLegacyTeam
+    - !Not [!Equals [!Ref pS3Prefix, ""]]
+  RunInVpc: !Equals [!Ref pEnableVpc, true]
 
 Resources:
+  ######## KMS #########
+  rKMSInfraKey:
+    Type: AWS::KMS::Key
+    Condition: NotUseLegacyTeam
+    UpdateReplacePolicy: Retain
+    DeletionPolicy: RetainExceptOnCreate
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: F76
+            reason: Full access is allowed to Key admin and some AWS services
+    Properties:
+      Description: !Sub SDLF ${pDatasetName} Infrastructure KMS Key
+      EnableKeyRotation: True
+      KeyPolicy:
+        Version: "2012-10-17"
+        Id: !Sub sdlf-${pDatasetName}-infra-key-policy
+        Statement:
+          - Sid: Allow administration of the key
+            Effect: Allow
+            Principal:
+              AWS: [!Sub "arn:${AWS::Partition}:iam::${AWS::AccountId}:root"]
+            Action: kms:*
+            Resource: "*"
+          - Sid: Allow CloudWatch alarms access
+            Effect: Allow
+            Principal:
+              Service:
+                - cloudwatch.amazonaws.com
+                - events.amazonaws.com
+            Action:
+              - kms:Decrypt
+              - kms:GenerateDataKey*
+            Resource: "*"
+          - Sid: Allow logs access
+            Effect: Allow
+            Principal:
+              Service:
+                - !Sub logs.${AWS::Region}.amazonaws.com
+            Action:
+              - kms:CreateGrant
+              - kms:Decrypt
+              - kms:DescribeKey
+              - kms:Encrypt
+              - kms:GenerateDataKey*
+              - kms:ReEncrypt*
+            Resource: "*"
+          - Sid: Allow SNS access
+            Effect: Allow
+            Principal:
+              AWS: "*"
+            Action:
+              - kms:Decrypt
+              - kms:GenerateDataKey*
+            Resource: "*"
+            Condition:
+              StringEquals:
+                kms:CallerAccount: !Ref AWS::AccountId
+                kms:ViaService: !Sub sns.${AWS::Region}.amazonaws.com
+
+  rKMSInfraKeyAlias:
+    Type: AWS::KMS::Alias
+    Condition: NotUseLegacyTeam
+    UpdateReplacePolicy: Retain
+    DeletionPolicy: RetainExceptOnCreate
+    Properties:
+      AliasName: !Sub alias/sdlf-${pDatasetName}-kms-infra-key
+      TargetKeyId: !Ref rKMSInfraKey
+
+  rKMSInfraKeySsm:
+    Type: AWS::SSM::Parameter
+    Condition: NotUseLegacyTeam
+    Properties:
+      Name: !Sub /SDLF/KMS/${pDatasetName}/InfraKeyId
+      Type: String
+      Value: !GetAtt rKMSInfraKey.Arn
+      Description: !Sub ${pDatasetName} KMS infrastructure key ARN
+
+  rKMSDataKey:
+    Type: AWS::KMS::Key
+    Condition: IsS3Prefix
+    UpdateReplacePolicy: Retain
+    DeletionPolicy: RetainExceptOnCreate
+    Properties:
+      Description: !Sub SDLF ${pDatasetName} Data KMS Key
+      EnableKeyRotation: True
+      KeyPolicy:
+        Version: "2012-10-17"
+        Id: !Sub sdlf-${pDatasetName}-data-key-policy
+        Statement:
+          - Sid: Allow administration of the key
+            Action: kms:*
+            Effect: Allow
+            Principal:
+              AWS: [!Sub "arn:${AWS::Partition}:iam::${AWS::AccountId}:root"]
+            Resource: "*"
+          - Sid: Allow Lake Formation permissions
+            Action:
+              - kms:Encrypt*
+              - kms:Decrypt*
+              - kms:ReEncrypt*
+              - kms:GenerateDataKey*
+              - kms:Describe*
+            Effect: Allow
+            Principal:
+              AWS: !Ref pLakeFormationDataAccessRole
+            Resource: "*"
+
+  rKMSDataKeyAlias:
+    Type: AWS::KMS::Alias
+    Condition: IsS3Prefix
+    UpdateReplacePolicy: Retain
+    DeletionPolicy: RetainExceptOnCreate
+    Properties:
+      AliasName: !Sub alias/sdlf-${pDatasetName}-kms-data-key
+      TargetKeyId: !Ref rKMSDataKey
+
+  rKMSDataKeySsm:
+    Type: AWS::SSM::Parameter
+    Condition: IsS3Prefix
+    Properties:
+      Name: !Sub /SDLF/KMS/${pDatasetName}/DataKeyId
+      Type: String
+      Value: !GetAtt rKMSDataKey.Arn
+      Description: !Sub ${pDatasetName} KMS data key ARN
+
   ######## GLUE #########
   rGlueDataCatalog:
     Type: AWS::Glue::Database
     Properties:
       CatalogId: !Ref AWS::AccountId
-      DatabaseInput:
-        Description: !Sub "${pTeamName} team ${pDatasetName} metadata catalog"
-        Name: !Sub ${pOrg}_${pDomain}_${pEnvironment}_${pTeamName}_${pDatasetName}_db
+      DatabaseInput: !If
+        - NotUseLegacyTeam
+        - Description: !Sub "${pDatasetName} metadata catalog"
+          Name: !Sub ${pOrg}_${pDomain}_${pEnvironment}_${pDatasetName}
+        - Description: !Sub "${pTeamName} team ${pDatasetName} metadata catalog"
+          Name: !Sub ${pOrg}_${pDomain}_${pEnvironment}_${pTeamName}_${pDatasetName}_db
 
-  rGlueDataCatalogLakeFormationTag:
-      Type: AWS::LakeFormation::TagAssociation
-      Properties:
-        Resource:
-          Database:
-            CatalogId: !Ref AWS::AccountId
-            Name: !Ref rGlueDataCatalog
-        LFTags:
-          - CatalogId: !Ref AWS::AccountId
-            TagKey: !Sub "sdlf:team:${pTeamName}"
-            TagValues:
-              - !Sub ${pTeamName}
+  rGlueDataCatalogSsm:
+    Type: AWS::SSM::Parameter
+    Properties:
+      Name: !If
+        - NotUseLegacyTeam
+        - !Sub /SDLF/Glue/${pDatasetName}/DataCatalog
+        - !Sub /SDLF/Glue/${pTeamName}/${pDatasetName}/DataCatalog
+      Type: String
+      Value: !Ref rGlueDataCatalog
+      Description: !If
+        - NotUseLegacyTeam
+        - !Sub "${pDatasetName} metadata catalog"
+        - !Sub "${pTeamName} team ${pDatasetName} metadata catalog"
+
+  rGlueSecurityConfiguration:
+    Type: AWS::Glue::SecurityConfiguration
+    Condition: NotUseLegacyTeam
+    Properties:
+      Name: !Sub sdlf-${pDatasetName}-glue-security-config
+      EncryptionConfiguration:
+        CloudWatchEncryption:
+          CloudWatchEncryptionMode: SSE-KMS
+          KmsKeyArn: !GetAtt rKMSInfraKey.Arn
+        JobBookmarksEncryption:
+          JobBookmarksEncryptionMode: CSE-KMS
+          KmsKeyArn: !GetAtt rKMSInfraKey.Arn
+        S3Encryptions:
+          - S3EncryptionMode: SSE-KMS
+            KmsKeyArn: !If
+              - IsS3Prefix
+              - !GetAtt rKMSDataKey.Arn
+              - "{{resolve:ssm:/SDLF/KMS/KeyArn}}"
+
+  rGlueSecurityConfigurationSsm:
+    Type: AWS::SSM::Parameter
+    Condition: NotUseLegacyTeam
+    Properties:
+      Name: !Sub /SDLF/Glue/${pDatasetName}/SecurityConfigurationId
+      Type: String
+      Value: !Sub sdlf-${pDatasetName}-glue-security-config # unfortunately AWS::Glue::SecurityConfiguration doesn't provide any return value
+      Description: !Sub Name of the ${pDatasetName} Glue security configuration
+
+  rEMRSecurityConfiguration:
+    Type: AWS::EMR::SecurityConfiguration
+    Condition: NotUseLegacyTeam
+    Properties:
+      Name: !Sub sdlf-${pDatasetName}-emr-security-config
+      SecurityConfiguration: !If
+        - IsS3Prefix
+        - !Sub |
+            {
+              "EncryptionConfiguration": {
+                "EnableInTransitEncryption" : false,
+                "EnableAtRestEncryption" : true,
+                "AtRestEncryptionConfiguration" : {
+                  "S3EncryptionConfiguration" : {
+                    "EncryptionMode" : "SSE-KMS",
+                    "AwsKmsKey": "${rKMSDataKey}"
+                  },
+                  "LocalDiskEncryptionConfiguration" : {
+                    "EncryptionKeyProviderType" : "AwsKms",
+                    "AwsKmsKey" : "${rKMSDataKey}",
+                    "EnableEbsEncryption" : true
+                  }
+                }
+              },
+              "InstanceMetadataServiceConfiguration":{
+                "MinimumInstanceMetadataServiceVersion": 2,
+                "HttpPutResponseHopLimit": 1
+              }
+            }
+        - |
+            {
+              "EncryptionConfiguration": {
+                "EnableInTransitEncryption" : false,
+                "EnableAtRestEncryption" : true,
+                "AtRestEncryptionConfiguration" : {
+                  "S3EncryptionConfiguration" : {
+                    "EncryptionMode" : "SSE-KMS",
+                    "AwsKmsKey": "{{resolve:ssm:/SDLF/KMS/KeyArn}}"
+                  },
+                  "LocalDiskEncryptionConfiguration" : {
+                    "EncryptionKeyProviderType" : "AwsKms",
+                    "AwsKmsKey" : "{{resolve:ssm:/SDLF/KMS/KeyArn}}",
+                    "EnableEbsEncryption" : true
+                  }
+                }
+              },
+              "InstanceMetadataServiceConfiguration":{
+                "MinimumInstanceMetadataServiceVersion": 2,
+                "HttpPutResponseHopLimit": 1
+              }
+            }
+
+  rDatalakeCrawlerRole:
+    Type: AWS::IAM::Role
+    Condition: NotUseLegacyTeam
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W11
+            reason: The actions with "*" are all ones that only support the all resources wildcard
+    Properties:
+      Path: !Sub /sdlf-${pDatasetName}/
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - glue.amazonaws.com
+            Action:
+              - sts:AssumeRole
+      ManagedPolicyArns:
+        - !Sub arn:${AWS::Partition}:iam::aws:policy/service-role/AWSGlueServiceRole
+      Policies:
+        - PolicyName: !Sub sdlf-${pDatasetName}-glue-crawler
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - s3:CreateBucket
+                Resource: !Sub arn:${AWS::Partition}:s3:::aws-glue-*
+              - Effect: Allow
+                Action:
+                  - s3:DeleteObject
+                  - s3:GetObject
+                  - s3:PutObject
+                Resource:
+                  - !Sub arn:${AWS::Partition}:s3:::aws-glue-*/*
+                  - !Sub arn:${AWS::Partition}:s3:::*/*aws-glue-*/*
+              - Effect: Allow
+                Action:
+                  - s3:GetObject
+                Resource:
+                  - !Sub arn:${AWS::Partition}:s3:::crawler-public*
+                  - !Sub arn:${AWS::Partition}:s3:::aws-glue-*
+              - Effect: Allow
+                Action:
+                  - s3:ListObjectsV2
+                  - s3:GetObject
+                  - s3:GetObjectVersion
+                  - s3:GetBucketVersioning
+                  - s3:GetBucketAcl
+                  - s3:GetBucketLocation
+                  - s3:PutObject
+                  - s3:PutObjectVersion
+                Resource:
+                  - !Sub arn:${AWS::Partition}:s3:::${pRawBucket}/${pDatasetName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/${pDatasetName}/*
+                  - !Sub arn:${AWS::Partition}:s3:::${pAnalyticsBucket}/${pDatasetName}/*
+              - Effect: Allow
+                Action:
+                  - kms:DescribeKey
+                  - kms:Encrypt
+                  - kms:Decrypt
+                  - kms:ReEncrypt*
+                  - kms:GenerateDataKey*
+                  - kms:CreateGrant
+                Resource: !If
+                  - IsS3Prefix
+                  - - !GetAtt rKMSInfraKey.Arn
+                    - !GetAtt rKMSDataKey.Arn
+                    - "{{resolve:ssm:/SDLF/KMS/KeyArn}}"
+                  - - !GetAtt rKMSInfraKey.Arn
+                    - "{{resolve:ssm:/SDLF/KMS/KeyArn}}"
+              - Effect: Allow
+                Action:
+                  - lakeformation:GetDataAccess # W11 exception
+                Resource: "*"
+              - Effect: Allow
+                Action:
+                  - logs:CreateLogGroup
+                  - logs:CreateLogStream
+                  - logs:PutLogEvents
+                  - logs:AssociateKmsKey
+                Resource:
+                  - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws-glue/crawlers-role/sdlf-${pDatasetName}/*
+
+  rDatalakeCrawlerRoleArnSsm:
+    Type: AWS::SSM::Parameter
+    Condition: NotUseLegacyTeam
+    Properties:
+      Name: !Sub /SDLF/IAM/${pDatasetName}/CrawlerRoleArn
+      Type: String
+      Value: !GetAtt rDatalakeCrawlerRole.Arn
+      Description: ARN of the Crawler role
 
   rGlueCrawler:
     Type: AWS::Glue::Crawler
     Properties:
-      Role: !Sub "{{resolve:ssm:/SDLF/IAM/${pTeamName}/CrawlerRoleArn}}"
-      CrawlerSecurityConfiguration: !Sub "{{resolve:ssm:/SDLF/Glue/${pTeamName}/SecurityConfigurationId}}"
+      Role: !If
+        - NotUseLegacyTeam
+        - !GetAtt rDatalakeCrawlerRole.Arn
+        - !Sub "{{resolve:ssm:/SDLF/IAM/${pTeamName}/CrawlerRoleArn}}"
+      CrawlerSecurityConfiguration: !If
+        - NotUseLegacyTeam
+        - !Sub sdlf-${pDatasetName}-glue-security-config # unfortunately AWS::Glue::SecurityConfiguration doesn't provide any return value
+        - !Sub "{{resolve:ssm:/SDLF/Glue/${pTeamName}/SecurityConfigurationId}}"
       DatabaseName: !Ref rGlueDataCatalog
-      Name: !Sub sdlf-${pTeamName}-${pDatasetName}-post-stage-crawler
+      Name: !If
+        - NotUseLegacyTeam
+        - !Sub sdlf-${pDatasetName}-crawler
+        - !Sub sdlf-${pTeamName}-${pDatasetName}-post-stage-crawler
       Targets:
         S3Targets:
-          - Path: !Sub s3://${pStageBucket}/post-stage/${pTeamName}/${pDatasetName}
+          - Path: !If
+            - NotUseLegacyTeam
+            - !Sub s3://${pStageBucket}/${pDatasetName}
+            - !Sub s3://${pStageBucket}/post-stage/${pTeamName}/${pDatasetName}
 
   rGlueCrawlerLakeFormationPermissions:
     Type: AWS::LakeFormation::Permissions
     Properties:
       DataLakePrincipal:
-        DataLakePrincipalIdentifier: !Sub "{{resolve:ssm:/SDLF/IAM/${pTeamName}/CrawlerRoleArn}}"
+        DataLakePrincipalIdentifier: !If
+          - NotUseLegacyTeam
+          - !GetAtt rDatalakeCrawlerRole.Arn
+          - !Sub "{{resolve:ssm:/SDLF/IAM/${pTeamName}/CrawlerRoleArn}}"
       Permissions:
         - CREATE_TABLE
         - ALTER
@@ -93,30 +456,422 @@ Resources:
         DatabaseResource:
           Name: !Ref rGlueDataCatalog
 
-  ######## SSM #########
-  rGlueDataCatalogSsm:
-    Type: AWS::SSM::Parameter
-    Properties:
-      Name: !Sub /SDLF/Glue/${pTeamName}/${pDatasetName}/DataCatalog
-      Type: String
-      Value: !Ref rGlueDataCatalog
-      Description: !Sub "${pTeamName} team ${pDatasetName} metadata catalog"
-
   rGlueCrawlerSsm:
     Type: AWS::SSM::Parameter
     Properties:
-      Name: !Sub /SDLF/Glue/${pTeamName}/${pDatasetName}/GlueCrawler
+      Name: !If
+        - NotUseLegacyTeam
+        - !Sub /SDLF/Glue/${pDatasetName}/GlueCrawler
+        - !Sub /SDLF/Glue/${pTeamName}/${pDatasetName}/GlueCrawler
       Type: String
       Value: !Ref rGlueCrawler
-      Description: !Sub "${pTeamName} team ${pDatasetName} Glue crawler"
+      Description: !If
+        - NotUseLegacyTeam
+        - !Sub "${pDatasetName} Glue crawler"
+        - !Sub "${pTeamName} team ${pDatasetName} Glue crawler"
+
+  rLakeFormationTag:
+    Type: AWS::LakeFormation::Tag
+    Condition: NotUseLegacyTeam
+    Properties:
+      CatalogId: !Ref AWS::AccountId
+      TagKey: "sdlf:dataset"
+      TagValues:
+        - !Ref pDatasetName
+
+  rLakeFormationTagTablesPermissions: # allows sdlf pipelines to grant permissions on tables associated with this lf-tag
+    Type: AWS::LakeFormation::PrincipalPermissions
+    Condition: NotUseLegacyTeam
+    Properties:
+      Principal:
+        DataLakePrincipalIdentifier: !If
+          - CicdRoleProvided
+          - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/${pCicdRole}
+          - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/sdlf-cicd-team-${pDatasetName}
+      Resource:
+        LFTagPolicy:
+          CatalogId: !Ref AWS::AccountId
+          ResourceType: TABLE
+          Expression:
+            - TagKey: !Ref rLakeFormationTag
+              TagValues:
+                - !Ref pDatasetName
+      Permissions:
+        - ALL
+      PermissionsWithGrantOption:
+        - ALL
+
+  rGlueDataCatalogLakeFormationTag:
+    Type: AWS::LakeFormation::TagAssociation
+    Properties:
+      Resource:
+        Database:
+          CatalogId: !Ref AWS::AccountId
+          Name: !Ref rGlueDataCatalog
+      LFTags:
+        - CatalogId: !Ref AWS::AccountId
+          TagKey: !If
+            - NotUseLegacyTeam
+            - "sdlf:dataset"
+            - !Sub "sdlf:team:${pTeamName}"
+          TagValues:
+            - !If
+              - NotUseLegacyTeam
+              - !Ref pDatasetName
+              - !Sub ${pTeamName}
+
+  ######## LAKEFORMATION PERMISSIONS #########
+  rRawLakeFormationPermissions:
+    Type: AWS::LakeFormation::Permissions
+    Condition: NotUseLegacyTeam
+    Properties:
+      DataLakePrincipal:
+        DataLakePrincipalIdentifier: !GetAtt rDatalakeCrawlerRole.Arn
+      Permissions:
+        - DATA_LOCATION_ACCESS
+      Resource:
+        DataLocationResource:
+          S3Resource: !Sub arn:${AWS::Partition}:s3:::${pRawBucket}/${pDatasetName}/
+
+  rStageLakeFormationPermissions:
+    Type: AWS::LakeFormation::Permissions
+    Condition: NotUseLegacyTeam
+    Properties:
+      DataLakePrincipal:
+        DataLakePrincipalIdentifier: !GetAtt rDatalakeCrawlerRole.Arn
+      Permissions:
+        - DATA_LOCATION_ACCESS
+      Resource:
+        DataLocationResource:
+          S3Resource: !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/${pDatasetName}/
+
+  rAnalyticsLakeFormationPermissions:
+    Type: AWS::LakeFormation::Permissions
+    Condition: NotUseLegacyTeam
+    Properties:
+      DataLakePrincipal:
+        DataLakePrincipalIdentifier: !GetAtt rDatalakeCrawlerRole.Arn
+      Permissions:
+        - DATA_LOCATION_ACCESS
+      Resource:
+        DataLocationResource:
+          S3Resource: !Sub arn:${AWS::Partition}:s3:::${pAnalyticsBucket}/${pDatasetName}/
+
+  ######## EVENTBRIDGE #########
+  rEventBus:
+    Type: AWS::Events::EventBus
+    Condition: NotUseLegacyTeam
+    Properties:
+        Name: !Sub sdlf-${pDatasetName}
+
+  rEventBusSsm:
+    Type: AWS::SSM::Parameter
+    Condition: NotUseLegacyTeam
+    Properties:
+      Name: !Sub /SDLF/EventBridge/${pDatasetName}/EventBusName
+      Type: String
+      Value: !Ref rEventBus
+      Description: !Sub Name of the ${pDatasetName} event bus
+
+  rScheduleGroup:
+    Type: AWS::Scheduler::ScheduleGroup
+    Condition: NotUseLegacyTeam
+    Properties:
+      Name: !Sub sdlf-${pDatasetName}
+
+  rScheduleGroupSsm:
+    Type: AWS::SSM::Parameter
+    Condition: NotUseLegacyTeam
+    Properties:
+      Name: !Sub /SDLF/EventBridge/${pDatasetName}/ScheduleGroupName
+      Type: String
+      Value: !Ref rScheduleGroup
+      Description: !Sub Name of the ${pDatasetName} schedule group
+
+  rForwardEventBusTriggerRole:
+    Type: AWS::IAM::Role
+    Condition: NotUseLegacyTeam
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - events.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: sdlf-cicd-events-trigger
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action: events:PutEvents
+                Resource:
+                  - !GetAtt rEventBus.Arn
+
+  rForwardEventBusRule:
+    Type: AWS::Events::Rule
+    Condition: NotUseLegacyTeam
+    Properties:
+      EventPattern:
+        source:
+          - prefix: aws.
+        account:
+          - !Ref AWS::AccountId
+        region:
+          - !Ref AWS::Region
+      Targets:
+        - Arn: !GetAtt rEventBus.Arn
+          RoleArn: !GetAtt rForwardEventBusTriggerRole.Arn
+          Id: default-to-sdlf-dataset
+
+  ######## IAM #########
+  rIamManagedPolicy:
+    Condition: NotUseLegacyTeam
+    Type: AWS::IAM::ManagedPolicy
+    Metadata:
+      cfn_nag:
+        rules_to_suppress:
+          - id: W13
+            reason: |-
+              Condition applied to restrict access, and the KMS keys do not exist at this stage
+              The other actions with "*" are all ones that only support the all resources wildcard
+    Properties:
+      Path: !Sub /sdlf/${pDatasetName}/ # keep this path for the dataset's permissions boundary policy only
+      Description: Team Permissions Boundary IAM policy. Add/remove permissions based on company policy and associate it to federated role
+      PolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Sid: AllowConsoleListBuckets
+            Effect: Allow
+            Action:
+              - s3:GetBucketLocation
+              - s3:ListAllMyBuckets
+            Resource: !Sub arn:${AWS::Partition}:s3:::*
+          - Sid: AllowTeamBucketList
+            Effect: Allow
+            Action:
+              - s3:ListBucket
+            Resource:
+              - !Sub arn:${AWS::Partition}:s3:::${pArtifactsBucket}
+              - !Sub arn:${AWS::Partition}:s3:::${pRawBucket}
+              - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}
+              - !Sub arn:${AWS::Partition}:s3:::${pAnalyticsBucket}
+          - Sid: AllowTeamPrefixActions
+            Effect: Allow
+            Action:
+              - s3:DeleteObject
+              - s3:GetObject
+              - s3:PutObject
+            Resource:
+              - !Sub arn:${AWS::Partition}:s3:::${pArtifactsBucket}/${pDatasetName}/*
+              - !Sub arn:${AWS::Partition}:s3:::${pRawBucket}/${pDatasetName}/*
+              - !Sub arn:${AWS::Partition}:s3:::${pStageBucket}/${pDatasetName}/*
+              - !Sub arn:${AWS::Partition}:s3:::${pAnalyticsBucket}/${pDatasetName}/*
+          - Sid: AllowFullCodeCommitOnTeamRepositories
+            Effect: Allow
+            Action:
+              - codecommit:AssociateApprovalRuleTemplateWithRepository
+              - codecommit:Batch* # Get, Describe, ApprovalRuleTemplate
+              - codecommit:Create*
+              - codecommit:DeleteBranch
+              - codecommit:DeleteFile
+              - codecommit:Describe*
+              - codecommit:DisassociateApprovalRuleTemplateFromRepository
+              - codecommit:EvaluatePullRequestApprovalRules
+              - codecommit:Get*
+              - codecommit:List*
+              - codecommit:Merge*
+              - codecommit:OverridePullRequestApprovalRules
+              - codecommit:Put*
+              - codecommit:Post*
+              - codecommit:TagResource
+              - codecommit:Test*
+              - codecommit:UntagResource
+              - codecommit:Update*
+              - codecommit:Git*
+            Resource:
+              - !Sub arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:sdlf-${pTeamName}-*
+          - Sid: AllowTeamKMSDataKeyUsage
+            Effect: Allow
+            Action:
+              - kms:CreateGrant
+              - kms:Decrypt
+              - kms:DescribeKey
+              - kms:Encrypt
+              - kms:GenerateDataKey*
+              - kms:ReEncrypt*
+            Resource: !If
+              - IsS3Prefix
+              - - !GetAtt rKMSInfraKey.Arn
+                - !GetAtt rKMSDataKey.Arn
+                - "{{resolve:ssm:/SDLF/KMS/KeyArn}}"
+              - - !GetAtt rKMSInfraKey.Arn
+                - "{{resolve:ssm:/SDLF/KMS/KeyArn}}"
+          - Effect: Allow
+            Action:
+              - ssm:GetParameter
+              - ssm:GetParameters
+            Resource: !Sub arn:${AWS::Partition}:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/*
+          - Sid: AllowOctagonDynamoAccess
+            Effect: Allow
+            Action:
+              - dynamodb:BatchGetItem
+              - dynamodb:BatchWriteItem
+              - dynamodb:DeleteItem
+              - dynamodb:DescribeTable
+              - dynamodb:GetItem
+              - dynamodb:GetRecords
+              - dynamodb:PutItem
+              - dynamodb:Query
+              - dynamodb:Scan
+              - dynamodb:UpdateItem
+            Resource:
+              - !Sub arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/octagon-*
+          - Sid: AllowSQSManagement
+            Effect: Allow
+            Action:
+              - sqs:DeleteMessage
+              - sqs:GetQueueAttributes
+              - sqs:GetQueueUrl
+              - sqs:List*
+              - sqs:ReceiveMessage
+              - sqs:SendMessage
+            Resource:
+              - !Sub arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:sdlf-${pDatasetName}-*
+          - Effect: Allow
+            Action:
+              - states:StartExecution
+            Resource:
+              - !Sub arn:${AWS::Partition}:states:${AWS::Region}:${AWS::AccountId}:stateMachine:sdlf-${pDatasetName}-*
+          - Effect: Allow
+            Action:
+              - iam:PassRole
+            Resource:
+              - !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/sdlf-${pDatasetName}/sdlf-*
+            Condition:
+              StringEquals:
+                "iam:PassedToService":
+                  - glue.amazonaws.com
+          - Effect: Allow
+            Action:
+              - glue:GetSecurityConfiguration # W13 exception
+            Resource: "*"
+          - Effect: Allow
+            Action:
+              - glue:GetTable
+              - glue:StartCrawler
+              - glue:GetCrawler
+              - glue:GetJobRun
+              - glue:GetJobRuns
+              - glue:StartJobRun
+              - glue:StartDataQualityRule*
+              - glue:GetDataQualityRule*
+            Resource:
+              - !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:catalog
+              - !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:database/${pOrg}_${pDomain}_${pEnvironment}_${pDatasetName}_*
+              - !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:table/${pOrg}_${pDomain}_${pEnvironment}_${pDatasetName}_*
+              - !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:crawler/sdlf-${pDatasetName}-*
+              - !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:job/sdlf-${pDatasetName}-*
+              - !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:job/${pOrg}-${pDomain}-${pEnvironment}-${pDatasetName}-*
+              - !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:dataQualityRuleset/* # glue:StartDataQualityRuleRecommendationRun requires dataQualityRuleset/*
+          - Effect: Allow
+            Action:
+              - logs:CreateLogGroup
+            Resource: !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:*
+          - Effect: Allow
+            Action:
+              - logs:CreateLogStream
+              - logs:DescribeLogStreams
+              - logs:GetLogEvents
+              - logs:PutLogEvents
+              - logs:AssociateKmsKey
+            Resource:
+              - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/lambda/sdlf-${pDatasetName}-*
+              - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws/codebuild/sdlf-${pDatasetName}-*
+              - !Sub arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::AccountId}:log-group:/aws-glue/jobs/sdlf-${pDatasetName}-*
+          - Sid: AllowCloudFormationReadOnlyAccess
+            Effect: Allow
+            Action:
+              - cloudformation:DescribeStacks
+              - cloudformation:DescribeStackEvents
+              - cloudformation:DescribeStackResource
+              - cloudformation:DescribeStackResources
+            Resource:
+              - !Sub arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stack:sdlf-${pDatasetName}:*
+          - Effect: Allow
+            Action:
+              - lambda:InvokeFunction
+            Resource:
+              - !Sub arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:sdlf-${pDatasetName}-*
+          - Effect: Allow
+            Action:
+              - events:PutTargets
+              - events:PutRule
+              - events:DescribeRule
+            Resource:
+              - !Sub arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:rule/StepFunctions* # Step Functions managed rules: https://docs.aws.amazon.com/step-functions/latest/dg/service-integration-iam-templates.html#connect-iam-sync-async
+          - Effect: Allow
+            Action:
+              - emr-serverless:CreateApplication
+              - emr-serverless:GetApplication
+            Resource:
+              - !Sub arn:${AWS::Partition}:emr-serverless:${AWS::Region}:${AWS::AccountId}:/applications/*
+          - !If
+            - RunInVpc
+            - Effect: Allow
+              Action:
+                - ec2:CreateNetworkInterface # W13 condition applied
+                - ec2:DescribeNetworkInterfaces # W13 exception
+                - ec2:DeleteNetworkInterface # W13 condition applied
+                - ec2:AssignPrivateIpAddresses # W13 condition applied
+                - ec2:UnassignPrivateIpAddresses # W13 condition applied
+                - ec2:DescribeSubnets # W13 exception
+                - ec2:DescribeSecurityGroups # W13 exception
+                - ec2:DescribeVpcEndpoints # W13 exception
+                - ec2:DescribeRouteTables # W13 exception
+                - ec2:CreateTags # W13 condition applied
+                - ec2:DeleteTags # W13 condition applied
+              Resource:
+                - "*"
+              Condition:
+                ArnEqualsIfExists:
+                  "ec2:Vpc":
+                    - !Sub "arn:${AWS::Partition}:ec2:${AWS::Region}:{{resolve:ssm:/SDLF/VPC/VpcAccountId}}:vpc/{{resolve:ssm:/SDLF/VPC/VpcId}}"
+                "ForAllValues:StringEqualsIfExists":
+                  "aws:TagKeys":
+                    - aws-glue-service-resource
+            - !Ref "AWS::NoValue"
+          - !If
+            - RunInVpc
+            - Effect: Allow
+              Action:
+                - Glue:GetConnection
+              Resource:
+                - !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:catalog
+                - !Sub arn:${AWS::Partition}:glue:${AWS::Region}:${AWS::AccountId}:connection/sdlf-${pDatasetName}-glue-conn-*
+            - !Ref "AWS::NoValue"
+
+  rIamManagedPolicySsm:
+    Type: AWS::SSM::Parameter
+    Condition: NotUseLegacyTeam
+    Properties:
+      Name: !Sub /SDLF/IAM/${pDatasetName}/TeamPermissionsBoundary
+      Type: String
+      Value: !Ref rIamManagedPolicy
+      Description: The permissions boundary IAM Managed policy for the team
 
   rDatasetSsm:
     Type: AWS::SSM::Parameter
     Properties:
-      Name: !Sub /SDLF/Datasets/${pTeamName}/${pDatasetName}
+      Name: !If
+        - NotUseLegacyTeam
+        - !Sub /SDLF/Datasets/${pDatasetName}
+        - !Sub /SDLF/Datasets/${pTeamName}/${pDatasetName}
       Type: String
       Value: !Ref pPipelineDetails # bit of a hack for datasets lambda
-      Description: !Sub "Placeholder ${pTeamName} ${pDatasetName}"
+      Description: !Sub "Placeholder ${pDatasetName}"
 
 Outputs:
   oPipelineReference:

--- a/sdlf-foundations/src/template.yaml
+++ b/sdlf-foundations/src/template.yaml
@@ -1407,6 +1407,7 @@ Resources:
 
   rDynamoOctagonManifests:
     Type: AWS::DynamoDB::Table
+    Condition: UseLegacyTables
     Metadata:
       cfn_nag:
         rules_to_suppress:
@@ -1482,6 +1483,7 @@ Resources:
       Description: Name of the DynamoDB used to store data schemas
   rDynamoManifestsSsm:
     Type: AWS::SSM::Parameter
+    Condition: UseLegacyTables
     Properties:
       Name: /SDLF/Dynamo/Manifests
       Type: String

--- a/sdlf-foundations/src/template.yaml
+++ b/sdlf-foundations/src/template.yaml
@@ -969,6 +969,7 @@ Resources:
 
   rDynamoOctagonDatasets:
     Type: AWS::DynamoDB::Table
+    Condition: UseLegacyTables
     Metadata:
       cfn_nag:
         rules_to_suppress:
@@ -1169,6 +1170,7 @@ Resources:
 
   rDynamoOctagonTeams:
     Type: AWS::DynamoDB::Table
+    Condition: UseLegacyTables
     Metadata:
       cfn_nag:
         rules_to_suppress:
@@ -1194,6 +1196,7 @@ Resources:
 
   rDynamoOctagonPipelines:
     Type: AWS::DynamoDB::Table
+    Condition: UseLegacyTables
     Metadata:
       cfn_nag:
         rules_to_suppress:
@@ -1447,6 +1450,7 @@ Resources:
       Description: Name of the DynamoDB used to store metadata
   rDynamoTransformMappingSsm:
     Type: AWS::SSM::Parameter
+    Condition: UseLegacyTables
     Properties:
       Name: /SDLF/Dynamo/TransformMapping
       Type: String
@@ -1454,6 +1458,7 @@ Resources:
       Description: Name of the DynamoDB used to store mappings to transformation (same as /SDLF/Dynamo/Datasets)
   rDynamoDatasetsSsm:
     Type: AWS::SSM::Parameter
+    Condition: UseLegacyTables
     Properties:
       Name: /SDLF/Dynamo/Datasets
       Type: String
@@ -1461,6 +1466,7 @@ Resources:
       Description: Name of the DynamoDB used to store datasets metadata
   rDynamoPipelinesSsm:
     Type: AWS::SSM::Parameter
+    Condition: UseLegacyTables
     Properties:
       Name: /SDLF/Dynamo/Pipelines
       Type: String
@@ -1468,6 +1474,7 @@ Resources:
       Description: Name of the DynamoDB used to store pipelines metadata
   rDynamoTeamMetadataSsm:
     Type: AWS::SSM::Parameter
+    Condition: UseLegacyTables
     Properties:
       Name: /SDLF/Dynamo/TeamMetadata
       Type: String

--- a/sdlf-foundations/src/template.yaml
+++ b/sdlf-foundations/src/template.yaml
@@ -1281,6 +1281,7 @@ Resources:
 
   rDynamoOctagonExecutionHistory:
     Type: AWS::DynamoDB::Table
+    Condition: UseLegacyTables
     Metadata:
       cfn_nag:
         rules_to_suppress:

--- a/sdlf-team/src/template.yaml
+++ b/sdlf-team/src/template.yaml
@@ -53,6 +53,10 @@ Parameters:
     Description: Name of the IAM role used to deploy SDLF constructs
     Type: String
     Default: ""
+  pLegacyTeam:
+    Description: Dataset resources are still deployed with sdlf-team
+    Type: String
+    Default: true
   pCloudWatchLogsRetentionInDays:
     Description: The number of days log events are kept in CloudWatch Logs
     Type: Number
@@ -98,6 +102,7 @@ Parameters:
 
 Conditions:
   CicdRoleProvided: !Not [!Equals [!Ref pCicdRole, ""]]
+  UseLegacyTeam: !Equals [!Ref pLegacyTeam, true]
   RunInVpc: !Equals [!Ref pEnableVpc, true]
 
 Globals:
@@ -181,6 +186,7 @@ Resources:
 
   rKMSInfraKeySsm:
     Type: AWS::SSM::Parameter
+    Condition: UseLegacyTeam
     Properties:
       Name: !Sub /SDLF/KMS/${pTeamName}/InfraKeyId
       Type: String
@@ -189,6 +195,7 @@ Resources:
 
   rKMSDataKey:
     Type: AWS::KMS::Key
+    Condition: UseLegacyTeam
     UpdateReplacePolicy: Retain
     DeletionPolicy: RetainExceptOnCreate
     Properties:
@@ -218,6 +225,7 @@ Resources:
 
   rKMSDataKeyAlias:
     Type: AWS::KMS::Alias
+    Condition: UseLegacyTeam
     UpdateReplacePolicy: Retain
     DeletionPolicy: RetainExceptOnCreate
     Properties:
@@ -226,6 +234,7 @@ Resources:
 
   rKMSDataKeySsm:
     Type: AWS::SSM::Parameter
+    Condition: UseLegacyTeam
     Properties:
       Name: !Sub /SDLF/KMS/${pTeamName}/DataKeyId
       Type: String
@@ -234,11 +243,13 @@ Resources:
 
   rEventBus:
     Type: AWS::Events::EventBus
+    Condition: UseLegacyTeam
     Properties:
         Name: !Sub sdlf-${pTeamName}
 
   rEventBusSsm:
     Type: AWS::SSM::Parameter
+    Condition: UseLegacyTeam
     Properties:
       Name: !Sub /SDLF/EventBridge/${pTeamName}/EventBusName
       Type: String
@@ -247,6 +258,7 @@ Resources:
 
   rForwardEventBusTriggerRole:
     Type: AWS::IAM::Role
+    Condition: UseLegacyTeam
     Properties:
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
@@ -268,6 +280,7 @@ Resources:
 
   rForwardEventBusRule:
     Type: AWS::Events::Rule
+    Condition: UseLegacyTeam
     Properties:
       EventPattern:
         source:
@@ -283,11 +296,13 @@ Resources:
 
   rScheduleGroup:
     Type: AWS::Scheduler::ScheduleGroup
+    Condition: UseLegacyTeam
     Properties:
       Name: !Sub sdlf-${pTeamName}
 
   rScheduleGroupSsm:
     Type: AWS::SSM::Parameter
+    Condition: UseLegacyTeam
     Properties:
       Name: !Sub /SDLF/EventBridge/${pTeamName}/ScheduleGroupName
       Type: String
@@ -296,6 +311,7 @@ Resources:
 
   rGlueSecurityConfiguration:
     Type: AWS::Glue::SecurityConfiguration
+    Condition: UseLegacyTeam
     Properties:
       Name: !Sub sdlf-${pTeamName}-glue-security-config
       EncryptionConfiguration:
@@ -311,6 +327,7 @@ Resources:
 
   rGlueSecurityConfigurationSsm:
     Type: AWS::SSM::Parameter
+    Condition: UseLegacyTeam
     Properties:
       Name: !Sub /SDLF/Glue/${pTeamName}/SecurityConfigurationId
       Type: String
@@ -319,6 +336,7 @@ Resources:
 
   rEMRSecurityConfiguration:
     Type: AWS::EMR::SecurityConfiguration
+    Condition: UseLegacyTeam
     Properties:
       Name: !Sub sdlf-${pTeamName}-emr-security-config
       SecurityConfiguration: !Sub |
@@ -347,6 +365,7 @@ Resources:
   ######## IAM #########
   rTeamIAMManagedPolicy:
     Type: AWS::IAM::ManagedPolicy
+    Condition: UseLegacyTeam
     Metadata:
       cfn_nag:
         rules_to_suppress:
@@ -571,6 +590,7 @@ Resources:
 
   rTeamIAMManagedPolicySsm:
     Type: AWS::SSM::Parameter
+    Condition: UseLegacyTeam
     Properties:
       Name: !Sub /SDLF/IAM/${pTeamName}/TeamPermissionsBoundary
       Type: String
@@ -579,6 +599,7 @@ Resources:
 
   rDatalakeCrawlerRole:
     Type: AWS::IAM::Role
+    Condition: UseLegacyTeam
     Metadata:
       cfn_nag:
         rules_to_suppress:
@@ -663,6 +684,7 @@ Resources:
 
   rDatalakeCrawlerRoleArnSsm:
     Type: AWS::SSM::Parameter
+    Condition: UseLegacyTeam
     Properties:
       Name: !Sub /SDLF/IAM/${pTeamName}/CrawlerRoleArn
       Type: String
@@ -694,7 +716,6 @@ Resources:
       Topics:
         - !Ref rSNSTopic
 
-  ######## SSM #########
   rSNSTopicSsm:
     Type: AWS::SSM::Parameter
     Properties:
@@ -705,6 +726,7 @@ Resources:
 
   rDatasetsDynamodbLambdaLogGroup:
     Type: AWS::Logs::LogGroup
+    Condition: UseLegacyTeam
     DeletionPolicy: Delete
     UpdateReplacePolicy: Delete
     Properties:
@@ -714,6 +736,7 @@ Resources:
 
   rDatasetsDynamodbLambdaRole:
     Type: AWS::IAM::Role
+    Condition: UseLegacyTeam
     Properties:
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
@@ -774,6 +797,7 @@ Resources:
 
   rDatasetsDynamodbLambda:
     Type: AWS::Serverless::Function
+    Condition: UseLegacyTeam
     Properties:
       Description: !Sub Creates/updates DynamoDB entries for ${pTeamName} datasets
       FunctionName: !Sub sdlf-${pTeamName}-datasets-dynamodb
@@ -788,6 +812,7 @@ Resources:
 
   rPermissionForDatasetsEventsToInvokeLambda:
     Type: AWS::Lambda::Permission
+    Condition: UseLegacyTeam
     Properties:
       FunctionName: !Ref rDatasetsDynamodbLambda
       Action: lambda:InvokeFunction
@@ -796,6 +821,7 @@ Resources:
 
   rDatasetsDynamodbTriggerEventRule:
     Type: AWS::Events::Rule
+    Condition: UseLegacyTeam
     Properties:
       Description: "Run Datasets DynamoDB update"
       EventPattern:
@@ -818,6 +844,7 @@ Resources:
 
   rPipelinesDynamodbLambdaLogGroup:
     Type: AWS::Logs::LogGroup
+    Condition: UseLegacyTeam
     DeletionPolicy: Delete
     UpdateReplacePolicy: Delete
     Properties:
@@ -827,6 +854,7 @@ Resources:
 
   rPipelinesDynamodbLambdaRole:
     Type: AWS::IAM::Role
+    Condition: UseLegacyTeam
     Properties:
       AssumeRolePolicyDocument:
         Version: "2012-10-17"
@@ -887,6 +915,7 @@ Resources:
 
   rPipelinesDynamodbLambda:
     Type: AWS::Serverless::Function
+    Condition: UseLegacyTeam
     Properties:
       Description: !Sub Creates/updates DynamoDB entries for ${pTeamName} pipelines
       FunctionName: !Sub sdlf-${pTeamName}-pipelines-dynamodb
@@ -901,6 +930,7 @@ Resources:
 
   rPermissionForPipelinesEventsToInvokeLambda:
     Type: AWS::Lambda::Permission
+    Condition: UseLegacyTeam
     Properties:
       FunctionName: !Ref rPipelinesDynamodbLambda
       Action: lambda:InvokeFunction
@@ -909,6 +939,7 @@ Resources:
 
   rPipelinesDynamodbTriggerEventRule:
     Type: AWS::Events::Rule
+    Condition: UseLegacyTeam
     Properties:
       Description: "Run Pipelines DynamoDB update"
       EventPattern:
@@ -932,6 +963,7 @@ Resources:
   ######## LAKEFORMATION PERMISSIONS #########
   rCentralTeamLakeFormationPermissions:
     Type: AWS::LakeFormation::Permissions
+    Condition: UseLegacyTeam
     Properties:
       DataLakePrincipal:
         DataLakePrincipalIdentifier: !GetAtt rDatalakeCrawlerRole.Arn
@@ -943,6 +975,7 @@ Resources:
 
   rStagePreTeamLakeFormationPermissions:
     Type: AWS::LakeFormation::Permissions
+    Condition: UseLegacyTeam
     Properties:
       DataLakePrincipal:
         DataLakePrincipalIdentifier: !GetAtt rDatalakeCrawlerRole.Arn
@@ -954,6 +987,7 @@ Resources:
 
   rStagePostTeamLakeFormationPermissions:
     Type: AWS::LakeFormation::Permissions
+    Condition: UseLegacyTeam
     Properties:
       DataLakePrincipal:
         DataLakePrincipalIdentifier: !GetAtt rDatalakeCrawlerRole.Arn
@@ -965,6 +999,7 @@ Resources:
 
   rAnalyticsTeamLakeFormationPermissions:
     Type: AWS::LakeFormation::Permissions
+    Condition: UseLegacyTeam
     Properties:
       DataLakePrincipal:
         DataLakePrincipalIdentifier: !GetAtt rDatalakeCrawlerRole.Arn
@@ -976,6 +1011,7 @@ Resources:
 
   rTeamLakeFormationTag:
     Type: AWS::LakeFormation::Tag
+    Condition: UseLegacyTeam
     Properties:
       CatalogId: !Ref AWS::AccountId
       # sdlf:team as key and team names as values would be best but impossible here
@@ -984,22 +1020,24 @@ Resources:
         - !Sub ${pTeamName}
 
   rTeamLakeFormationTagPermissions: # allows associating this lf-tag to datasets in sdlf-dataset
-      Type: AWS::LakeFormation::PrincipalPermissions
-      Properties:
-        Principal:
-          DataLakePrincipalIdentifier: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/sdlf-cicd-team-${pTeamName}
-        Resource:
-          LFTag:
-            CatalogId: !Ref AWS::AccountId
-            TagKey: !Ref rTeamLakeFormationTag
-            TagValues:
-              - !Sub ${pTeamName}
-        Permissions:
-          - ASSOCIATE
-        PermissionsWithGrantOption: []
+    Type: AWS::LakeFormation::PrincipalPermissions
+    Condition: UseLegacyTeam
+    Properties:
+      Principal:
+        DataLakePrincipalIdentifier: !Sub arn:${AWS::Partition}:iam::${AWS::AccountId}:role/sdlf-cicd-team-${pTeamName}
+      Resource:
+        LFTag:
+          CatalogId: !Ref AWS::AccountId
+          TagKey: !Ref rTeamLakeFormationTag
+          TagValues:
+            - !Sub ${pTeamName}
+      Permissions:
+        - ASSOCIATE
+      PermissionsWithGrantOption: []
 
   rTeamLakeFormationTagTablesPermissions: # allows sdlf pipelines to grant permissions on tables associated with this lf-tag
     Type: AWS::LakeFormation::PrincipalPermissions
+    Condition: UseLegacyTeam
     Properties:
       Principal:
         DataLakePrincipalIdentifier: !If
@@ -1034,7 +1072,7 @@ Resources:
         ResultConfiguration:
           EncryptionConfiguration:
             EncryptionOption: SSE_KMS
-            KmsKey: !GetAtt rKMSDataKey.Arn
+            KmsKey: !GetAtt rKMSInfraKey.Arn
           OutputLocation: !Sub s3://${pAthenaBucket}/${pTeamName}/
 
   rAthenaWorkgroupSsm:


### PR DESCRIPTION
*Description of changes:*
`sdlf-dataset` as catalog module, `sdlf-team` as consumption module.

sdlf-team is no longer involved with data encryption, this is now specific to datasets. sdlf-team still exists, as a consumption module, currently focused on Athena. Having encryption per dataset is better in the sharing use case - no need to grant access to an entire team's kms keys for access to a single dataset.

Move around a couple DynamoDB tables and decommission most of them as part of this change - they were mostly leftover from the old Octagon compatibility, and that is not very alive nowadays.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
