### PR TITLE
[sdlf-cicd] extract create_repository into new file, add API-support gitlab

### DIFF
--- a/docs/constructs/cicd.md
+++ b/docs/constructs/cicd.md
@@ -91,49 +91,14 @@ Rnabled by setting `pEnableLambdaLayerBuilder` to `true` when deploying `templat
 
 ### GitLab
 
-- Create a dedicated user on GitLab. Currently the user must be named: `sdlf`.
-- Create an access token with the `sdlf` user. The token name must be named `aws`. Permissions must be `api` and `write_repository`.
-- Create [CodeConnections](https://docs.aws.amazon.com/codepipeline/latest/userguide/connections-gitlab-managed.html) for the self-managed GitLab instance
+The creation of GitLab repositories will be performed through the GitLab API.
 
 Populate:
 
 - `/SDLF/GitLab/Url` :: secure-string :: GitLab URL **with** trailing `/`
 - `/SDLF/GitLab/AccessToken` :: secure-string :: User access token
+- `/SDLF/GitLab/NamespaceId` :: secure-string :: User/Enterprise namespace ID
 - `/SDLF/GitLab/CodeConnection` :: string :: CodeConnections ARN
-
-Create CloudFormation role:
-
-```
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Effect": "Allow",
-            "Principal": {
-                "Service": "resources.cloudformation.amazonaws.com"
-            },
-            "Action": "sts:AssumeRole",
-			"Condition": {
-				"StringEquals": {
-					"aws:SourceAccount": "111111111111"
-				}
-        }
-    ]
-}
-```
-
-Enable `GitLab::Projects::Project` third-party resource type in CloudFormation Registry.
-
-Add configuration (use of ssm-secure is mandatory):
-
-```
-{
-    "GitLabAccess": {
-        "AccessToken": "{{resolve:ssm-secure:/SDLF/GitLab/AccessToken:1}}",
-        "Url": "{{resolve:ssm-secure:/SDLF/GitLab/Url:1}}"
-    }
-}
-```
 
 ## Interface
 

--- a/sdlf-cicd/lambda/domain-cicd/src/repository_manager.py
+++ b/sdlf-cicd/lambda/domain-cicd/src/repository_manager.py
@@ -1,0 +1,219 @@
+import json
+import logging
+import os
+import ssl
+from urllib.request import HTTPError, Request, URLError, urlopen
+
+import boto3
+from botocore.exceptions import ClientError
+
+logger = logging.getLogger()
+
+ssm_endpoint_url = "https://ssm." + os.getenv("AWS_REGION") + ".amazonaws.com"
+ssm = boto3.client("ssm", endpoint_url=ssm_endpoint_url)
+codecommit_endpoint_url = "https://codecommit." + os.getenv("AWS_REGION") + ".amazonaws.com"
+codecommit = boto3.client("codecommit", endpoint_url=codecommit_endpoint_url)
+cloudformation_endpoint_url = "https://cloudformation." + os.getenv("AWS_REGION") + ".amazonaws.com"
+cloudformation = boto3.client("cloudformation", endpoint_url=cloudformation_endpoint_url)
+
+
+def _create_team_repository_cicd_stack(domain, team_name, template_body_url, cloudformation_role):
+    response = {}
+    cloudformation_waiter_type = None
+    stack_name = f"sdlf-cicd-teams-{domain}-{team_name}-repository"
+    stack_parameters = [
+        {
+            "ParameterKey": "pDomain",
+            "ParameterValue": domain,
+            "UsePreviousValue": False,
+        },
+        {
+            "ParameterKey": "pTeamName",
+            "ParameterValue": team_name,
+            "UsePreviousValue": False,
+        },
+    ]
+    stack_arguments = dict(
+        StackName=stack_name,
+        TemplateURL=template_body_url,
+        Parameters=stack_parameters,
+        Capabilities=[
+            "CAPABILITY_AUTO_EXPAND",
+        ],
+        RoleARN=cloudformation_role,
+        Tags=[
+            {"Key": "Framework", "Value": "sdlf"},
+        ],
+    )
+
+    try:
+        response = cloudformation.create_stack(**stack_arguments)
+        cloudformation_waiter_type = "stack_create_complete"
+    except cloudformation.exceptions.AlreadyExistsException:
+        try:
+            response = cloudformation.update_stack(**stack_arguments)
+            cloudformation_waiter_type = "stack_update_complete"
+        except ClientError as err:
+            if "No updates are to be performed" in err.response["Error"]["Message"]:
+                pass
+            else:
+                raise err
+
+    logger.info("RESPONSE: %s", response)
+    return (stack_name, cloudformation_waiter_type)
+
+
+def _create_codecommit_repositories(
+    domain_details, domain, template_cicd_team_repository_url, cloudformation_role, main_repository_prefix
+):
+    """Create CodeCommit repositories and branches for teams"""
+    cloudformation_waiters = {
+        "stack_create_complete": [],
+        "stack_update_complete": [],
+    }
+    for team in domain_details["teams"]:
+        stack_details = _create_team_repository_cicd_stack(
+            domain,
+            team,
+            template_cicd_team_repository_url,
+            cloudformation_role,
+        )
+        if stack_details[1]:
+            cloudformation_waiters[stack_details[1]].append(stack_details[0])
+
+    cloudformation_create_waiter = cloudformation.get_waiter("stack_create_complete")
+    cloudformation_update_waiter = cloudformation.get_waiter("stack_update_complete")
+    for stack in cloudformation_waiters["stack_create_complete"]:
+        cloudformation_create_waiter.wait(StackName=stack, WaiterConfig={"Delay": 30, "MaxAttempts": 10})
+    for stack in cloudformation_waiters["stack_update_complete"]:
+        cloudformation_update_waiter.wait(StackName=stack, WaiterConfig={"Delay": 30, "MaxAttempts": 10})
+
+    # Create branches for each team repository
+    for team in domain_details["teams"]:
+        repository_name = f"{main_repository_prefix}{domain}-{team}"
+        env_branches = ["dev", "test"]
+        for env_branch in env_branches:
+            try:
+                codecommit.create_branch(
+                    repositoryName=repository_name,
+                    branchName=env_branch,
+                    commitId=codecommit.get_branch(
+                        repositoryName=repository_name,
+                        branchName="main",
+                    )["branch"]["commitId"],
+                )
+                logger.info(
+                    "Branch %s created in repository %s",
+                    env_branch,
+                    repository_name,
+                )
+            except codecommit.exceptions.BranchNameExistsException:
+                logger.info(
+                    "Branch %s already created in repository %s",
+                    env_branch,
+                    repository_name,
+                )
+
+
+def _create_gitlab_repositories(domain_details, domain, template_cicd_team_repository_url, cloudformation_role):
+    """Create GitLab repositories for teams"""
+    for team in domain_details["teams"]:
+        # Create GitLab repository via API
+        # !Sub ${pMainRepositoriesPrefix}${pDomain}-${pTeamName}
+        repository = f"sdlf-main-{domain}-{team}"
+        gitlab_url = ssm.get_parameter(Name="/SDLF/GitLab/Url", WithDecryption=True)["Parameter"]["Value"]
+        gitlab_accesstoken = ssm.get_parameter(Name="/SDLF/GitLab/AccessToken", WithDecryption=True)["Parameter"][
+            "Value"
+        ]
+        namespace_id = ssm.get_parameter(Name="/SDLF/GitLab/NamespaceId", WithDecryption=True)["Parameter"]["Value"]
+
+        url = f"{gitlab_url}api/v4/projects/"
+        headers = {"Content-Type": "application/json", "PRIVATE-TOKEN": gitlab_accesstoken}
+        data = {
+            "name": repository,
+            "description": repository,
+            "path": repository,
+            "namespace_id": namespace_id,
+            "initialize_with_readme": "false",
+        }
+        json_data = json.dumps(data).encode("utf-8")
+        req = Request(url, data=json_data, headers=headers, method="POST")
+        unverified_context = ssl._create_unverified_context()
+        try:
+            with urlopen(req, context=unverified_context) as response:
+                response_body = response.read().decode("utf-8")
+                logger.info(response_body)
+        except HTTPError as e:
+            logger.warning(
+                f"HTTP error occurred: {e.code} {e.reason}. Most likely the repository {repository} already exists"
+            )
+        except URLError as e:
+            logger.error(f"URL error occurred: {e.reason}")
+
+    # Create CloudFormation stacks for GitLab repositories
+    cloudformation_waiters = {
+        "stack_create_complete": [],
+        "stack_update_complete": [],
+    }
+    for team in domain_details["teams"]:
+        stack_details = _create_team_repository_cicd_stack(
+            domain,
+            team,
+            template_cicd_team_repository_url,
+            cloudformation_role,
+        )
+        if stack_details[1]:
+            cloudformation_waiters[stack_details[1]].append(stack_details[0])
+
+    cloudformation_create_waiter = cloudformation.get_waiter("stack_create_complete")
+    cloudformation_update_waiter = cloudformation.get_waiter("stack_update_complete")
+    for stack in cloudformation_waiters["stack_create_complete"]:
+        cloudformation_create_waiter.wait(StackName=stack, WaiterConfig={"Delay": 30, "MaxAttempts": 10})
+    for stack in cloudformation_waiters["stack_update_complete"]:
+        cloudformation_update_waiter.wait(StackName=stack, WaiterConfig={"Delay": 30, "MaxAttempts": 10})
+
+
+def _create_github_repositories(domain_details, domain, template_cicd_team_repository_url, cloudformation_role):
+    """Create GitHub repositories for teams"""
+    # GitHub repositories are created via CloudFormation template
+    cloudformation_waiters = {
+        "stack_create_complete": [],
+        "stack_update_complete": [],
+    }
+    for team in domain_details["teams"]:
+        stack_details = _create_team_repository_cicd_stack(
+            domain,
+            team,
+            template_cicd_team_repository_url,
+            cloudformation_role,
+        )
+        if stack_details[1]:
+            cloudformation_waiters[stack_details[1]].append(stack_details[0])
+
+    cloudformation_create_waiter = cloudformation.get_waiter("stack_create_complete")
+    cloudformation_update_waiter = cloudformation.get_waiter("stack_update_complete")
+    for stack in cloudformation_waiters["stack_create_complete"]:
+        cloudformation_create_waiter.wait(StackName=stack, WaiterConfig={"Delay": 30, "MaxAttempts": 10})
+    for stack in cloudformation_waiters["stack_update_complete"]:
+        cloudformation_update_waiter.wait(StackName=stack, WaiterConfig={"Delay": 30, "MaxAttempts": 10})
+
+
+def create_repositories(
+    git_platform,
+    domain_details,
+    domain,
+    template_cicd_team_repository_url,
+    cloudformation_role,
+    main_repository_prefix=None,
+):
+    """Create team repositories based on git platform"""
+    if git_platform == "CodeCommit":
+        _create_codecommit_repositories(
+            domain_details, domain, template_cicd_team_repository_url, cloudformation_role, main_repository_prefix
+        )
+    elif git_platform == "GitHub":
+        _create_github_repositories(domain_details, domain, template_cicd_team_repository_url, cloudformation_role)
+    elif git_platform == "GitLab":
+        _create_gitlab_repositories(domain_details, domain, template_cicd_team_repository_url, cloudformation_role)
+    else:
+        raise logging.exception("Git provider {} is not supported".format(git_platform))

--- a/sdlf-cicd/template-cicd-sdlf-repositories.gitlab.yaml
+++ b/sdlf-cicd/template-cicd-sdlf-repositories.gitlab.yaml
@@ -19,152 +19,185 @@ Conditions:
   EnableMonitoring: !Equals [!Ref pEnableMonitoring, true]
 
 Resources:
-  ######## GITLAB #########
-  # rSdlfGitLabGroup:
-  #   Type: GitLab::Groups::Group
-  #   Properties:
-  #     Name: SDLF
-  #     Path: "{{resolve:ssm:/SDLF/${pGitPlatform}/Group}}"
-
-  rCicdGitLab:
-    Type: GitLab::Projects::Project
-    Metadata:
-      cfn-lint:
-        config:
-          ignore_checks:
-          - E3001
+  ######## GITLAB CUSTOM RESOURCE LAMBDA #########
+  rGitLabRepositoryLambdaRole:
+    Type: AWS::IAM::Role
     Properties:
-      Name: !Sub sdlf-${pCustomIdentifier}cicd
-#      Path: "{{resolve:ssm:/SDLF/${pGitPlatform}/Group}}"
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+      Policies:
+        - PolicyName: SSMParameterAccess
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - ssm:GetParameter
+                Resource:
+                  - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/SDLF/GitLab/*"
+
+  rGitLabRepositoryLambda:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: !Sub sdlf-gitlab-repository-manager-${pCustomIdentifier}
+      Runtime: python3.12
+      Handler: index.lambda_handler
+      Role: !GetAtt rGitLabRepositoryLambdaRole.Arn
+      Timeout: 60
+      Code:
+        ZipFile: |
+          import json
+          import logging
+          import ssl
+          import boto3
+          import cfnresponse
+          from urllib.request import HTTPError, Request, URLError, urlopen
+          
+          logger = logging.getLogger()
+          logger.setLevel(logging.INFO)
+          
+          ssm = boto3.client('ssm')
+          
+          def lambda_handler(event, context):
+              try:
+                  logger.info(f"Event: {json.dumps(event)}")
+                  
+                  request_type = event['RequestType']
+                  repository = event['ResourceProperties']['RepositoryName']
+                  
+                  if request_type in ['Create', 'Update']:
+                      # Get GitLab parameters
+                      gitlab_url = ssm.get_parameter(Name="/SDLF/GitLab/Url", WithDecryption=True)["Parameter"]["Value"]
+                      gitlab_accesstoken = ssm.get_parameter(Name="/SDLF/GitLab/AccessToken", WithDecryption=True)["Parameter"]["Value"]
+                      namespace_id = ssm.get_parameter(Name="/SDLF/GitLab/NamespaceId", WithDecryption=True)["Parameter"]["Value"]
+                      
+                      # Create GitLab repository
+                      url = f"{gitlab_url}api/v4/projects/"
+                      headers = {"Content-Type": "application/json", "PRIVATE-TOKEN": gitlab_accesstoken}
+                      data = {
+                          "name": repository,
+                          "description": repository,
+                          "path": repository,
+                          "namespace_id": namespace_id,
+                          "initialize_with_readme": "false",
+                      }
+                      json_data = json.dumps(data).encode("utf-8")
+                      req = Request(url, data=json_data, headers=headers, method="POST")
+                      unverified_context = ssl._create_unverified_context()
+                      
+                      try:
+                          with urlopen(req, context=unverified_context) as response:
+                              response_body = response.read().decode("utf-8")
+                              logger.info(f"GitLab API response: {response_body}")
+                              response_data = json.loads(response_body)
+                              physical_resource_id = str(response_data.get('id', repository))
+                      except HTTPError as e:
+                          if e.code == 400:
+                              logger.warning(f"Repository {repository} likely already exists")
+                              physical_resource_id = repository
+                          else:
+                              raise e
+                      except URLError as e:
+                          logger.error(f"URL error occurred: {e.reason}")
+                          raise e
+                  else:
+                      # Delete operation - GitLab repositories are typically not deleted automatically
+                      physical_resource_id = event.get('PhysicalResourceId', repository)
+                      logger.info(f"Delete operation for repository {repository} - no action taken")
+                  
+                  cfnresponse.send(event, context, cfnresponse.SUCCESS, {}, physical_resource_id)
+                  
+              except Exception as e:
+                  logger.error(f"Error: {str(e)}")
+                  cfnresponse.send(event, context, cfnresponse.FAILED, {}, event.get('PhysicalResourceId', 'failed'))
+
+  ######## GITLAB REPOSITORIES #########
+  rCicdGitLab:
+    Type: AWS::CloudFormation::CustomResource
+    Properties:
+      ServiceToken: !GetAtt rGitLabRepositoryLambda.Arn
+      RepositoryName: !Sub sdlf-${pCustomIdentifier}cicd
 
   rFoundationsGitLab:
-    Type: GitLab::Projects::Project
-    Metadata:
-      cfn-lint:
-        config:
-          ignore_checks:
-          - E3001
+    Type: AWS::CloudFormation::CustomResource
     Properties:
-      Name: !Sub sdlf-${pCustomIdentifier}foundations
-#      Path: "{{resolve:ssm:/SDLF/${pGitPlatform}/Group}}"
+      ServiceToken: !GetAtt rGitLabRepositoryLambda.Arn
+      RepositoryName: !Sub sdlf-${pCustomIdentifier}foundations
 
   rTeamGitLab:
-    Type: GitLab::Projects::Project
-    Metadata:
-      cfn-lint:
-        config:
-          ignore_checks:
-          - E3001
+    Type: AWS::CloudFormation::CustomResource
     Properties:
-      Name: !Sub sdlf-${pCustomIdentifier}team
-#      Path: "{{resolve:ssm:/SDLF/${pGitPlatform}/Group}}"
+      ServiceToken: !GetAtt rGitLabRepositoryLambda.Arn
+      RepositoryName: !Sub sdlf-${pCustomIdentifier}team
 
   rPipelineGitLab:
-    Type: GitLab::Projects::Project
-    Metadata:
-      cfn-lint:
-        config:
-          ignore_checks:
-          - E3001
+    Type: AWS::CloudFormation::CustomResource
     Properties:
-      Name: !Sub sdlf-${pCustomIdentifier}pipeline
-#      Path: "{{resolve:ssm:/SDLF/${pGitPlatform}/Group}}"
+      ServiceToken: !GetAtt rGitLabRepositoryLambda.Arn
+      RepositoryName: !Sub sdlf-${pCustomIdentifier}pipeline
 
   rDatasetGitLab:
-    Type: GitLab::Projects::Project
-    Metadata:
-      cfn-lint:
-        config:
-          ignore_checks:
-          - E3001
+    Type: AWS::CloudFormation::CustomResource
     Properties:
-      Name: !Sub sdlf-${pCustomIdentifier}dataset
-#      Path: "{{resolve:ssm:/SDLF/${pGitPlatform}/Group}}"
+      ServiceToken: !GetAtt rGitLabRepositoryLambda.Arn
+      RepositoryName: !Sub sdlf-${pCustomIdentifier}dataset
 
   rStageAGitLab:
-    Type: GitLab::Projects::Project
-    Metadata:
-      cfn-lint:
-        config:
-          ignore_checks:
-          - E3001
+    Type: AWS::CloudFormation::CustomResource
     Properties:
-      Name: !Sub sdlf-${pCustomIdentifier}stageA
-#      Path: "{{resolve:ssm:/SDLF/${pGitPlatform}/Group}}"
+      ServiceToken: !GetAtt rGitLabRepositoryLambda.Arn
+      RepositoryName: !Sub sdlf-${pCustomIdentifier}stageA
 
   rStageLambdaGitLab:
-    Type: GitLab::Projects::Project
-    Metadata:
-      cfn-lint:
-        config:
-          ignore_checks:
-          - E3001
+    Type: AWS::CloudFormation::CustomResource
     Properties:
-      Name: !Sub sdlf-${pCustomIdentifier}stage-lambda
-#      Path: "{{resolve:ssm:/SDLF/${pGitPlatform}/Group}}"
+      ServiceToken: !GetAtt rGitLabRepositoryLambda.Arn
+      RepositoryName: !Sub sdlf-${pCustomIdentifier}stage-lambda
 
   rStageBGitLab:
-    Type: GitLab::Projects::Project
-    Metadata:
-      cfn-lint:
-        config:
-          ignore_checks:
-          - E3001
+    Type: AWS::CloudFormation::CustomResource
     Properties:
-      Name: !Sub sdlf-${pCustomIdentifier}stageB
-#      Path: "{{resolve:ssm:/SDLF/${pGitPlatform}/Group}}"
+      ServiceToken: !GetAtt rGitLabRepositoryLambda.Arn
+      RepositoryName: !Sub sdlf-${pCustomIdentifier}stageB
 
   rStageGlueGitLab:
-    Type: GitLab::Projects::Project
-    Metadata:
-      cfn-lint:
-        config:
-          ignore_checks:
-          - E3001
+    Type: AWS::CloudFormation::CustomResource
     Properties:
-      Name: !Sub sdlf-${pCustomIdentifier}stage-glue
-#      Path: "{{resolve:ssm:/SDLF/${pGitPlatform}/Group}}"
+      ServiceToken: !GetAtt rGitLabRepositoryLambda.Arn
+      RepositoryName: !Sub sdlf-${pCustomIdentifier}stage-glue
 
   rDatalakeLibraryGitLab:
-    Type: GitLab::Projects::Project
-    Metadata:
-      cfn-lint:
-        config:
-          ignore_checks:
-          - E3001
+    Type: AWS::CloudFormation::CustomResource
     Properties:
-      Name: !Sub sdlf-${pCustomIdentifier}datalakeLibrary
-#      Path: "{{resolve:ssm:/SDLF/${pGitPlatform}/Group}}"
+      ServiceToken: !GetAtt rGitLabRepositoryLambda.Arn
+      RepositoryName: !Sub sdlf-${pCustomIdentifier}datalakeLibrary
 
   rMainGitLab:
-    Type: GitLab::Projects::Project
-    Metadata:
-      cfn-lint:
-        config:
-          ignore_checks:
-          - E3001
+    Type: AWS::CloudFormation::CustomResource
     Properties:
-      Name: !Sub sdlf-${pCustomIdentifier}main
-#      Path: "{{resolve:ssm:/SDLF/${pGitPlatform}/Group}}"
+      ServiceToken: !GetAtt rGitLabRepositoryLambda.Arn
+      RepositoryName: !Sub sdlf-${pCustomIdentifier}main
 
   rMonitoringGitLab:
-    Type: GitLab::Projects::Project
-    Metadata:
-      cfn-lint:
-        config:
-          ignore_checks:
-          - E3001
+    Type: AWS::CloudFormation::CustomResource
     Condition: EnableMonitoring
     Properties:
-      Name: !Sub sdlf-${pCustomIdentifier}monitoring
-#      Path: "{{resolve:ssm:/SDLF/${pGitPlatform}/Group}}"
+      ServiceToken: !GetAtt rGitLabRepositoryLambda.Arn
+      RepositoryName: !Sub sdlf-${pCustomIdentifier}monitoring
 
   rCicdGitLabSsm:
     Type: AWS::SSM::Parameter
     Properties:
       Name: /SDLF/GitLab/CicdGitLab
       Type: String
-      Value: !Sub sdlf-${pCustomIdentifier}cicd # !GetAtt rCicdGitLab.Name
+      Value: !Sub sdlf-${pCustomIdentifier}cicd
       Description: Name of the Cicd repository
 
   rFoundationsGitLabSsm:
@@ -172,7 +205,7 @@ Resources:
     Properties:
       Name: /SDLF/GitLab/FoundationsGitLab
       Type: String
-      Value: !Sub sdlf-${pCustomIdentifier}foundations # !GetAtt rFoundationsGitLab.Name
+      Value: !Sub sdlf-${pCustomIdentifier}foundations
       Description: Name of the Foundations repository
 
   rTeamGitLabSsm:
@@ -180,7 +213,7 @@ Resources:
     Properties:
       Name: /SDLF/GitLab/TeamGitLab
       Type: String
-      Value: !Sub sdlf-${pCustomIdentifier}team # !GetAtt rTeamGitLab.Name
+      Value: !Sub sdlf-${pCustomIdentifier}team
       Description: Name of the Team repository
 
   rPipelineGitLabSsm:
@@ -188,7 +221,7 @@ Resources:
     Properties:
       Name: /SDLF/GitLab/PipelineGitLab
       Type: String
-      Value: !Sub sdlf-${pCustomIdentifier}pipeline # !GetAtt rPipelineGitLab.Name
+      Value: !Sub sdlf-${pCustomIdentifier}pipeline
       Description: Name of the Pipeline repository
 
   rDatasetGitLabSsm:
@@ -196,7 +229,7 @@ Resources:
     Properties:
       Name: /SDLF/GitLab/DatasetGitLab
       Type: String
-      Value: !Sub sdlf-${pCustomIdentifier}dataset # !GetAtt rDatasetGitLab.Name
+      Value: !Sub sdlf-${pCustomIdentifier}dataset
       Description: Name of the Dataset repository
 
   rStageAGitLabSsm:
@@ -204,7 +237,7 @@ Resources:
     Properties:
       Name: /SDLF/GitLab/StageAGitLab
       Type: String
-      Value: !Sub sdlf-${pCustomIdentifier}stageA # !GetAtt rStageAGitLab.Name
+      Value: !Sub sdlf-${pCustomIdentifier}stageA
       Description: Name of the StageA repository
 
   rStageLambdaGitLabSsm:
@@ -212,7 +245,7 @@ Resources:
     Properties:
       Name: /SDLF/GitLab/StageLambdaGitLab
       Type: String
-      Value: !Sub sdlf-${pCustomIdentifier}stage-lambda # !GetAtt rStageLambdaGitLab.Name
+      Value: !Sub sdlf-${pCustomIdentifier}stage-lambda
       Description: Name of the Stage-Lambda repository
 
   rStageBGitLabSsm:
@@ -220,7 +253,7 @@ Resources:
     Properties:
       Name: /SDLF/GitLab/StageBGitLab
       Type: String
-      Value: !Sub sdlf-${pCustomIdentifier}stageB # !GetAtt rStageBGitLab.Name
+      Value: !Sub sdlf-${pCustomIdentifier}stageB
       Description: Name of the StageB repository
 
   rStageGlueGitLabSsm:
@@ -228,7 +261,7 @@ Resources:
     Properties:
       Name: /SDLF/GitLab/StageGlueGitLab
       Type: String
-      Value: !Sub sdlf-${pCustomIdentifier}stage-glue # !GetAtt rStageGlueGitLab.Name
+      Value: !Sub sdlf-${pCustomIdentifier}stage-glue
       Description: Name of the Stage-Glue repository
 
   rDatalakeLibraryGitLabSsm:
@@ -236,7 +269,7 @@ Resources:
     Properties:
       Name: /SDLF/GitLab/DatalakeLibraryGitLab
       Type: String
-      Value: !Sub sdlf-${pCustomIdentifier}datalakeLibrary # !GetAtt rDatalakeLibraryGitLab.Name
+      Value: !Sub sdlf-${pCustomIdentifier}datalakeLibrary
       Description: Name of the DatalakeLibrary repository
 
   rMainGitLabSsm:
@@ -244,7 +277,7 @@ Resources:
     Properties:
       Name: /SDLF/GitLab/MainGitLab
       Type: String
-      Value: !Sub sdlf-${pCustomIdentifier}main # !GetAtt rMainGitLab.Name
+      Value: !Sub sdlf-${pCustomIdentifier}main
       Description: Name of the main repository
 
   rMonitoringGitLabSsm:
@@ -257,7 +290,6 @@ Resources:
       Description: Name of the monitoring repository
 
 Outputs:
-  # workaround {{resolve:ssm:}} not returning an array that can be used directly in VpcConfig blocks
   oKmsKey:
     Description: CICD KMS Key
     Value: !Ref pKMSKey

--- a/sdlf-cicd/template-cicd-team-repository.yaml
+++ b/sdlf-cicd/template-cicd-team-repository.yaml
@@ -23,7 +23,6 @@ Parameters:
 
 Conditions:
   GitPlatformCodeCommit: !Equals [!Ref pGitPlatform, "CodeCommit"]
-  GitPlatformGitLab: !Equals [!Ref pGitPlatform, "GitLab"]
   GitPlatformGitHub: !Equals [!Ref pGitPlatform, "GitHub"]
 
 Resources:
@@ -42,18 +41,6 @@ Resources:
       RepositoryDescription: !Sub ${pDomain} ${pTeamName} main repository
       RepositoryName: !Sub ${pMainRepositoriesPrefix}${pDomain}-${pTeamName}
       KmsKeyId: !Ref pKMSKey
-
-  rTeamMainGitLab:
-    Type: GitLab::Projects::Project
-    Metadata:
-      cfn-lint:
-        config:
-          ignore_checks:
-          - E3001
-    Condition: GitPlatformGitLab
-    Properties:
-      Name: !Sub ${pMainRepositoriesPrefix}${pDomain}-${pTeamName}
-#      Path: "{{resolve:ssm:/SDLF/${pGitPlatform}/Group}}"
 
   rTeamMainGitHub:
     Type: GitHub::Repositories::Repository
@@ -78,5 +65,5 @@ Resources:
       Value: !If
         - GitPlatformCodeCommit
         - !GetAtt rTeamMainCodeCommit.Name
-        - !Sub ${pMainRepositoriesPrefix}${pDomain}-${pTeamName} # !GetAtt rTeamMainGitLab.Name
+        - !Sub ${pMainRepositoriesPrefix}${pDomain}-${pTeamName}
       Description: !Sub Name of the ${pDomain} ${pTeamName} main repository

--- a/sdlf-utils/workshop-examples/legislators/scripts/legislators-glue-job.yaml
+++ b/sdlf-utils/workshop-examples/legislators/scripts/legislators-glue-job.yaml
@@ -63,7 +63,7 @@ Resources:
                 Resource:
                   - !Sub "{{resolve:ssm:/SDLF/KMS/${pTeamName}/InfraKeyId:1}}"
                   - !Sub "{{resolve:ssm:/SDLF/KMS/${pTeamName}/DataKeyId:1}}"
-                  - !Sub "{{resolve:ssm:/SDLF2/KMS/KeyArn:1}}"
+                  - "{{resolve:ssm:/SDLF2/KMS/KeyArn:1}}"
 
   rGlueJob:
     Type: AWS::Glue::Job
@@ -102,3 +102,7 @@ Outputs:
     Value: !GetAtt rGlueRole.Arn
     Export:
       Name: !Sub ${AWS::StackName}-glue-role-arn
+
+  oPipelineDeploymentInstance:
+    Description: Pipeline deployment instance
+    Value: !Ref pPipelineDeploymentInstance


### PR DESCRIPTION
*Issue #, if available:*
The CloudFormation resources for GitLab projects have some limitations and require hardcoded names for the namespaces/users.

*Description of changes:*
Refactored the lambda_function that creates the team repositories: moved creation logic outside of the lambda_handler file. Created a function for each git provider. In the GitLab provider, added API-first approach.

⚠️ This is the first of a series of pull requests 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
