### PR TITLE
Fix double slash in memberships output path

### DIFF
--- a/sdlf-utils/workshop-examples/legislators/scripts/legislators-glue-job.py
+++ b/sdlf-utils/workshop-examples/legislators/scripts/legislators-glue-job.py
@@ -48,7 +48,7 @@ history = Join.apply(
 
 persons.toDF().write.mode("overwrite").parquet("{}/persons/".format(destination))
 organizations.toDF().write.mode("overwrite").parquet("{}/organizations/".format(destination))
-memberships.toDF().write.mode("overwrite").parquet("{}//memberships/".format(destination))
+memberships.toDF().write.mode("overwrite").parquet("{}/memberships/".format(destination))
 history.toDF().write.mode("overwrite").parquet("{}/history/".format(destination), partitionBy=["org_name"])
 
 job.commit()


### PR DESCRIPTION
## Bug Description

The memberships output path uses `'{}//memberships/'` which creates a malformed S3 path with double slashes. This is an off-by-one error in string formatting where an extra slash was added.

## Fix

Changed the path format string from `'{}//memberships/'` to `'{}/memberships/'` to match the pattern used in other similar output paths in the same file.

## Before
```python
memberships.toDF().write.mode("overwrite").parquet("{}//memberships/".format(destination))
```

## After
```python
memberships.toDF().write.mode("overwrite").parquet("{}/memberships/".format(destination))
```

---

*This PR was generated by [PRJanitor](https://prjanitor.com) — an automated tool that finds and fixes small bugs in open-source projects.*

We respect your contribution guidelines — if your project doesn't accept bot PRs, we won't send more. You can also add a `.github/prjanitor.yml` file with `enabled: false` to opt out explicitly.