### PR TITLE
remove legacy ObjectMetadata table references

### DIFF
--- a/sdlf-datalakeLibrary/python/datalake_library/sdlf/config.py
+++ b/sdlf-datalakeLibrary/python/datalake_library/sdlf/config.py
@@ -73,7 +73,6 @@ class DynamoConfiguration:
         log_level=None,
         ssm_interface=None,
         instance=None,
-        object_metadata_table_instance=None,
         peh_table_instance=None,
         manifests_table_instance=None,
     ):
@@ -84,7 +83,6 @@ class DynamoConfiguration:
         """
         self.log_level = log_level or os.getenv("LOG_LEVEL", "INFO")
         self._logger = init_logger(__name__, self.log_level)
-        self.object_metadata_table_instance = object_metadata_table_instance or instance
         self.peh_table_instance = peh_table_instance or instance
         self.manifests_table_instance = manifests_table_instance or instance
 
@@ -95,13 +93,9 @@ class DynamoConfiguration:
 
     def _fetch_from_ssm(self):
         self._logger.info(
-            f"Reading configuration from SSM Parameter Store with configuration instances: {self.object_metadata_table_instance} {self.peh_table_instance} {self.manifests_table_instance}"
+            f"Reading configuration from SSM Parameter Store with configuration instances: {self.peh_table_instance} {self.manifests_table_instance}"
         )
         try:
-            object_metadata_table_ssm = f"/sdlf/storage/rDynamoObjectMetadata/{self.object_metadata_table_instance}"
-            self._logger.debug(f"Obtaining SSM Parameter: {object_metadata_table_ssm}")
-            self.object_metadata_table = self._ssm.get_parameter(Name=object_metadata_table_ssm)["Parameter"]["Value"]
-
             peh_table_ssm = f"/sdlf/dataset/rDynamoPipelineExecutionHistory/{self.peh_table_instance}"
             self._logger.debug(f"Obtaining SSM Parameter: {peh_table_ssm}")
             self.peh_table = self._ssm.get_parameter(Name=peh_table_ssm)["Parameter"]["Value"]

--- a/sdlf-datalakeLibrary/python/datalake_library/sdlf/peh.py
+++ b/sdlf-datalakeLibrary/python/datalake_library/sdlf/peh.py
@@ -37,14 +37,12 @@ class PipelineExecutionHistoryAPI:
         region: str = "us-east-1",
         profile: str = "default",
         # instance: str = "dev",
-        object_metadata_table_instance=None,
         peh_table_instance=None,
         manifests_table_instance=None,
         sns_topic: str = None,
     ):
         self.dynamodb = boto3.client("dynamodb")
         dynamo_config = DynamoConfiguration(
-            object_metadata_table_instance=object_metadata_table_instance,
             peh_table_instance=peh_table_instance,
             manifests_table_instance=manifests_table_instance,
         )

--- a/sdlf-stage-glue/src/lambda/postupdate-metadata/src/lambda_function.py
+++ b/sdlf-stage-glue/src/lambda/postupdate-metadata/src/lambda_function.py
@@ -8,7 +8,6 @@ dataset = os.environ["DATASET"]
 pipeline = os.environ["PIPELINE"]
 pipeline_stage = os.environ["PIPELINE_STAGE"]
 deployment_instance = os.environ["DEPLOYMENT_INSTANCE"]
-object_metadata_table_instance = os.environ["STORAGE_DEPLOYMENT_INSTANCE"]
 peh_table_instance = os.environ["DATASET_DEPLOYMENT_INSTANCE"]
 manifests_table_instance = os.environ["DATASET_DEPLOYMENT_INSTANCE"]
 
@@ -29,7 +28,6 @@ def lambda_handler(event, context):
         pipeline_execution = PipelineExecutionHistoryAPI(
             run_in_context="LAMBDA",
             region=os.getenv("AWS_REGION"),
-            object_metadata_table_instance=object_metadata_table_instance,
             peh_table_instance=peh_table_instance,
             manifests_table_instance=manifests_table_instance,
         )

--- a/sdlf-stage-glue/src/lambda/redrive/src/lambda_function.py
+++ b/sdlf-stage-glue/src/lambda/redrive/src/lambda_function.py
@@ -5,11 +5,12 @@ from datalake_library.configuration.resource_configs import SQSConfiguration
 from datalake_library.interfaces.sqs_interface import SQSInterface
 
 logger = init_logger(__name__)
+deployment_instance = os.environ["DEPLOYMENT_INSTANCE"]
 
 
 def lambda_handler(event, context):
     try:
-        sqs_config = SQSConfiguration(os.environ["TEAM"], os.environ["PIPELINE"], os.environ["STAGE"])
+        sqs_config = SQSConfiguration(instance=deployment_instance)
         dlq_interface = SQSInterface(sqs_config.get_stage_dlq_name)
         messages = dlq_interface.receive_messages(1)
         if not messages:

--- a/sdlf-stage-glue/src/lambda/routing/src/lambda_function.py
+++ b/sdlf-stage-glue/src/lambda/routing/src/lambda_function.py
@@ -16,7 +16,6 @@ dataset = os.environ["DATASET"]
 pipeline = os.environ["PIPELINE"]
 pipeline_stage = os.environ["PIPELINE_STAGE"]
 deployment_instance = os.environ["DEPLOYMENT_INSTANCE"]
-object_metadata_table_instance = os.environ["STORAGE_DEPLOYMENT_INSTANCE"]
 peh_table_instance = os.environ["DATASET_DEPLOYMENT_INSTANCE"]
 manifests_table_instance = os.environ["DATASET_DEPLOYMENT_INSTANCE"]
 
@@ -97,7 +96,6 @@ def lambda_handler(event, context):
         pipeline_execution = PipelineExecutionHistoryAPI(
             run_in_context="LAMBDA",
             region=os.getenv("AWS_REGION"),
-            object_metadata_table_instance=object_metadata_table_instance,
             peh_table_instance=peh_table_instance,
             manifests_table_instance=manifests_table_instance,
         )

--- a/sdlf-stage-lambda/src/lambda/postupdate-metadata/src/lambda_function.py
+++ b/sdlf-stage-lambda/src/lambda/postupdate-metadata/src/lambda_function.py
@@ -8,7 +8,6 @@ dataset = os.environ["DATASET"]
 pipeline = os.environ["PIPELINE"]
 pipeline_stage = os.environ["PIPELINE_STAGE"]
 deployment_instance = os.environ["DEPLOYMENT_INSTANCE"]
-object_metadata_table_instance = os.environ["STORAGE_DEPLOYMENT_INSTANCE"]
 peh_table_instance = os.environ["DATASET_DEPLOYMENT_INSTANCE"]
 manifests_table_instance = os.environ["DATASET_DEPLOYMENT_INSTANCE"]
 
@@ -29,7 +28,6 @@ def lambda_handler(event, context):
         pipeline_execution = PipelineExecutionHistoryAPI(
             run_in_context="LAMBDA",
             region=os.getenv("AWS_REGION"),
-            object_metadata_table_instance=object_metadata_table_instance,
             peh_table_instance=peh_table_instance,
             manifests_table_instance=manifests_table_instance,
         )

--- a/sdlf-stage-lambda/src/lambda/routing/src/lambda_function.py
+++ b/sdlf-stage-lambda/src/lambda/routing/src/lambda_function.py
@@ -16,7 +16,6 @@ dataset = os.environ["DATASET"]
 pipeline = os.environ["PIPELINE"]
 pipeline_stage = os.environ["PIPELINE_STAGE"]
 deployment_instance = os.environ["DEPLOYMENT_INSTANCE"]
-object_metadata_table_instance = os.environ["STORAGE_DEPLOYMENT_INSTANCE"]
 peh_table_instance = os.environ["DATASET_DEPLOYMENT_INSTANCE"]
 manifests_table_instance = os.environ["DATASET_DEPLOYMENT_INSTANCE"]
 
@@ -97,7 +96,6 @@ def lambda_handler(event, context):
         pipeline_execution = PipelineExecutionHistoryAPI(
             run_in_context="LAMBDA",
             region=os.getenv("AWS_REGION"),
-            object_metadata_table_instance=object_metadata_table_instance,
             peh_table_instance=peh_table_instance,
             manifests_table_instance=manifests_table_instance,
         )


### PR DESCRIPTION
*Description of changes:*
[sdlf-stage-glue] use deployment_instance in redrive
[sdlf-stage-glue] remove legacy ObjectMetadata table references
[sdlf-stage-lambda] remove legacy ObjectMetadata table references
[sdlf-datalakeLibrary] remove legacy ObjectMetadata table references

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
