### PR TITLE
fix: add conditional on empty custom identifier SSM param

### DIFF
--- a/sdlf-cicd/template-cicd-domain-roles.yaml
+++ b/sdlf-cicd/template-cicd-domain-roles.yaml
@@ -38,6 +38,7 @@ Conditions:
   UseCustomBucketPrefix: !Not [!Equals [!Ref pCustomBucketPrefix, sdlf]]
   RunInVpc: !Equals [!Ref pEnableVpc, true]
   EnableMonitoring: !Equals [!Ref pEnableMonitoring, true]
+  HasCustomIdentifier: !Not [!Equals [!Ref pCustomIdentifier, ""]]
 
 Resources:
   ######## OPTIONAL SDLF FEATURES #########
@@ -64,7 +65,7 @@ Resources:
     Properties:
       Name: /SDLF/CustomIdentifier
       Type: String
-      Value: !Ref pCustomIdentifier
+      Value: !If [HasCustomIdentifier, !Ref pCustomIdentifier, "FALSE"]
       Description: Add a custom identifier to foundational resource names
 
   rDevopsCrossaccountCodePipelineRole:

--- a/sdlf-foundations/src/template.yaml
+++ b/sdlf-foundations/src/template.yaml
@@ -83,6 +83,7 @@ Parameters:
 Conditions:
   UseCustomBucketPrefix: !Not [!Equals [!Ref pCustomBucketPrefix, sdlf]]
   UseLegacyTables: !Equals [!Ref pLegacyTables, true]
+  UseCustomSuffix: !Not [!Equals [!Ref pCustomSuffix, "FALSE"]]
   RunInVpc: !Equals [!Ref pEnableVpc, true]
 
 Globals:
@@ -315,7 +316,7 @@ Resources:
     UpdateReplacePolicy: Retain
     DeletionPolicy: RetainExceptOnCreate
     Properties:
-      AliasName: !Sub alias/sdlf-kms-key${pCustomSuffix}
+      AliasName: !If [UseCustomSuffix, !Sub "alias/sdlf-kms-key${pCustomSuffix}", "alias/sdlf-kms-key"]
       TargetKeyId: !Ref rKMSKey
 
   ######## SSM #########
@@ -726,7 +727,7 @@ Resources:
     DeletionPolicy: Delete
     UpdateReplacePolicy: Delete
     Properties:
-      QueueName: !Sub sdlf-catalog-queue${pCustomSuffix}
+      QueueName: !If [UseCustomSuffix, !Sub "sdlf-catalog-queue${pCustomSuffix}", "sdlf-catalog-queue"]
       RedrivePolicy:
         deadLetterTargetArn: !GetAtt rDeadLetterQueueCatalog.Arn
         maxReceiveCount: 1
@@ -739,7 +740,7 @@ Resources:
     DeletionPolicy: Delete
     UpdateReplacePolicy: Delete
     Properties:
-      QueueName: !Sub sdlf-catalog-dlq${pCustomSuffix}
+      QueueName: !If [UseCustomSuffix, !Sub "sdlf-catalog-dlq${pCustomSuffix}", "sdlf-catalog-dlq"]
       MessageRetentionPeriod: 1209600
       VisibilityTimeout: 60
       KmsMasterKeyId: !GetAtt rKMSKey.Arn
@@ -799,7 +800,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       CodeUri: ./lambda/catalog/src
-      FunctionName: !Sub sdlf-catalog${pCustomSuffix}
+      FunctionName: !If [UseCustomSuffix, !Sub "sdlf-catalog${pCustomSuffix}", "sdlf-catalog"]
       Environment:
         Variables:
           ENV: !Ref pEnvironment
@@ -813,7 +814,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       CodeUri: ./lambda/catalog-redrive/src
-      FunctionName: !Sub sdlf-catalog-redrive${pCustomSuffix}
+      FunctionName: !If [UseCustomSuffix, !Sub "sdlf-catalog-redrive${pCustomSuffix}", "sdlf-catalog-redrive"]
       Environment:
         Variables:
           QUEUE: !GetAtt rQueueCatalog.QueueName
@@ -960,7 +961,7 @@ Resources:
         - AttributeName: id
           KeyType: HASH
       BillingMode: PAY_PER_REQUEST
-      TableName: !Sub octagon-ObjectMetadata-${pEnvironment}${pCustomSuffix}
+      TableName: !If [UseCustomSuffix, !Sub "octagon-ObjectMetadata-${pEnvironment}${pCustomSuffix}", !Sub "octagon-ObjectMetadata-${pEnvironment}"]
       StreamSpecification:
         StreamViewType: NEW_AND_OLD_IMAGES
       SSESpecification:
@@ -988,7 +989,7 @@ Resources:
         - AttributeName: name
           AttributeType: S
       BillingMode: PAY_PER_REQUEST
-      TableName: !Sub octagon-Datasets-${pEnvironment}${pCustomSuffix}
+      TableName: !If [UseCustomSuffix, !Sub "octagon-Datasets-${pEnvironment}${pCustomSuffix}", !Sub "octagon-Datasets-${pEnvironment}"]
       SSESpecification:
         SSEEnabled: True
         SSEType: KMS
@@ -1063,7 +1064,7 @@ Resources:
               KeyType: HASH
           Projection:
             ProjectionType: ALL
-      TableName: !Sub octagon-Artifacts-${pEnvironment}${pCustomSuffix}
+      TableName: !If [UseCustomSuffix, !Sub "octagon-Artifacts-${pEnvironment}${pCustomSuffix}", !Sub "octagon-Artifacts-${pEnvironment}"]
       TimeToLiveSpecification:
         AttributeName: ttl
         Enabled: true
@@ -1125,7 +1126,7 @@ Resources:
               KeyType: RANGE
           Projection:
             ProjectionType: ALL
-      TableName: !Sub octagon-Metrics-${pEnvironment}${pCustomSuffix}
+      TableName: !If [UseCustomSuffix, !Sub "octagon-Metrics-${pEnvironment}${pCustomSuffix}", !Sub "octagon-Metrics-${pEnvironment}"]
       TimeToLiveSpecification:
         AttributeName: ttl
         Enabled: true
@@ -1163,7 +1164,7 @@ Resources:
               KeyType: HASH
           Projection:
             ProjectionType: ALL
-      TableName: !Sub octagon-Configuration-${pEnvironment}${pCustomSuffix}
+      TableName: !If [UseCustomSuffix, !Sub "octagon-Configuration-${pEnvironment}${pCustomSuffix}", !Sub "octagon-Configuration-${pEnvironment}"]
       SSESpecification:
         SSEEnabled: True
         SSEType: KMS
@@ -1189,7 +1190,7 @@ Resources:
         - AttributeName: team
           AttributeType: S
       BillingMode: PAY_PER_REQUEST
-      TableName: !Sub octagon-Teams-${pEnvironment}${pCustomSuffix}
+      TableName: !If [UseCustomSuffix, !Sub "octagon-Teams-${pEnvironment}${pCustomSuffix}", !Sub "octagon-Teams-${pEnvironment}"]
       SSESpecification:
         SSEEnabled: True
         SSEType: KMS
@@ -1215,7 +1216,7 @@ Resources:
         - AttributeName: name
           AttributeType: S
       BillingMode: PAY_PER_REQUEST
-      TableName: !Sub octagon-Pipelines-${pEnvironment}${pCustomSuffix}
+      TableName: !If [UseCustomSuffix, !Sub "octagon-Pipelines-${pEnvironment}${pCustomSuffix}", !Sub "octagon-Pipelines-${pEnvironment}"]
       SSESpecification:
         SSEEnabled: True
         SSEType: KMS
@@ -1274,7 +1275,7 @@ Resources:
               KeyType: RANGE
           Projection:
             ProjectionType: ALL
-      TableName: !Sub octagon-Events-${pEnvironment}${pCustomSuffix}
+      TableName: !If [UseCustomSuffix, !Sub "octagon-Events-${pEnvironment}${pCustomSuffix}", !Sub "octagon-Events-${pEnvironment}"]
       TimeToLiveSpecification:
         AttributeName: ttl
         Enabled: true
@@ -1372,7 +1373,7 @@ Resources:
               KeyType: RANGE
           Projection:
             ProjectionType: ALL
-      TableName: !Sub octagon-PipelineExecutionHistory-${pEnvironment}${pCustomSuffix}
+      TableName: !If [UseCustomSuffix, !Sub "octagon-PipelineExecutionHistory-${pEnvironment}${pCustomSuffix}", !Sub "octagon-PipelineExecutionHistory-${pEnvironment}"]
       TimeToLiveSpecification:
         AttributeName: ttl
         Enabled: true
@@ -1401,7 +1402,7 @@ Resources:
         - AttributeName: name
           AttributeType: S
       BillingMode: PAY_PER_REQUEST
-      TableName: !Sub octagon-DataSchemas-${pEnvironment}${pCustomSuffix}
+      TableName: !If [UseCustomSuffix, !Sub "octagon-DataSchemas-${pEnvironment}${pCustomSuffix}", !Sub "octagon-DataSchemas-${pEnvironment}"]
       StreamSpecification:
         StreamViewType: NEW_AND_OLD_IMAGES
       SSESpecification:
@@ -1433,7 +1434,7 @@ Resources:
         - AttributeName: datafile_name
           AttributeType: S
       BillingMode: PAY_PER_REQUEST
-      TableName: !Sub octagon-Manifests-${pEnvironment}${pCustomSuffix}
+      TableName: !If [UseCustomSuffix, !Sub "octagon-Manifests-${pEnvironment}${pCustomSuffix}", !Sub "octagon-Manifests-${pEnvironment}"]
       TimeToLiveSpecification:
         AttributeName: ttl
         Enabled: true
@@ -1508,7 +1509,7 @@ Resources:
     Type: AWS::Serverless::Function
     Condition: UseLegacyTables
     Properties:
-      FunctionName: !Sub sdlf-glue-replication${pCustomSuffix}
+      FunctionName: !If [UseCustomSuffix, !Sub "sdlf-glue-replication${pCustomSuffix}", "sdlf-glue-replication"]
       Description: Replicates Glue Catalog Metadata and Data Quality to Octagon Schemas Table
       CodeUri: ./lambda/replicate/src
       Environment:

--- a/sdlf-team/src/template.yaml
+++ b/sdlf-team/src/template.yaml
@@ -108,6 +108,7 @@ Conditions:
   CicdRoleProvided: !Not [!Equals [!Ref pCicdRole, ""]]
   UseLegacyTeam: !Equals [!Ref pLegacyTeam, true]
   RunInVpc: !Equals [!Ref pEnableVpc, true]
+  UseCustomOctagonSuffix: !Not [!Equals [!Ref pCustomOctagonSuffix, "FALSE"]]
 
 Globals:
   Function:
@@ -814,7 +815,7 @@ Resources:
         Variables:
           TEAM_NAME: !Ref pTeamName
           ENVIRONMENT: !Ref pEnvironment
-          CUSTOM_OCTAGON_SUFFIX: !Ref pCustomOctagonSuffix
+          CUSTOM_OCTAGON_SUFFIX: !If [UseCustomOctagonSuffix, !Ref pCustomOctagonSuffix, ""]
       CodeUri: ./lambda/datasets-dynamodb/src
 
   rPermissionForDatasetsEventsToInvokeLambda:
@@ -933,7 +934,7 @@ Resources:
         Variables:
           TEAM_NAME: !Ref pTeamName
           ENVIRONMENT: !Ref pEnvironment
-          CUSTOM_OCTAGON_SUFFIX: !Ref pCustomOctagonSuffix
+          CUSTOM_OCTAGON_SUFFIX: !If [UseCustomOctagonSuffix, !Ref pCustomOctagonSuffix, ""]
       CodeUri: ./lambda/pipelines-dynamodb/src
 
   rPermissionForPipelinesEventsToInvokeLambda:


### PR DESCRIPTION
*Issue #, if available:*
If CustomIdentifier is not used when deploying SDLF the data-lakes-on-aws/sdlf-cicd/template-cicd-domain-roles.yaml creation will fail because it will try to create an empty SSM param. 

*Description of changes:*
### 1. template-cicd-domain-roles.yaml:
• Modified rCustomIdentifierSsm to always create the SSM parameter, using "FALSE" as default when pCustomIdentifier is empty

### 2. sdlf-foundations/src/template.yaml:
• Added UseCustomSuffix condition that checks if pCustomSuffix is not equal to "FALSE"
• Updated all resource names (KMS alias, queues, Lambda functions, DynamoDB tables) to conditionally include the suffix only when UseCustomSuffix is true

### 3. sdlf-team/src/template.yaml:
• Added UseCustomOctagonSuffix condition that checks if pCustomOctagonSuffix is not equal to "FALSE"  
• Updated Lambda environment variables to conditionally include the suffix only when UseCustomOctagonSuffix is true

Now when pCustomSuffix or pCustomOctagonSuffix is set to "FALSE", the custom suffix won't be appended to resource names, while any other value (including the resolved SSM parameter) will be used as the 
suffix.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
