### PR TITLE
[sdlf-pipeline][sdlf-stage-lambda][cdk] rewrite

### DIFF
--- a/sdlf-dataset/src/dataset.py
+++ b/sdlf-dataset/src/dataset.py
@@ -79,7 +79,7 @@ class Dataset(Construct):
             "pDomain",
             description="Data domain name",
             type="String",
-            default=domain,
+            default=data_domain,
         )
         p_domain.override_logical_id("pDomain")
         p_rawbucket = CfnParameter(

--- a/sdlf-pipeline/src/pipeline.py
+++ b/sdlf-pipeline/src/pipeline.py
@@ -4,8 +4,7 @@
 import json
 
 from aws_cdk import (
-    CfnOutput,
-    CfnParameter,
+    #    CfnOutput,
     Duration,
     RemovalPolicy,
 )
@@ -13,185 +12,16 @@ from aws_cdk import aws_events as events
 from aws_cdk import aws_events_targets as targets
 from aws_cdk import aws_iam as iam
 from aws_cdk import aws_kms as kms
+from aws_cdk import aws_lambda as _lambda
 from aws_cdk import aws_scheduler as scheduler
 from aws_cdk import aws_sqs as sqs
 from aws_cdk import aws_ssm as ssm
 from constructs import Construct
 
+from aws_cdk.aws_lambda_event_sources import SqsEventSource
 
 class Pipeline(Construct):
-    p_datasetname = None
-    p_pipeline = None
-    p_stagename = None
-    p_stageenabled = None
-    p_triggertype = None
-    p_schedule = None
-    p_eventpattern = None
-
-    def resources(self, scope: Construct, lambda_routingstep) -> None:
-        routing_dlq = sqs.Queue(
-            self,
-            "rDeadLetterQueueRoutingStep",
-            removal_policy=RemovalPolicy.DESTROY,
-            queue_name=f"sdlf-{self.p_datasetname.value_as_string}-{self.p_pipeline.value_as_string}-dlq-{self.p_stagename.value_as_string}.fifo",
-            fifo=True,
-            retention_period=Duration.days(14),
-            visibility_timeout=Duration.seconds(60),
-            encryption_master_key=kms.Key.from_key_arn(
-                self,
-                "rDeadLetterQueueRoutingStepEncryption",
-                key_arn=f"{{{{resolve:ssm:/SDLF/KMS/{self.p_datasetname.value_as_string}/InfraKeyId}}}}",
-            ),
-        )
-        ssm.StringParameter(
-            self,
-            "rDeadLetterQueueRoutingStepSsm",
-            description=f"Name of the {self.p_stagename.value_as_string} {self.p_datasetname.value_as_string} {self.p_pipeline.value_as_string} DLQ",
-            parameter_name=f"/SDLF/SQS/{self.p_datasetname.value_as_string}/{self.p_pipeline.value_as_string}{self.p_stagename.value_as_string}DLQ",
-            simple_name=False,  # parameter name is a token
-            string_value=routing_dlq.queue_name,
-        )
-
-        routing_queue = sqs.Queue(
-            self,
-            "rQueueRoutingStep",
-            removal_policy=RemovalPolicy.DESTROY,
-            queue_name=f"sdlf-{self.p_datasetname.value_as_string}-{self.p_pipeline.value_as_string}-queue-{self.p_stagename.value_as_string}.fifo",
-            fifo=True,
-            content_based_deduplication=True,
-            retention_period=Duration.days(7),
-            visibility_timeout=Duration.seconds(60),
-            encryption_master_key=kms.Key.from_key_arn(
-                self,
-                "rQueueRoutingStepEncryption",
-                key_arn=f"{{{{resolve:ssm:/SDLF/KMS/{self.p_datasetname.value_as_string}/InfraKeyId}}}}",
-            ),
-            dead_letter_queue=sqs.DeadLetterQueue(
-                max_receive_count=1,
-                queue=routing_dlq,
-            ),
-        )
-        ssm.StringParameter(
-            self,
-            "rQueueRoutingStepSsm",
-            description=f"Name of the {self.p_stagename.value_as_string} {self.p_datasetname.value_as_string} {self.p_pipeline.value_as_string} Queue",
-            parameter_name=f"/SDLF/SQS/{self.p_datasetname.value_as_string}/{self.p_pipeline.value_as_string}{self.p_stagename.value_as_string}Queue",
-            simple_name=False,  # parameter name is a token
-            string_value=routing_dlq.queue_name,
-        )
-
-        stage_rule = events.Rule(
-            self,
-            "rStageRule",
-            rule_name=f"sdlf-{self.p_datasetname.value_as_string}-{self.p_pipeline.value_as_string}-rule-{self.p_stagename.value_as_string}",
-            description=f"Send events to {self.p_stagename.value_as_string} queue",
-            event_bus=events.EventBus.from_event_bus_name(
-                self,
-                "rStageRuleEventBus",
-                f"{{{{resolve:ssm:/SDLF/EventBridge/{self.p_datasetname.value_as_string}/EventBusName}}}}",
-            ),
-            enabled=True if self.p_stageenabled.value_as_string.lower() == "true" else False,
-            #            event_pattern=json.loads(self.p_eventpattern.value_as_string),  # TODO { "source": ["aws.states"] }
-            event_pattern={"source": ["aws.states"]},
-            targets=[
-                targets.SqsQueue(
-                    routing_queue,
-                    message_group_id=f"{self.p_datasetname.value_as_string}-{self.p_pipeline.value_as_string}",
-                    message=events.RuleTargetInput.from_event_path("$.detail"),
-                )
-            ],
-        )
-
-        routing_queue_policy = iam.PolicyStatement(
-            effect=iam.Effect.ALLOW,
-            principals=[
-                iam.ServicePrincipal("events.amazonaws.com"),
-            ],
-            actions=["SQS:SendMessage"],
-            resources=[routing_queue.queue_arn],
-            conditions={"ArnEquals": {"aws:SourceArn": stage_rule.rule_arn}},
-        )
-        routing_queue.add_to_resource_policy(routing_queue_policy)  # TODO may be a cdk grant
-
-        #         catalog_function.add_event_source(eventsources.SqsEventSource(catalog_queue, batch_size=10))
-        #   rQueueLambdaEventSourceMapping:
-        #     Type: AWS::Lambda::EventSourceMapping
-        #     Condition: EventBased
-        #     Properties:
-        #       BatchSize: 10
-        #       Enabled: True
-        #       EventSourceArn: !GetAtt rQueueRoutingStep.Arn
-        #       FunctionName: !Ref pLambdaRoutingStep
-
-        poststateschedule_role_policy = iam.Policy(
-            self,
-            "sdlf-schedule",
-            statements=[
-                iam.PolicyStatement(
-                    actions=["lambda:InvokeFunction"],
-                    resources=[lambda_routingstep, f"{lambda_routingstep}:*"],
-                ),
-                iam.PolicyStatement(
-                    actions=["kms:Decrypt"],
-                    resources=[f"{{{{resolve:ssm:/SDLF/KMS/{self.p_datasetname.value_as_string}/InfraKeyId}}}}"],
-                ),
-            ],
-        )
-        poststateschedule_role = iam.Role(
-            self,
-            "rPostStateScheduleRole",
-            path=f"/sdlf-{self.p_datasetname.value_as_string}/",
-            assumed_by=iam.ServicePrincipal("scheduler.amazonaws.com"),
-            permissions_boundary=iam.ManagedPolicy.from_managed_policy_arn(
-                self,
-                "rPostStateScheduleRolePermissionsBoundary",
-                managed_policy_arn=f"{{{{resolve:ssm:/SDLF/IAM/{self.p_datasetname.value_as_string}/TeamPermissionsBoundary}}}}",
-            ),
-        )
-        poststateschedule_role.attach_inline_policy(poststateschedule_role_policy)
-
-        poststate_schedule_input = {
-            "FunctionName": lambda_routingstep,
-            "InvocationType": "Event",
-            "Payload": json.dumps(
-                {
-                    "dataset": self.p_datasetname.value_as_string,
-                    "pipeline": self.p_pipeline.value_as_string,
-                    "pipeline_stage": self.p_stagename.value_as_string,
-                    "trigger_type": self.p_triggertype.value_as_string,
-                    "event_pattern": "true",
-                    "org": self.p_org.value_as_string,
-                    "domain": self.p_domain.value_as_string,
-                }
-            ),
-        }
-        scheduler.CfnSchedule(
-            self,
-            "rPostStateSchedule",
-            name=f"sdlf-{self.p_datasetname.value_as_string}-{self.p_pipeline.value_as_string}-schedule-rule-{self.p_stagename.value_as_string}",
-            description=f"Trigger {self.p_stagename.value_as_string} Routing Lambda on a specified schedule",
-            group_name=f"{{{{resolve:ssm:/SDLF/EventBridge/{self.p_datasetname.value_as_string}/ScheduleGroupName}}}}",
-            kms_key_arn=f"{{{{resolve:ssm:/SDLF/KMS/{self.p_datasetname.value_as_string}/InfraKeyId}}}}",
-            schedule_expression=self.p_schedule.value_as_string,
-            flexible_time_window=scheduler.CfnSchedule.FlexibleTimeWindowProperty(
-                mode="OFF",
-            ),
-            state="ENABLED" if self.p_stageenabled.value_as_string.lower() == "true" else "DISABLED",
-            target=scheduler.CfnSchedule.TargetProperty(
-                arn=f"arn:{scope.partition}:scheduler:::aws-sdk:lambda:invoke",
-                role_arn=poststateschedule_role.role_arn,
-                input=json.dumps(poststate_schedule_input),
-            ),
-        )
-
-        ssm.StringParameter(
-            self,
-            "rPipelineStageSsm",
-            description=f"Placeholder {self.p_datasetname.value_as_string} {self.p_pipeline.value_as_string} {self.p_stagename.value_as_string}",
-            parameter_name=f"/SDLF/Pipelines/{self.p_datasetname.value_as_string}/{self.p_pipeline.value_as_string}/{self.p_stagename.value_as_string}",
-            simple_name=False,  # parameter name is a token
-            string_value="placeholder",
-        )
+    external_interface = {}
 
     def __init__(
         self,
@@ -200,116 +30,184 @@ class Pipeline(Construct):
         dataset: str,
         pipeline: str,
         stage: str,
-        stage_enabled: str,
         trigger_type: str,
-        schedule: str,
-        event_pattern: str,
-        org: str,
-        data_domain: str,
+        trigger_target: str, # here, a lambda arn. later: eventbridge universal target
+        kms_key: str,
+        stage_enabled: bool = True,
+        schedule: str = None, # only used if schedule or event-schedule
+        event_pattern: str = None, # only used if event or event-schedule
+        event_bus: str = "default", # can be default
+        schedule_group: str = "default", # can be default
+        # permissions boundary yeah well...
         **kwargs,
     ) -> None:
         super().__init__(scope, id)
 
-        # if arguments are passed to the constructor, their values are fed to CfnParameter() below as default
-        # if arguments aren't specified, standard SDLF SSM parameters are checked instead
-        # the jury is still out on the usage of CfnParameter(),
-        # and there is still work to get the latest SSM parameter values as well as using a prefix to allow multiple deployments TODO
-        trigger_type = trigger_type or "event"
-        schedule = schedule or "cron(*/5 * * * ? *)"
-        event_pattern = event_pattern or ""
-        org = org or "{{resolve:ssm:/sdlf/storage/rOrganization:1}}"
-        data_domain = data_domain or "{{resolve:ssm:/sdlf/storage/rDomain:1}}"
+        # Pipeline stages have three types of triggers: event, event-schedule, schedule
+        # event: run stage when an event received on the team's event bus matches the configured event pattern
+        # event-schedule: store events received on the team's event bus matching the configured event pattern, then process them on the configured schedule
+        # schedule: run stage on the configured schedule, without any event as input
 
-        self.p_pipelinereference = CfnParameter(
-            self,
-            "pPipelineReference",
-            type="String",
-            default="none",
-        )
-        self.p_pipelinereference.override_logical_id("pPipelineReference")
-        self.p_org = CfnParameter(
-            self,
-            "pOrg",
-            description="Name of the organization owning the datalake",
-            type="String",
-            default=org,
-        )
-        self.p_org.override_logical_id("pOrg")
-        self.p_domain = CfnParameter(
-            self,
-            "pDomain",
-            description="Data domain name",
-            type="String",
-            default=data_domain,
-        )
-        self.p_domain.override_logical_id("pDomain")
-        self.p_datasetname = CfnParameter(
-            self,
-            "pDatasetName",
-            description="Name of the dataset (all lowercase, no symbols or spaces)",
-            type="String",
-            allowed_pattern="[a-z0-9]{2,14}",
-            default=dataset,
-        )
-        self.p_datasetname.override_logical_id("pDatasetName")
-        self.p_pipeline = CfnParameter(
-            self,
-            "pPipelineName",
-            description="The name of the pipeline (all lowercase, no symbols or spaces)",
-            type="String",
-            allowed_pattern="[a-z0-9]*",
-            default=pipeline,
-        )
-        self.p_pipeline.override_logical_id("pPipeline")
-        self.p_stagename = CfnParameter(
-            self,
-            "pStageName",
-            description="Name of the stage (all lowercase, hyphen allowed, no other symbols or spaces)",
-            type="String",
-            allowed_pattern="[a-zA-Z0-9\\-]{1,12}",
-            default=stage,
-        )
-        self.p_stagename.override_logical_id("pStageName")
-        self.p_stageenabled = CfnParameter(
-            self,
-            "pStageEnabled",
-            description="Whether the stage is enabled or not",
-            type="String",
-            allowed_values=["true", "false"],
-            default=stage_enabled,
-        )
-        self.p_stageenabled.override_logical_id("pStageEnabled")
-        self.p_triggertype = CfnParameter(
-            self,
-            "pTriggerType",
-            description="Trigger type of the stage (event or schedule)",
-            type="String",
-            allowed_values=["event", "schedule"],
-            default=trigger_type,
-        )
-        self.p_triggertype.override_logical_id("pTriggerType")
-        self.p_schedule = CfnParameter(
-            self,
-            "pSchedule",
-            description="Cron expression when trigger type is schedule",
-            type="String",
-            default=schedule,
-        )
-        self.p_schedule.override_logical_id("pSchedule")
-        self.p_eventpattern = CfnParameter(
-            self,
-            "pEventPattern",
-            description="Event pattern to match from previous stage",
-            type="String",
-            default=event_pattern,
-        )
-        self.p_eventpattern.override_logical_id("pEventPattern")
+        if event_pattern: # infra needed for event and event-schedule (trigger-type in ["event", "schedule"], and event_pattern specified)
+            routing_dlq_resource_name = "rDeadLetterQueueRoutingStep"
+            routing_dlq = sqs.Queue(
+                self,
+                routing_dlq_resource_name,
+                removal_policy=RemovalPolicy.DESTROY,
+                queue_name=f"sdlf-{dataset}-{pipeline}-dlq-{stage}.fifo",
+                fifo=True,
+                retention_period=Duration.days(14),
+                visibility_timeout=Duration.seconds(60),
+                encryption_master_key=kms.Key.from_key_arn(
+                    self,
+                    "rDeadLetterQueueRoutingStepEncryption",
+                    key_arn=kms_key,
+                ),
+            )
+            self._external_interface(
+                routing_dlq_resource_name,
+                f"Name of the {stage} {dataset} {pipeline} DLQ",
+                routing_dlq.queue_name,
+            )
+
+            routing_queue_resource_name = "rQueueRoutingStep"
+            routing_queue = sqs.Queue(
+                self,
+                routing_queue_resource_name,
+                removal_policy=RemovalPolicy.DESTROY,
+                queue_name=f"sdlf-{dataset}-{pipeline}-queue-{stage}.fifo",
+                fifo=True,
+                content_based_deduplication=True,
+                retention_period=Duration.days(7),
+                visibility_timeout=Duration.seconds(60),
+                encryption_master_key=kms.Key.from_key_arn(
+                    self,
+                    "rQueueRoutingStepEncryption",
+                    key_arn=kms_key,
+                ),
+                dead_letter_queue=sqs.DeadLetterQueue(
+                    max_receive_count=1,
+                    queue=routing_dlq,
+                ),
+            )
+            self._external_interface(
+                routing_queue_resource_name,
+                f"Name of the {stage} {dataset} {pipeline} Queue",
+                routing_dlq.queue_name,
+            )
+
+            stage_rule = events.Rule(
+                self,
+                "rStageRule",
+                rule_name=f"sdlf-{dataset}-{pipeline}-rule-{stage}",
+                description=f"Send events to {stage} queue",
+                event_bus=events.EventBus.from_event_bus_name(
+                    self,
+                    "rStageRuleEventBus",
+                    event_bus,
+                ),
+                enabled=stage_enabled,
+                event_pattern={key.replace("-", "_"): value for key,value in json.loads(event_pattern).items()}, # events.EventPattern(**json.loads(event_pattern)), #{"source": ["aws.states"]},
+                targets=[
+                    targets.SqsQueue(
+                        routing_queue,
+                        message_group_id=f"{dataset}-{pipeline}",
+                        message=events.RuleTargetInput.from_event_path("$.detail"),
+                    )
+                ],
+            )
+
+            routing_queue_policy = iam.PolicyStatement(
+                effect=iam.Effect.ALLOW,
+                principals=[
+                    iam.ServicePrincipal("events.amazonaws.com"),
+                ],
+                actions=["SQS:SendMessage"],
+                resources=[routing_queue.queue_arn],
+                conditions={"ArnEquals": {"aws:SourceArn": stage_rule.rule_arn}},
+            )
+            routing_queue.add_to_resource_policy(routing_queue_policy)  # TODO may be a cdk grant
+
+        if trigger_type == "event" and event_pattern: # infra needed for event only
+            _lambda.Function.from_function_arn(self, "rRoutingLambda", function_arn=trigger_target).add_event_source(SqsEventSource(routing_queue, batch_size=10))
+
+        if schedule: # infra needed for event-schedule and schedule (trigger-type in ["event", "schedule"], and schedule specified)
+            poststateschedule_role_policy = iam.Policy(
+                self,
+                "sdlf-schedule",
+                statements=[
+                    iam.PolicyStatement(
+                        actions=["lambda:InvokeFunction"],
+                        resources=[trigger_target, f"{trigger_target}:*"],
+                    ),
+                    iam.PolicyStatement(
+                        actions=["kms:Decrypt"],
+                        resources=[kms_key],
+                    ),
+                ],
+            )
+            poststateschedule_role = iam.Role(
+                self,
+                "rPostStateScheduleRole",
+                path=f"/sdlf-{dataset}/",
+                assumed_by=iam.ServicePrincipal("scheduler.amazonaws.com"),
+                # permissions_boundary=iam.ManagedPolicy.from_managed_policy_arn(
+                #     self,
+                #     "rPostStateScheduleRolePermissionsBoundary",
+                #     managed_policy_arn=f"{{{{resolve:ssm:/sdlf/IAM/{dataset}/TeamPermissionsBoundary}}}}",
+                # ),
+            )
+            poststateschedule_role.attach_inline_policy(poststateschedule_role_policy)
+
+            poststate_schedule_input = {
+                "FunctionName": trigger_target,
+                "InvocationType": "Event",
+                "Payload": json.dumps(
+                    {
+                        "dataset": dataset,
+                        "pipeline": pipeline,
+                        "pipeline_stage": stage,
+                        "trigger_type": trigger_type,
+                        "event_pattern": "true",  # TODO not too sure passing org, domain, is that useful, maybe others too
+                        "domain": data_domain,
+                        "org": org,
+                    }
+                ),
+            }
+            scheduler.CfnSchedule(
+                self,
+                "rPostStateSchedule",
+                name=f"sdlf-{dataset}-{pipeline}-schedule-rule-{stage}",
+                description=f"Trigger {stage} Routing Lambda on a specified schedule",
+                group_name=schedule_group,
+                kms_key_arn=kms_key,
+                schedule_expression=schedule,
+                flexible_time_window=scheduler.CfnSchedule.FlexibleTimeWindowProperty(
+                    mode="OFF",
+                ),
+                state="ENABLED" if stage_enabled.lower() == "true" else "DISABLED",
+                target=scheduler.CfnSchedule.TargetProperty(
+                    arn=f"arn:{scope.partition}:scheduler:::aws-sdk:lambda:invoke",
+                    role_arn=poststateschedule_role.role_arn,
+                    input=json.dumps(poststate_schedule_input),
+                ),
+            )
 
         # CloudFormation Outputs TODO
-        o_pipelinereference = CfnOutput(
+        # o_pipelinereference = CfnOutput(
+        #     self,
+        #     "oPipelineReference",
+        #     description="CodePipeline reference this stack has been deployed with",
+        #     value=p_pipelinereference.value_as_string,
+        # )
+        # o_pipelinereference.override_logical_id("oPipelineReference")
+
+    def _external_interface(self, resource_name, description, value):
+        ssm.StringParameter(
             self,
-            "oPipelineReference",
-            description="CodePipeline reference this stack has been deployed with",
-            value=self.p_pipelinereference.value_as_string,
+            f"{resource_name}Ssm",
+            description=description,
+            parameter_name=f"/sdlf/pipeline/{resource_name}",
+            string_value=value,
         )
-        o_pipelinereference.override_logical_id("oPipelineReference")
+        self.external_interface[resource_name] = value

--- a/sdlf-stage-lambda/deployspec.yaml
+++ b/sdlf-stage-lambda/deployspec.yaml
@@ -1,142 +1,31 @@
-publishGenericEnvVariables: true
+publishGenericEnvVariables: True
 deploy:
   phases:
     install:
       commands:
+        - npm install -g aws-cdk
         - |-
-            # force Python3.12
-            rm -Rf ~/.venv/
-            pyenv global 3.12
-            python3 -m venv ~/.venv
-            . ~/.venv/bin/activate
-            pip install --upgrade pip setuptools
-            pip install aws-codeseeder~=1.1.0 seed-farmer==5.0.0
-        - |-
-            CFN_ENDPOINT="https://cloudformation.$AWS_REGION.amazonaws.com"
-            ARTIFACTS_BUCKET=$(aws cloudformation --endpoint-url "$CFN_ENDPOINT" describe-stacks --query "Stacks[?StackName=='aws-codeseeder-$SEEDFARMER_PROJECT_NAME'][].Outputs[?OutputKey=='Bucket'].OutputValue" --output text)
-
-            deps=(
-              "https://raw.githubusercontent.com/aws/serverless-application-model/develop/bin/sam-translate.py"
-              "https://github.com/aws/aws-sam-cli/releases/latest/download/aws-sam-cli-linux-x86_64.zip"
-              "https://raw.githubusercontent.com/awslabs/aws-serverless-data-lake-framework/main/sdlf-cicd/template-generic-cfn-module.yaml"
-            )
-            for u in "${deps[@]}"; do
-              aws s3api get-object --bucket "$ARTIFACTS_BUCKET" --key "${u##*/}" "${u##*/}" || {
-                curl -L -O "$u"
-                aws s3api put-object --bucket "$ARTIFACTS_BUCKET" --key "${u##*/}" --body "${u##*/}"
-              }
-            done
-        - |-
-            pip uninstall -y aws-sam-cli && unzip -q aws-sam-cli-linux-x86_64.zip -d sam-installation
-            ./sam-installation/install && sam --version
-            pip install "cfn-lint<1" cloudformation-cli poetry
-            npm install -g aws-cdk@2.159.1
-            poetry config virtualenvs.create false --local
+          pip install --upgrade pip setuptools
+          pip install poetry
+          poetry config virtualenvs.create false --local
+          poetry install -v
     build:
       commands:
         - |-
-          # deployment-type possible values: cfn-module, cdk-construct
-          # cfn-module creates a CloudFormation Registry module out of template.yaml
-          # cdk-construct publishes a pip library out of template.py on CodeArtifact
-          echo "$SEEDFARMER_PARAMETER_DEPLOYMENT_TYPE"
-        - |-
-          if [ "$SEEDFARMER_PARAMETER_DEPLOYMENT_TYPE" = "cfn-module" ]; then
-            # SEEDFARMER_PARAMETER_LIBRARY_MODULE can be used to pass the module name. If not, the module name is inferred from SEEDFARMER_MODULE_NAME
-            # by removing everything up to the first hyphen, then anything that isn't a letter/number, and lower-casing everything.
-            sf_module_name_without_prefix="${SEEDFARMER_MODULE_NAME#*-}"
-            sf_module_name_alnum="${sf_module_name_without_prefix//[^[:alnum:]]/}"
-            MODULE="${sf_module_name_alnum,,}"
-
-            : "${SEEDFARMER_PARAMETER_LIBRARY_ORG:=awslabs}" "${SEEDFARMER_PARAMETER_LIBRARY_FRAMEWORK:=sdlf}" "${SEEDFARMER_PARAMETER_LIBRARY_MODULE:=$MODULE}"
-            cd src || exit
-            sam package --template-file ./template.yaml --s3-bucket "$ARTIFACTS_BUCKET" --s3-prefix sdlf --output-template-file template.yaml
-            python3 ../sam-translate.py --template-file=template.yaml --output-template=translated-template.json
-
-            SSM_ENDPOINT="https://ssm.$AWS_REGION.amazonaws.com"
-            TEMPLATE_BASE_FILE_PATH="modules/$SEEDFARMER_PARAMETER_LIBRARY_ORG/$SEEDFARMER_PARAMETER_LIBRARY_FRAMEWORK/$SEEDFARMER_PARAMETER_LIBRARY_MODULE"
-            aws s3api put-object --bucket "$ARTIFACTS_BUCKET" --key "$TEMPLATE_BASE_FILE_PATH/translated-template.json" --body translated-template.json
-            TEMPLATE_URL="https://$ARTIFACTS_BUCKET.s3.$AWS_REGION.amazonaws.com/$TEMPLATE_BASE_FILE_PATH/translated-template.json"
-            aws cloudformation --endpoint-url "$CFN_ENDPOINT" validate-template --template-url "$TEMPLATE_URL"
-
-            mkdir module
-            cd module || exit
-            cfn init --artifact-type MODULE --type-name "$SEEDFARMER_PARAMETER_LIBRARY_ORG::$SEEDFARMER_PARAMETER_LIBRARY_FRAMEWORK::$SEEDFARMER_PARAMETER_LIBRARY_MODULE::MODULE" && rm fragments/sample.json
-            cp -i -a ../translated-template.json fragments/
-            cfn generate
-            zip -q -r "../$SEEDFARMER_PARAMETER_LIBRARY_MODULE.zip" .rpdk-config fragments/ schema.json
-
-            NEW_MODULE="$(sha256sum "../$SEEDFARMER_PARAMETER_LIBRARY_MODULE.zip" | cut -c1-12)"
-            aws s3api put-object --bucket "$ARTIFACTS_BUCKET" --key "$TEMPLATE_BASE_FILE_PATH-$NEW_MODULE.zip" --body "../$SEEDFARMER_PARAMETER_LIBRARY_MODULE.zip"
-
-            if CURRENT_MODULE=$(aws ssm --endpoint-url "$SSM_ENDPOINT" get-parameter --name "/SDLF/CFN/$SEEDFARMER_PARAMETER_LIBRARY_ORG-$SEEDFARMER_PARAMETER_LIBRARY_FRAMEWORK-$SEEDFARMER_PARAMETER_LIBRARY_MODULE-MODULE" --query "Parameter.Value" --output text); then
-              echo "Current module hash: $CURRENT_MODULE / New module hash: $NEW_MODULE"
-              if [ "$NEW_MODULE" == "$CURRENT_MODULE" ]; then
-                echo "No change since last build, exiting module creation."
-                exit 0
-              fi
-            fi
-
-            STACK_NAME="sdlf-cfn-module-$SEEDFARMER_PARAMETER_LIBRARY_FRAMEWORK-$SEEDFARMER_PARAMETER_LIBRARY_MODULE"
-            aws cloudformation --endpoint-url "$CFN_ENDPOINT" deploy \
-              --stack-name "$STACK_NAME" \
-              --template-file ../../template-generic-cfn-module.yaml \
-              --parameter-overrides \
-                  pArtifactsBucket="$ARTIFACTS_BUCKET" \
-                  pLibraryOrg="$SEEDFARMER_PARAMETER_LIBRARY_ORG" \
-                  pLibraryFramework="$SEEDFARMER_PARAMETER_LIBRARY_FRAMEWORK" \
-                  pLibraryModule="$SEEDFARMER_PARAMETER_LIBRARY_MODULE" \
-                  pModuleGitRef="$NEW_MODULE" \
-              --tags Framework=sdlf || exit 1
-            echo "done"
-            cd .. && rm -Rf module
-          fi
-        - |-
-          if [ "$SEEDFARMER_PARAMETER_DEPLOYMENT_TYPE" = "cdk-construct" ]; then
-            CA_ENDPOINT="https://codeartifact.$AWS_REGION.amazonaws.com"
-            CA_REPOSITORY_ENDPOINT=$(aws codeartifact --endpoint-url "$CA_ENDPOINT" get-repository-endpoint --domain "$SEEDFARMER_PARAMETER_CODEARTIFACT_DOMAIN" --domain-owner "$AWS_ACCOUNT_ID" --repository "$SEEDFARMER_PARAMETER_CODEARTIFACT_REPOSITORY" --format pypi --query repositoryEndpoint --output text)
-            CA_TOKEN=$(aws codeartifact --endpoint-url "$CA_ENDPOINT" get-authorization-token --domain "$SEEDFARMER_PARAMETER_CODEARTIFACT_DOMAIN" --domain-owner "$AWS_ACCOUNT_ID" --query authorizationToken --output text)
-            poetry source add private "https://aws:${CA_TOKEN}@${CA_REPOSITORY_ENDPOINT#https://}simple/"
-            poetry install -v
-            poetry config repositories.private "$CA_REPOSITORY_ENDPOINT"
-            poetry config http-basic.private aws "$CA_TOKEN"
-            poetry publish --skip-existing --build -r private || exit 1
-          fi
-    post_build:
-      commands:
-      - echo "Deploy successful"
+          env | grep "SEEDFARMER"
+          mv sdlf-pipeline/src/pipeline.py src/
+          cdk deploy --all --require-approval never --progress events --app "python src/app.py" --outputs-file ./cdk-exports.json
+        - seedfarmer metadata convert -f cdk-exports.json || true
 destroy:
   phases:
     install:
       commands:
+        - npm install -g aws-cdk
         - |-
-            pip install --upgrade pip setuptools
-            pip install poetry
+          pip install --upgrade pip setuptools
+          pip install poetry
+          poetry config virtualenvs.create false --local
+          poetry install -v
     build:
       commands:
-      - |-
-          echo "DESTROY! $SEEDFARMER_PARAMETER_DEPLOYMENT_TYPE"
-      - |-
-          if [ "$SEEDFARMER_PARAMETER_DEPLOYMENT_TYPE" = "cfn-module" ]; then
-            CFN_ENDPOINT="https://cloudformation.$AWS_REGION.amazonaws.com"
-            sf_module_name_without_prefix="${SEEDFARMER_MODULE_NAME#*-}"
-            sf_module_name_alnum="${sf_module_name_without_prefix//[^[:alnum:]]/}"
-            MODULE="${sf_module_name_alnum,,}"
-            : "${SEEDFARMER_PARAMETER_LIBRARY_ORG:=awslabs}" "${SEEDFARMER_PARAMETER_LIBRARY_FRAMEWORK:=sdlf}" "${SEEDFARMER_PARAMETER_LIBRARY_MODULE:=$MODULE}"
-            STACK_NAME="sdlf-cfn-module-$SEEDFARMER_PARAMETER_LIBRARY_FRAMEWORK-$SEEDFARMER_PARAMETER_LIBRARY_MODULE"
-            aws cloudformation --endpoint-url "$CFN_ENDPOINT" delete-stack --stack-name "$STACK_NAME" || exit 1
-          fi
-      - |-
-          if [ "$SEEDFARMER_PARAMETER_DEPLOYMENT_TYPE" = "cdk-construct" ]; then
-            CA_ENDPOINT="https://codeartifact.$AWS_REGION.amazonaws.com"
-            package_version_poetry=$(poetry version --short)
-            package_prerelease_id=$(echo "$package_version_poetry" | cut -d'-' -f2 | cut -d'.' -f1)
-            pypi_prerelease_id=$(test "$package_prerelease_id" = "rc" && echo "rc" || echo "${package_prerelease_id:0:1}")
-            pypi_package_version="$(echo "$package_version_poetry" | cut -d'-' -f1)$pypi_prerelease_id$(echo "$package_version_poetry" | cut -d'-' -f2 | cut -d'.' -f2)"
-            aws codeartifact --endpoint-url "$CA_ENDPOINT" delete-package-versions \
-              --domain "$SEEDFARMER_PARAMETER_CODEARTIFACT_DOMAIN" --domain-owner "$AWS_ACCOUNT_ID" \
-              --repository "$SEEDFARMER_PARAMETER_CODEARTIFACT_REPOSITORY" --format pypi --package "$(poetry version | cut -d' ' -f1)" --versions "$pypi_package_version"
-          fi
-    post_build:
-      commands:
-      - echo "Destroy successful"
-build_type: BUILD_GENERAL1_SMALL
+        - cdk destroy --force --all --app "python src/app.py"

--- a/sdlf-stage-lambda/pyproject.toml
+++ b/sdlf-stage-lambda/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "sdlf.stage-lambda"
-version = "2.7.0-alpha.0"
+version = "2.7.0-alpha.1"
 description = "AWS Serverless Data Lake Framework"
 authors = ["Amazon Web Services"]
 license = "MIT-0"
@@ -15,10 +15,10 @@ packages = [
 exclude = ["**/*.yaml"]
 
 [tool.poetry.dependencies]
-python = "^3.12"
+python = "^3.11"
 aws-cdk-lib = "^2.159.1"
 constructs = ">=10.0.0,<11.0.0"
-sdlf-pipeline = "^2.7.0a0"
+#sdlf-pipeline = "^2.7.0a1"
 
 [build-system]
 requires = ["poetry-core"]

--- a/sdlf-stage-lambda/src/app.py
+++ b/sdlf-stage-lambda/src/app.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+
+import os
+
+import aws_cdk as cdk
+from awslambda import StageLambda
+
+# Project specific
+project_name = os.getenv("SEEDFARMER_PROJECT_NAME", "")
+deployment_name = os.getenv("SEEDFARMER_DEPLOYMENT_NAME", "")
+module_name = os.getenv("SEEDFARMER_MODULE_NAME", "")
+
+if project_name:
+    stack_name = f"{project_name}-{deployment_name}-{module_name}"
+    param_prefix = "SEEDFARMER_PARAMETER_"
+else:  # app.py not used in a seedfarmer context somehow
+    stack_name = "sdlf-stage-lambda"
+    param_prefix = ""
+
+
+def _param(name: str, default: str = None) -> str:
+    return os.getenv(f"{param_prefix}{name}", default)
+
+
+env = cdk.Environment(account=os.getenv("CDK_DEFAULT_ACCOUNT"), region=os.getenv("CDK_DEFAULT_REGION"))
+
+app = cdk.App()
+stack = cdk.Stack(app, stack_name, env=env)
+stack_stagelambda = StageLambda(
+    stack,
+    "stagelambda",
+    org=_param("ORG"),
+    data_domain=_param("DATA_DOMAIN"),
+    raw_bucket=_param("RAW_BUCKET"),
+    stage_bucket=_param("STAGE_BUCKET"),
+    infra_kms_key=_param("INFRA_KMS_KEY"),
+    data_kms_key=_param("DATA_KMS_KEY"),
+    transform=_param("TRANSFORM"),
+    dataset=_param("DATASET"),
+    pipeline=_param("PIPELINE"),
+    stage=_param("STAGE"),
+    trigger_type=_param("TRIGGER_TYPE"),
+    event_bus=_param("EVENT_BUS"),
+    event_pattern=_param("EVENT_PATTERN"),
+)
+
+cdk.CfnOutput(
+    scope=stack,
+    id="metadata",
+    value=stack.to_json_string(stack_stagelambda.external_interface),
+)
+
+app.synth()

--- a/sdlf-stage-lambda/src/state-machine/stage-lambda.asl.json
+++ b/sdlf-stage-lambda/src/state-machine/stage-lambda.asl.json
@@ -33,7 +33,7 @@
                     "ResultPath": "$",
                     "Parameters": {
                       "Payload.$": "$.Items",
-                      "FunctionName.$": "$.Items[0].transform.transform"
+                      "FunctionName": "${lTransform}:$LATEST"
                     },
                     "Retry": [
                       {


### PR DESCRIPTION
*Description of changes:*
* sdlf-pipeline no longer contains any CfnParameter
* use python 3.11 for cdk (seedfarmer just does not play well with python3.12 currently)
* rework sdlf-stage-lambda deployspec to be more in line with the existing seedfarmer community
* let CloudFormation generate SQS queue names
* follow the new format set in sdlf-foundations and sdlf-dataset for SSM parameters
* remove references to Octagon
* use sdlf-datalakeLibrary lambda layer in stage lambda functions
* pass the event pattern from the user to the event rule properly

still all WIP for now...

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
